### PR TITLE
fix: include both sidebar sections in tab cycle

### DIFF
--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -1688,7 +1688,10 @@ impl App {
                                 Focus::Query
                             }
                         }
-                        Focus::Sidebar(_) => Focus::Query,
+                        Focus::Sidebar(SidebarSection::Connections) => {
+                            Focus::Sidebar(SidebarSection::Schema)
+                        }
+                        Focus::Sidebar(SidebarSection::Schema) => Focus::Query,
                     };
                     return false;
                 }
@@ -1702,7 +1705,10 @@ impl App {
                             }
                         }
                         Focus::Grid => Focus::Query,
-                        Focus::Sidebar(_) => Focus::Grid,
+                        Focus::Sidebar(SidebarSection::Schema) => {
+                            Focus::Sidebar(SidebarSection::Connections)
+                        }
+                        Focus::Sidebar(SidebarSection::Connections) => Focus::Grid,
                     };
                     return false;
                 }


### PR DESCRIPTION
## Summary
- Tab cycling now visits both Connections and Schema sections in the sidebar
- Forward (Tab): Query → Grid → Connections → Schema → Query
- Backward (Shift+Tab): Query → Schema → Connections → Grid → Query

## Test plan
- [ ] Press Tab repeatedly and verify cycle goes through all four areas
- [ ] Press Shift+Tab and verify reverse cycle works correctly
- [ ] Hide sidebar (Ctrl+B) and verify Tab skips sidebar sections