### PR TITLE
fix: improve schema panel UX with distinct indicator and auto-select

### DIFF
--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -1865,6 +1865,7 @@ impl App {
                         }
                         Focus::Sidebar(SidebarSection::Connections) => {
                             self.sidebar_focus = SidebarSection::Schema;
+                            self.sidebar.select_first_schema_if_empty();
                             Focus::Sidebar(SidebarSection::Schema)
                         }
                         Focus::Sidebar(SidebarSection::Schema) => Focus::Query,
@@ -1876,6 +1877,7 @@ impl App {
                         Focus::Query => {
                             if self.sidebar_visible {
                                 self.sidebar_focus = SidebarSection::Schema;
+                                self.sidebar.select_first_schema_if_empty();
                                 Focus::Sidebar(SidebarSection::Schema)
                             } else {
                                 Focus::Grid
@@ -1959,9 +1961,7 @@ impl App {
                                 GridKeyResult::None
                             }
                             Action::GotoTables => {
-                                self.sidebar_visible = true;
-                                self.sidebar_focus = SidebarSection::Schema;
-                                self.focus = Focus::Sidebar(SidebarSection::Schema);
+                                self.focus_schema();
                                 GridKeyResult::None
                             }
                             Action::GotoResults => {
@@ -2041,8 +2041,7 @@ impl App {
                 let at_bottom =
                     self.sidebar.connections_state.selected() == Some(count.saturating_sub(1));
                 if at_bottom && count > 0 {
-                    self.sidebar_focus = SidebarSection::Schema;
-                    self.focus = Focus::Sidebar(SidebarSection::Schema);
+                    self.focus_schema();
                 } else {
                     self.sidebar.connections_down(count);
                 }
@@ -2242,6 +2241,9 @@ impl App {
                     if let Some(section) = section {
                         self.focus = Focus::Sidebar(section);
                         self.sidebar_focus = section;
+                        if section == SidebarSection::Schema {
+                            self.sidebar.select_first_schema_if_empty();
+                        }
                     }
 
                     // Handle any action from the sidebar
@@ -2374,6 +2376,14 @@ impl App {
                 }
             }
         }
+    }
+
+    /// Focus on the Schema section of the sidebar, ensuring first item is selected
+    fn focus_schema(&mut self) {
+        self.sidebar_visible = true;
+        self.sidebar_focus = SidebarSection::Schema;
+        self.sidebar.select_first_schema_if_empty();
+        self.focus = Focus::Sidebar(SidebarSection::Schema);
     }
 
     fn copy_to_clipboard(&mut self, text: &str) {
@@ -3476,9 +3486,7 @@ impl App {
                 self.focus = Focus::Sidebar(SidebarSection::Connections);
             }
             Action::GotoTables => {
-                self.sidebar_visible = true;
-                self.sidebar_focus = SidebarSection::Schema;
-                self.focus = Focus::Sidebar(SidebarSection::Schema);
+                self.focus_schema();
             }
             Action::GotoResults => {
                 self.focus = Focus::Grid;
@@ -3954,9 +3962,7 @@ impl App {
                             return;
                         }
                         Action::GotoTables => {
-                            self.sidebar_visible = true;
-                            self.sidebar_focus = SidebarSection::Schema;
-                            self.focus = Focus::Sidebar(SidebarSection::Schema);
+                            self.focus_schema();
                             return;
                         }
                         Action::GotoResults => {
@@ -4327,9 +4333,7 @@ impl App {
                 self.focus = Focus::Sidebar(SidebarSection::Connections);
             }
             KeySequenceAction::GotoTables => {
-                self.sidebar_visible = true;
-                self.sidebar_focus = SidebarSection::Schema;
-                self.focus = Focus::Sidebar(SidebarSection::Schema);
+                self.focus_schema();
             }
             KeySequenceAction::GotoResults => {
                 self.focus = Focus::Grid;

--- a/crates/tsql/src/ui/sidebar.rs
+++ b/crates/tsql/src/ui/sidebar.rs
@@ -219,7 +219,7 @@ impl Sidebar {
             .expect("valid tree items")
             .block(block)
             .highlight_style(highlight_style)
-            .highlight_symbol("▶ ");
+            .highlight_symbol("› ");
 
         frame.render_stateful_widget(tree, area, &mut self.schema_state);
     }
@@ -324,6 +324,13 @@ impl Sidebar {
     /// Get the selected schema item identifier (for inserting into query)
     pub fn get_selected_schema_name(&self) -> Option<String> {
         self.schema_state.selected().last().cloned()
+    }
+
+    /// Select the first item in the schema tree if nothing is selected
+    pub fn select_first_schema_if_empty(&mut self) {
+        if self.schema_state.selected().is_empty() {
+            self.schema_state.select_first();
+        }
     }
 
     /// Handle mouse events in the sidebar


### PR DESCRIPTION
## Summary
- Change the current line indicator in the Schema panel from ▶ to › to avoid visual confusion with the tree expand/collapse indicators
- Auto-select the first item when entering the Schema panel if no item is currently selected

## Test plan
- [ ] Navigate to the Schema panel and verify the selection indicator (›) is distinct from tree indicators (▶/▼)
- [ ] Enter the Schema panel via Tab, Shift+Tab, arrow keys, keyboard shortcuts (gt), and mouse clicks
- [ ] Verify the first item is automatically selected when entering an empty selection state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-selects the first schema when opening the Schema panel and ensures consistent focus behavior across keyboard, mouse, and navigation flows.
* **Style**
  * Updated the schema tree highlight symbol for improved visual clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->