### PR TITLE
fix: correct schema sidebar click offset bug

### DIFF
--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -27,15 +27,14 @@ use crate::config::{
 };
 use crate::history::{History, HistoryEntry};
 use crate::ui::{
-    create_sql_highlighter, determine_context, escape_sql_value, get_word_before_cursor,
-    is_inside, quote_identifier, ColumnInfo, CommandPrompt, CompletionKind, CompletionPopup,
-    ConfirmContext, ConfirmPrompt, ConfirmResult, ConnectionFormAction, ConnectionFormModal,
-    ConnectionInfo, ConnectionManagerAction, ConnectionManagerModal, DataGrid, FuzzyPicker,
-    GridKeyResult, GridModel, GridState, HelpAction, HelpPopup, HighlightedTextArea,
-    JsonEditorAction, JsonEditorModal, KeyHintPopup, KeySequenceAction, KeySequenceHandler,
-    KeySequenceResult, PickerAction, Priority, QueryEditor, ResizeAction, RowDetailAction,
-    RowDetailModal, SchemaCache, SearchPrompt, Sidebar, SidebarAction, StatusLineBuilder,
-    StatusSegment, TableInfo,
+    create_sql_highlighter, determine_context, escape_sql_value, get_word_before_cursor, is_inside,
+    quote_identifier, ColumnInfo, CommandPrompt, CompletionKind, CompletionPopup, ConfirmContext,
+    ConfirmPrompt, ConfirmResult, ConnectionFormAction, ConnectionFormModal, ConnectionInfo,
+    ConnectionManagerAction, ConnectionManagerModal, DataGrid, FuzzyPicker, GridKeyResult,
+    GridModel, GridState, HelpAction, HelpPopup, HighlightedTextArea, JsonEditorAction,
+    JsonEditorModal, KeyHintPopup, KeySequenceAction, KeySequenceHandler, KeySequenceResult,
+    PickerAction, Priority, QueryEditor, ResizeAction, RowDetailAction, RowDetailModal,
+    SchemaCache, SearchPrompt, Sidebar, SidebarAction, StatusLineBuilder, StatusSegment, TableInfo,
 };
 use crate::util::format_pg_error;
 use crate::util::{is_json_column_type, should_use_multiline_editor};

--- a/crates/tsql/src/ui/sidebar.rs
+++ b/crates/tsql/src/ui/sidebar.rs
@@ -420,17 +420,13 @@ impl Sidebar {
         &mut self,
         x: u16,
         y: u16,
-        schema_area: Rect,
+        _schema_area: Rect,
     ) -> (Option<SidebarAction>, Option<SidebarSection>) {
-        // Calculate position relative to the schema area's inner content
-        // (accounting for border)
-        let rel_x = x.saturating_sub(schema_area.x + 1);
-        let rel_y = y.saturating_sub(schema_area.y + 1);
-
-        // Use TreeState's click_at method which properly handles scroll offset
-        // click_at takes a Position relative to the tree widget's render area
+        // TreeState's click_at expects absolute screen coordinates, not relative ones.
+        // The tree widget stores absolute y positions in last_rendered_identifiers
+        // during render, so we pass the mouse coordinates directly.
         use ratatui::layout::Position;
-        self.schema_state.click_at(Position::new(rel_x, rel_y));
+        self.schema_state.click_at(Position::new(x, y));
 
         (None, Some(SidebarSection::Schema))
     }


### PR DESCRIPTION
## Summary
- Fixed a bug where clicking on items in the Schema tree sidebar would select the wrong item (several rows above where clicked)
- The issue was that `handle_schema_click` was converting absolute screen coordinates to relative coordinates before passing to `TreeState::click_at()`, but the tree widget expects absolute coordinates

## Test plan
- [ ] Click on various items in the Schema sidebar tree and verify the correct item gets selected
- [ ] Test clicking on items at different scroll positions
- [ ] Verify connections list click behavior is still correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coordinate handling for schema clicks in the sidebar to ensure accurate interaction processing.

* **Style**
  * Reformatted import statements for improved code readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->