### PR TITLE
feat(tui): phase 2 standalone in-app update apply flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1652,6 +1653,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2284,6 +2291,7 @@ dependencies = [
  "percent-encoding",
  "ratatui",
  "rustls",
+ "semver",
  "serde",
  "serde_json",
  "serial_test",
@@ -2299,6 +2307,7 @@ dependencies = [
  "tui-tree-widget",
  "tui_confirm_dialog_with_mouse",
  "unicode-width 0.2.0",
+ "ureq",
  "url",
  "uuid",
  "webpki-roots 0.26.11",
@@ -2418,6 +2427,24 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,6 +1925,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2308,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "dotenvy",
+ "flate2",
  "keyring",
  "nucleo-matcher",
  "percent-encoding",
@@ -2295,7 +2318,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "shlex",
+ "tar",
  "tempfile",
  "throbber-widgets-tui",
  "tokio",
@@ -2952,6 +2977,16 @@ dependencies = [
  "der",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1"
 semver = "1"
 ureq = { version = "2", features = ["json"] }
+sha2 = "0.10"
+flate2 = "1"
+tar = "0.4"
 
 # Secure password storage
 # Must enable platform-specific features for actual keychain storage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ dirs = "5"
 nucleo-matcher = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1"
+semver = "1"
+ureq = { version = "2", features = ["json"] }
 
 # Secure password storage
 # Must enable platform-specific features for actual keychain storage

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you like this crate show some support by [following fcoury (me) on X](https:/
 - **Query history** - Persistent history with fuzzy search, pinning, and deletion
 - **External editor** - Open the current query in `$VISUAL` / `$EDITOR` with `vv`
 - **1Password integration** - Store an `op://` secret reference per connection instead of a plain password
-- **Update checks** - Notify-only update checks with install-method specific upgrade hints
+- **Update checks** - Notify of new versions with install-method specific upgrade hints, plus optional in-app apply for standalone installs when `updates.mode = "auto"`
 - **Configurable** - Customize keybindings and appearance via config file
 
 ## Installation
@@ -179,7 +179,7 @@ tsql --debug-keys --mouse
 | `:\l`                           | List databases      |
 | `:\du`                          | List roles          |
 
-`:\update apply` is only available in `updates.mode = "auto"` and only for
+`:update apply` is only available in `updates.mode = "auto"` and only for
 standalone binary installs.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you like this crate show some support by [following fcoury (me) on X](https:/
 - **Query history** - Persistent history with fuzzy search, pinning, and deletion
 - **External editor** - Open the current query in `$VISUAL` / `$EDITOR` with `vv`
 - **1Password integration** - Store an `op://` secret reference per connection instead of a plain password
+- **Update checks** - Notify-only update checks with install-method specific upgrade hints
 - **Configurable** - Customize keybindings and appearance via config file
 
 ## Installation
@@ -168,6 +169,7 @@ tsql --debug-keys --mouse
 | `:connect <url>`                | Connect to database |
 | `:disconnect`                   | Disconnect          |
 | `:export csv\|json\|tsv <path>` | Export results      |
+| `:update [check\|status]`       | Check update status |
 | `:sbt` / `:sidebar-toggle`      | Toggle sidebar      |
 | `:q` / `:quit`                  | Quit                |
 | `:\dt`                          | List tables         |
@@ -189,8 +191,17 @@ default_url = "postgres://localhost/mydb"
 # Enable 1Password CLI support for `password_onepassword` refs
 enable_onepassword = false
 
-[keybindings]
-# Custom keybindings (see config.example.toml for options)
+[updates]
+# Notify-only update checks (phase 1)
+enabled = true
+check_on_startup = true
+channel = "stable"
+mode = "auto"
+interval_hours = 24
+github_repo = "fcoury/tsql"
+
+[keymap]
+# Custom keymap overrides (see config.example.toml for options)
 ```
 
 See [config.example.toml](config.example.toml) for all available options.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ tsql --debug-keys --mouse
 | `:connect <url>`                | Connect to database |
 | `:disconnect`                   | Disconnect          |
 | `:export csv\|json\|tsv <path>` | Export results      |
-| `:update [check\|status]`       | Check update status |
+| `:update [check\|status\|apply]` | Check/apply updates |
 | `:sbt` / `:sidebar-toggle`      | Toggle sidebar      |
 | `:q` / `:quit`                  | Quit                |
 | `:\dt`                          | List tables         |
@@ -178,6 +178,9 @@ tsql --debug-keys --mouse
 | `:\di`                          | List indexes        |
 | `:\l`                           | List databases      |
 | `:\du`                          | List roles          |
+
+`:\update apply` is only available in `updates.mode = "auto"` and only for
+standalone binary installs.
 
 ## Configuration
 
@@ -192,12 +195,13 @@ default_url = "postgres://localhost/mydb"
 enable_onepassword = false
 
 [updates]
-# Notify-only update checks (phase 1)
+# Update checks + optional in-app apply for standalone installs
 enabled = true
 check_on_startup = true
 channel = "stable"
 mode = "auto"
 interval_hours = 24
+allow_apply_for_standalone = true
 github_repo = "fcoury/tsql"
 
 [keymap]

--- a/config.example.toml
+++ b/config.example.toml
@@ -92,6 +92,31 @@ auto_reconnect = true
 # connections. When enabled, `op` must be installed and available on PATH.
 enable_onepassword = false
 
+# Update checking
+[updates]
+# Enable update checks
+enabled = true
+
+# Check once during startup (non-blocking)
+check_on_startup = true
+
+# Release channel:
+# - "stable": only stable releases
+# - "prerelease": include prereleases
+channel = "stable"
+
+# Update mode:
+# - "auto": phase 1 behavior is notify-only
+# - "notify-only": check and show upgrade hints
+# - "off": disable update checks
+mode = "auto"
+
+# Minimum interval between checks (hours)
+interval_hours = 24
+
+# GitHub repository used for release checks
+github_repo = "fcoury/tsql"
+
 # Clipboard settings
 [clipboard]
 # Clipboard backend:

--- a/config.example.toml
+++ b/config.example.toml
@@ -106,13 +106,16 @@ check_on_startup = true
 channel = "stable"
 
 # Update mode:
-# - "auto": phase 1 behavior is notify-only
+# - "auto": notify + allow `:update apply` for standalone installs
 # - "notify-only": check and show upgrade hints
 # - "off": disable update checks
 mode = "auto"
 
 # Minimum interval between checks (hours)
 interval_hours = 24
+
+# Allow in-app apply only when running a standalone binary
+allow_apply_for_standalone = true
 
 # GitHub repository used for release checks
 github_repo = "fcoury/tsql"

--- a/crates/tsql/Cargo.toml
+++ b/crates/tsql/Cargo.toml
@@ -35,6 +35,8 @@ unicode-width.workspace = true
 nucleo-matcher.workspace = true
 chrono.workspace = true
 serde_json.workspace = true
+semver.workspace = true
+ureq.workspace = true
 
 # Secure password storage
 keyring.workspace = true

--- a/crates/tsql/Cargo.toml
+++ b/crates/tsql/Cargo.toml
@@ -37,6 +37,9 @@ chrono.workspace = true
 serde_json.workspace = true
 semver.workspace = true
 ureq.workspace = true
+sha2.workspace = true
+flate2.workspace = true
+tar.workspace = true
 
 # Secure password storage
 keyring.workspace = true

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -23,6 +23,7 @@ use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, Server
 use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme};
+use semver::Version;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use tokio_postgres::{CancelToken, Client, NoTls, SimpleQueryMessage};
@@ -48,6 +49,10 @@ use crate::ui::{
     PendingKey, PickerAction, Priority, QueryEditor, ResizeAction, RowDetailAction, RowDetailModal,
     SchemaCache, SearchPrompt, Sidebar, SidebarAction, StatusLineBuilder, StatusSegment, TableInfo,
     YankFormat,
+};
+use crate::update::{
+    check_for_update, detect_current_install_method, upgrade_hint, GitHubReleasesProvider,
+    UpdateCheckOutcome, UpdateState,
 };
 use crate::util::format_pg_error;
 use crate::util::{is_json_column_type, should_use_multiline_editor};
@@ -788,6 +793,11 @@ pub enum DbEvent {
         primary_keys: Vec<String>,
         col_types: Vec<String>,
     },
+    /// A background update check completed.
+    UpdateChecked {
+        outcome: UpdateCheckOutcome,
+        manual: bool,
+    },
 }
 
 pub struct DbSession {
@@ -1116,6 +1126,9 @@ pub struct App {
 
     /// Query execution UI state (spinner animation, timing).
     query_ui: QueryRunUi,
+
+    /// Runtime state for update checks.
+    update_state: UpdateState,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1272,6 +1285,7 @@ impl App {
             last_cursor_style: None,
 
             query_ui: QueryRunUi::default(),
+            update_state: UpdateState::default(),
         };
 
         // Load saved connections
@@ -1420,6 +1434,8 @@ impl App {
             if self.db.running {
                 self.query_ui.tick();
             }
+
+            self.maybe_start_scheduled_update_check();
 
             // Pre-compute highlighted lines before the draw closure
             let query_text = self.editor.text();
@@ -3995,12 +4011,137 @@ impl App {
             "sbt" | "sidebar-toggle" => {
                 self.toggle_sidebar();
             }
+            "update" => {
+                self.handle_update_command(args);
+            }
             _ => {
                 self.last_status = Some(format!("Unknown command: {}", command));
             }
         }
 
         false
+    }
+
+    fn handle_update_command(&mut self, args: &str) {
+        let subcommand = args.split_whitespace().next().unwrap_or("check");
+        match subcommand {
+            "check" | "" => self.start_update_check(true, false),
+            "status" => self.show_update_status(),
+            _ => {
+                self.last_status = Some("Usage: :update [check|status]".to_string());
+            }
+        }
+    }
+
+    fn show_update_status(&mut self) {
+        let Some(outcome) = self.update_state.last_outcome.as_ref() else {
+            self.last_status = Some("No update check has run yet. Use :update check".to_string());
+            return;
+        };
+
+        self.last_status = Some(self.update_status_message(outcome, true));
+    }
+
+    fn maybe_start_scheduled_update_check(&mut self) {
+        if self
+            .update_state
+            .should_check_on_startup(&self.config.updates)
+        {
+            self.start_update_check(false, true);
+            return;
+        }
+
+        if self
+            .update_state
+            .should_check_by_interval(&self.config.updates, Instant::now())
+        {
+            self.start_update_check(false, false);
+        }
+    }
+
+    fn start_update_check(&mut self, manual: bool, from_startup: bool) {
+        if self.update_state.check_in_flight {
+            if manual {
+                self.last_status = Some("Update check already running".to_string());
+            }
+            return;
+        }
+
+        if matches!(
+            UpdateState::policy(&self.config.updates),
+            crate::update::UpdatePolicy::Off
+        ) {
+            let outcome = UpdateCheckOutcome::Disabled;
+            self.update_state.mark_check_finished(outcome.clone());
+            if manual {
+                self.last_status = Some(self.update_status_message(&outcome, true));
+            }
+            return;
+        }
+
+        self.update_state.mark_check_started(from_startup);
+
+        if manual {
+            self.last_status = Some("Checking for updates...".to_string());
+        }
+
+        let repo = self.config.updates.github_repo.clone();
+        let channel = self.config.updates.channel;
+        let tx = self.db_events_tx.clone();
+        let current_version = env!("CARGO_PKG_VERSION").to_string();
+
+        self.rt.spawn(async move {
+            let outcome = tokio::task::spawn_blocking(move || {
+                let current = Version::parse(&current_version).map_err(|error| {
+                    format!(
+                        "Current version '{}' is not valid semver: {}",
+                        current_version, error
+                    )
+                });
+
+                match current {
+                    Ok(current) => {
+                        let provider = GitHubReleasesProvider::new(repo);
+                        check_for_update(&provider, &current, channel)
+                    }
+                    Err(error) => UpdateCheckOutcome::Error(error),
+                }
+            })
+            .await
+            .unwrap_or_else(|error| {
+                UpdateCheckOutcome::Error(format!("Update task failed: {}", error))
+            });
+
+            let _ = tx.send(DbEvent::UpdateChecked { outcome, manual });
+        });
+    }
+
+    fn update_status_message(&self, outcome: &UpdateCheckOutcome, manual: bool) -> String {
+        match outcome {
+            UpdateCheckOutcome::Disabled => "Update checks are disabled".to_string(),
+            UpdateCheckOutcome::Error(error) => error.clone(),
+            UpdateCheckOutcome::UpToDate { current } => {
+                if manual {
+                    format!("You're up to date (v{})", current)
+                } else {
+                    format!("Running v{}", current)
+                }
+            }
+            UpdateCheckOutcome::UpdateAvailable(info) => {
+                let install_method = detect_current_install_method();
+                if let Some(hint) = upgrade_hint(install_method) {
+                    format!(
+                        "Update available: v{} -> v{} ({})",
+                        info.current, info.latest, hint
+                    )
+                } else {
+                    format!(
+                        "Update available: v{} -> v{} (see release notes)",
+                        info.current, info.latest
+                    )
+                }
+            }
+        }
     }
 
     fn goto_result_row(&mut self, row_num: usize) -> bool {
@@ -6746,6 +6887,18 @@ impl App {
                 self.grid.primary_keys = primary_keys;
                 self.grid.col_types = col_types;
             }
+            DbEvent::UpdateChecked { outcome, manual } => {
+                let show_status = manual
+                    || matches!(
+                        outcome,
+                        UpdateCheckOutcome::UpdateAvailable(_) | UpdateCheckOutcome::Error(_)
+                    );
+                let status = self.update_status_message(&outcome, manual);
+                self.update_state.mark_check_finished(outcome);
+                if show_status {
+                    self.last_status = Some(status);
+                }
+            }
         }
     }
 
@@ -7317,6 +7470,98 @@ mod tests {
         assert_eq!(effective_max_rows(0), 2000);
         assert_eq!(effective_max_rows(1), 1);
         assert_eq!(effective_max_rows(10_000), 10_000);
+    }
+
+    #[test]
+    fn test_update_status_reports_when_no_check_has_run() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+
+        app.execute_command("update status");
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("No update check has run yet. Use :update check")
+        );
+    }
+
+    #[test]
+    fn test_update_check_respects_disabled_config() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut config = Config::default();
+        config.updates.enabled = false;
+
+        let mut app = App::with_config(
+            GridModel::empty(),
+            rt.handle().clone(),
+            tx,
+            rx,
+            None,
+            config,
+        );
+
+        app.execute_command("update check");
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Update checks are disabled")
+        );
+    }
+
+    #[test]
+    fn test_background_up_to_date_check_does_not_override_status_line() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+
+        app.last_status = Some("Ready".to_string());
+        app.update_state.mark_check_started(true);
+        app.apply_db_event(DbEvent::UpdateChecked {
+            outcome: UpdateCheckOutcome::UpToDate {
+                current: Version::new(0, 4, 2),
+            },
+            manual: false,
+        });
+
+        assert_eq!(app.last_status.as_deref(), Some("Ready"));
+        assert!(!app.update_state.check_in_flight);
+        assert!(app.update_state.last_checked_at.is_some());
+        assert!(matches!(
+            app.update_state.last_outcome,
+            Some(UpdateCheckOutcome::UpToDate { .. })
+        ));
+    }
+
+    #[test]
+    fn test_manual_up_to_date_check_updates_status_line() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+
+        app.apply_db_event(DbEvent::UpdateChecked {
+            outcome: UpdateCheckOutcome::UpToDate {
+                current: Version::new(0, 4, 2),
+            },
+            manual: true,
+        });
+
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("You're up to date (v0.4.2)")
+        );
     }
 
     // ========== CellEditor Tests ==========

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -51,8 +51,9 @@ use crate::ui::{
     YankFormat,
 };
 use crate::update::{
-    apply_update, check_for_update, detect_current_install_method, upgrade_hint, ApplyResult,
-    GitHubReleasesProvider, InstallMethod, UpdateCheckOutcome, UpdateInfo, UpdateState,
+    apply_update, check_for_update, current_target_triple, detect_current_install_method,
+    upgrade_hint, ApplyResult, GitHubReleasesProvider, InstallMethod, UpdateCheckOutcome,
+    UpdateInfo, UpdateState,
 };
 use crate::util::format_pg_error;
 use crate::util::{is_json_column_type, should_use_multiline_editor};
@@ -4132,6 +4133,18 @@ impl App {
     }
 
     fn request_update_apply(&mut self) {
+        if cfg!(windows) {
+            self.last_status = Some("In-app apply is not supported on Windows yet".to_string());
+            return;
+        }
+
+        let Some(target_triple) = current_target_triple() else {
+            self.last_status = Some(
+                "In-app apply is unavailable on this platform (unknown target triple)".to_string(),
+            );
+            return;
+        };
+
         if self.update_apply_in_flight {
             self.last_status = Some("Update apply already running".to_string());
             return;
@@ -4165,6 +4178,11 @@ impl App {
             }
         };
 
+        if let Err(message) = self.validate_apply_candidate(&info, target_triple) {
+            self.last_status = Some(message);
+            return;
+        }
+
         self.confirm_prompt = Some(ConfirmPrompt::new(
             format!(
                 "Apply update now? {} -> {}. This will replace the current tsql binary.",
@@ -4196,6 +4214,52 @@ impl App {
 
             let _ = tx.send(DbEvent::UpdateApplyFinished { result });
         });
+    }
+
+    fn validate_apply_candidate(
+        &self,
+        info: &UpdateInfo,
+        target_triple: &str,
+    ) -> std::result::Result<(), String> {
+        let asset_url = info.asset_url.as_deref().ok_or_else(|| {
+            format!(
+                "No compatible release asset found for target {}. In-app apply is unavailable",
+                target_triple
+            )
+        })?;
+
+        let asset_path = url::Url::parse(asset_url)
+            .ok()
+            .map(|url| url.path().to_string())
+            .unwrap_or_else(|| asset_url.to_string());
+        let asset_name = std::path::Path::new(&asset_path)
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or(asset_path);
+        let asset_name_lc = asset_name.to_ascii_lowercase();
+        let target_lc = target_triple.to_ascii_lowercase();
+
+        if !asset_name_lc.contains(&target_lc) {
+            return Err(format!(
+                "Selected update asset '{}' is not compatible with {}",
+                asset_name, target_triple
+            ));
+        }
+
+        if !(asset_name_lc.ends_with(".tar.gz") || asset_name_lc.ends_with(".tgz")) {
+            return Err(format!(
+                "Unsupported update archive format '{}' (expected .tar.gz or .tgz)",
+                asset_name
+            ));
+        }
+
+        if info.checksum_url.is_none() {
+            return Err(
+                "No checksum file found for this release; in-app apply is unavailable".to_string(),
+            );
+        }
+
+        Ok(())
     }
 
     fn apply_not_allowed_message(&self, method: InstallMethod) -> String {
@@ -7001,6 +7065,7 @@ impl App {
                 self.update_apply_in_flight = false;
                 match result {
                     Ok(applied) => {
+                        self.last_error = None;
                         self.update_state.last_outcome = Some(UpdateCheckOutcome::UpToDate {
                             current: applied.to.clone(),
                         });
@@ -7691,11 +7756,25 @@ mod tests {
         let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
 
         app.execute_command("update apply");
-        assert_eq!(
-            app.last_status.as_deref(),
-            Some("No update info available. Run :update check first")
-        );
-        assert!(app.confirm_prompt.is_none());
+        if cfg!(windows) {
+            assert_eq!(
+                app.last_status.as_deref(),
+                Some("In-app apply is not supported on Windows yet")
+            );
+            assert!(app.confirm_prompt.is_none());
+        } else if crate::update::current_target_triple().is_none() {
+            assert_eq!(
+                app.last_status.as_deref(),
+                Some("In-app apply is unavailable on this platform (unknown target triple)")
+            );
+            assert!(app.confirm_prompt.is_none());
+        } else {
+            assert_eq!(
+                app.last_status.as_deref(),
+                Some("No update info available. Run :update check first")
+            );
+            assert!(app.confirm_prompt.is_none());
+        }
     }
 
     #[test]
@@ -7710,11 +7789,25 @@ mod tests {
         app.config.updates.mode = UpdateMode::NotifyOnly;
         app.execute_command("update apply");
 
-        assert_eq!(
-            app.last_status.as_deref(),
-            Some("In-app apply is disabled in notify-only mode")
-        );
-        assert!(app.confirm_prompt.is_none());
+        if cfg!(windows) {
+            assert_eq!(
+                app.last_status.as_deref(),
+                Some("In-app apply is not supported on Windows yet")
+            );
+            assert!(app.confirm_prompt.is_none());
+        } else if crate::update::current_target_triple().is_none() {
+            assert_eq!(
+                app.last_status.as_deref(),
+                Some("In-app apply is unavailable on this platform (unknown target triple)")
+            );
+            assert!(app.confirm_prompt.is_none());
+        } else {
+            assert_eq!(
+                app.last_status.as_deref(),
+                Some("In-app apply is disabled in notify-only mode")
+            );
+            assert!(app.confirm_prompt.is_none());
+        }
     }
 
     #[test]
@@ -7726,16 +7819,32 @@ mod tests {
             .unwrap();
         let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
 
+        let target = crate::update::current_target_triple().unwrap_or("x86_64-unknown-linux-gnu");
+
         app.update_state.last_outcome = Some(UpdateCheckOutcome::UpdateAvailable(UpdateInfo {
             current: Version::new(0, 4, 2),
             latest: Version::new(0, 4, 3),
             notes_url: Some("https://example.com/release".to_string()),
-            asset_url: Some("https://example.com/tsql-x86_64-unknown-linux-gnu.tar.gz".to_string()),
+            asset_url: Some(format!("https://example.com/tsql-{}.tar.gz", target)),
             checksum_url: Some("https://example.com/SHA256SUMS.txt".to_string()),
         }));
 
         app.execute_command("update apply");
-        assert!(app.confirm_prompt.is_some());
+        if cfg!(windows) {
+            assert!(app.confirm_prompt.is_none());
+            assert_eq!(
+                app.last_status.as_deref(),
+                Some("In-app apply is not supported on Windows yet")
+            );
+        } else if crate::update::current_target_triple().is_none() {
+            assert!(app.confirm_prompt.is_none());
+            assert_eq!(
+                app.last_status.as_deref(),
+                Some("In-app apply is unavailable on this platform (unknown target triple)")
+            );
+        } else {
+            assert!(app.confirm_prompt.is_some());
+        }
     }
 
     // ========== CellEditor Tests ==========

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -4059,6 +4059,8 @@ impl App {
     }
 
     fn maybe_start_scheduled_update_check(&mut self) {
+        let now = Instant::now();
+
         if self
             .update_state
             .should_check_on_startup(&self.config.updates)
@@ -4067,9 +4069,14 @@ impl App {
             return;
         }
 
+        if !self.config.updates.check_on_startup && !self.update_state.startup_check_started {
+            self.update_state.mark_startup_skipped(now);
+            return;
+        }
+
         if self
             .update_state
-            .should_check_by_interval(&self.config.updates, Instant::now())
+            .should_check_by_interval(&self.config.updates, now)
         {
             self.start_update_check(false, false);
         }
@@ -7845,6 +7852,26 @@ mod tests {
         } else {
             assert!(app.confirm_prompt.is_some());
         }
+    }
+
+    #[test]
+    fn test_check_on_startup_false_does_not_run_interval_immediately() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+        app.config.updates.check_on_startup = false;
+
+        assert!(!app.update_state.startup_check_started);
+        assert!(app.update_state.last_checked_at.is_none());
+
+        app.maybe_start_scheduled_update_check();
+
+        assert!(!app.update_state.check_in_flight);
+        assert!(app.update_state.startup_check_started);
+        assert!(app.update_state.last_checked_at.is_some());
     }
 
     // ========== CellEditor Tests ==========

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -34,7 +34,7 @@ use webpki_roots::TLS_SERVER_ROOTS;
 use super::state::{DbStatus, Focus, Mode, PanelDirection, SearchTarget, SidebarSection};
 use crate::config::{
     load_connections, save_connections, Action, ClipboardBackend, Config, ConnectionEntry,
-    ConnectionsFile, KeyBinding, Keymap, SslMode,
+    ConnectionsFile, KeyBinding, Keymap, SslMode, UpdateMode,
 };
 use crate::history::{History, HistoryEntry};
 use crate::session::SessionState;
@@ -51,8 +51,8 @@ use crate::ui::{
     YankFormat,
 };
 use crate::update::{
-    check_for_update, detect_current_install_method, upgrade_hint, GitHubReleasesProvider,
-    UpdateCheckOutcome, UpdateState,
+    apply_update, check_for_update, detect_current_install_method, upgrade_hint, ApplyResult,
+    GitHubReleasesProvider, InstallMethod, UpdateCheckOutcome, UpdateInfo, UpdateState,
 };
 use crate::util::format_pg_error;
 use crate::util::{is_json_column_type, should_use_multiline_editor};
@@ -798,6 +798,10 @@ pub enum DbEvent {
         outcome: UpdateCheckOutcome,
         manual: bool,
     },
+    /// A background update apply completed.
+    UpdateApplyFinished {
+        result: std::result::Result<ApplyResult, String>,
+    },
 }
 
 pub struct DbSession {
@@ -1129,6 +1133,8 @@ pub struct App {
 
     /// Runtime state for update checks.
     update_state: UpdateState,
+    /// True while an update apply flow is running in the background.
+    update_apply_in_flight: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1286,6 +1292,7 @@ impl App {
 
             query_ui: QueryRunUi::default(),
             update_state: UpdateState::default(),
+            update_apply_in_flight: false,
         };
 
         // Load saved connections
@@ -3459,6 +3466,10 @@ impl App {
                 self.connect_to_entry(entry);
                 false
             }
+            ConfirmContext::ApplyUpdate { info } => {
+                self.start_update_apply(info);
+                false
+            }
         }
     }
 
@@ -3488,6 +3499,9 @@ impl App {
             ConfirmContext::SwitchConnection { .. } => {
                 // Cancelled connection switch
                 self.last_status = Some("Connection switch cancelled".to_string());
+            }
+            ConfirmContext::ApplyUpdate { .. } => {
+                self.last_status = Some("Update apply cancelled".to_string());
             }
         }
     }
@@ -4027,8 +4041,9 @@ impl App {
         match subcommand {
             "check" | "" => self.start_update_check(true, false),
             "status" => self.show_update_status(),
+            "apply" => self.request_update_apply(),
             _ => {
-                self.last_status = Some("Usage: :update [check|status]".to_string());
+                self.last_status = Some("Usage: :update [check|status|apply]".to_string());
             }
         }
     }
@@ -4114,6 +4129,89 @@ impl App {
 
             let _ = tx.send(DbEvent::UpdateChecked { outcome, manual });
         });
+    }
+
+    fn request_update_apply(&mut self) {
+        if self.update_apply_in_flight {
+            self.last_status = Some("Update apply already running".to_string());
+            return;
+        }
+
+        let install_method = detect_current_install_method();
+        if !UpdateState::apply_allowed(&self.config.updates, install_method) {
+            self.last_status = Some(self.apply_not_allowed_message(install_method));
+            return;
+        }
+
+        let Some(outcome) = self.update_state.last_outcome.as_ref() else {
+            self.last_status =
+                Some("No update info available. Run :update check first".to_string());
+            return;
+        };
+
+        let info = match outcome {
+            UpdateCheckOutcome::UpdateAvailable(info) => info.clone(),
+            UpdateCheckOutcome::UpToDate { .. } => {
+                self.last_status = Some("Already up to date; nothing to apply".to_string());
+                return;
+            }
+            UpdateCheckOutcome::Error(error) => {
+                self.last_status = Some(format!("Cannot apply update: {}", error));
+                return;
+            }
+            UpdateCheckOutcome::Disabled => {
+                self.last_status = Some("Update checks are disabled".to_string());
+                return;
+            }
+        };
+
+        self.confirm_prompt = Some(ConfirmPrompt::new(
+            format!(
+                "Apply update now? {} -> {}. This will replace the current tsql binary.",
+                info.current, info.latest
+            ),
+            ConfirmContext::ApplyUpdate { info },
+        ));
+    }
+
+    fn start_update_apply(&mut self, info: UpdateInfo) {
+        if self.update_apply_in_flight {
+            self.last_status = Some("Update apply already running".to_string());
+            return;
+        }
+
+        self.update_apply_in_flight = true;
+        self.last_status = Some(format!(
+            "Applying update {} -> {}...",
+            info.current, info.latest
+        ));
+        let tx = self.db_events_tx.clone();
+
+        self.rt.spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                apply_update(&info).map_err(|error| format!("Update apply failed: {}", error))
+            })
+            .await
+            .unwrap_or_else(|error| Err(format!("Update apply task failed: {}", error)));
+
+            let _ = tx.send(DbEvent::UpdateApplyFinished { result });
+        });
+    }
+
+    fn apply_not_allowed_message(&self, method: InstallMethod) -> String {
+        if matches!(self.config.updates.mode, UpdateMode::Off) || !self.config.updates.enabled {
+            return "Update checks are disabled".to_string();
+        }
+        if matches!(self.config.updates.mode, UpdateMode::NotifyOnly) {
+            return "In-app apply is disabled in notify-only mode".to_string();
+        }
+        if !self.config.updates.allow_apply_for_standalone {
+            return "In-app apply is disabled by config (`updates.allow_apply_for_standalone = false`)".to_string();
+        }
+        if let Some(hint) = upgrade_hint(method) {
+            return format!("In-app apply is unavailable for this install. Use {}", hint);
+        }
+        "In-app apply is only available for standalone binaries".to_string()
     }
 
     fn update_status_message(&self, outcome: &UpdateCheckOutcome, manual: bool) -> String {
@@ -6899,6 +6997,25 @@ impl App {
                     self.last_status = Some(status);
                 }
             }
+            DbEvent::UpdateApplyFinished { result } => {
+                self.update_apply_in_flight = false;
+                match result {
+                    Ok(applied) => {
+                        self.update_state.last_outcome = Some(UpdateCheckOutcome::UpToDate {
+                            current: applied.to.clone(),
+                        });
+                        self.last_status = Some(format!(
+                            "Updated to v{} (backup: {}). Restart tsql to run the new binary",
+                            applied.to,
+                            applied.backup_path.display()
+                        ));
+                    }
+                    Err(error) => {
+                        self.last_error = Some(error);
+                        self.last_status = Some("Update apply failed (see error)".to_string());
+                    }
+                }
+            }
         }
     }
 
@@ -7562,6 +7679,63 @@ mod tests {
             app.last_status.as_deref(),
             Some("You're up to date (v0.4.2)")
         );
+    }
+
+    #[test]
+    fn test_update_apply_requires_existing_update_info() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+
+        app.execute_command("update apply");
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("No update info available. Run :update check first")
+        );
+        assert!(app.confirm_prompt.is_none());
+    }
+
+    #[test]
+    fn test_update_apply_disallowed_in_notify_only_mode() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+
+        app.config.updates.mode = UpdateMode::NotifyOnly;
+        app.execute_command("update apply");
+
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("In-app apply is disabled in notify-only mode")
+        );
+        assert!(app.confirm_prompt.is_none());
+    }
+
+    #[test]
+    fn test_update_apply_prompts_when_update_available() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+
+        app.update_state.last_outcome = Some(UpdateCheckOutcome::UpdateAvailable(UpdateInfo {
+            current: Version::new(0, 4, 2),
+            latest: Version::new(0, 4, 3),
+            notes_url: Some("https://example.com/release".to_string()),
+            asset_url: Some("https://example.com/tsql-x86_64-unknown-linux-gnu.tar.gz".to_string()),
+            checksum_url: Some("https://example.com/SHA256SUMS.txt".to_string()),
+        }));
+
+        app.execute_command("update apply");
+        assert!(app.confirm_prompt.is_some());
     }
 
     // ========== CellEditor Tests ==========

--- a/crates/tsql/src/config/mod.rs
+++ b/crates/tsql/src/config/mod.rs
@@ -17,7 +17,8 @@ pub use connections::{
 pub use keymap::{Action, KeyBinding, Keymap};
 pub use schema::{
     ClipboardBackend, ClipboardConfig, Config, ConnectionConfig, CustomKeyBinding, DisplayConfig,
-    EditorConfig, IdentifierStyle, KeymapConfig, SqlConfig,
+    EditorConfig, IdentifierStyle, KeymapConfig, SqlConfig, UpdateChannel, UpdateMode,
+    UpdatesConfig,
 };
 
 use anyhow::{Context, Result};

--- a/crates/tsql/src/config/schema.rs
+++ b/crates/tsql/src/config/schema.rs
@@ -19,6 +19,8 @@ pub struct Config {
     pub clipboard: ClipboardConfig,
     /// Keymap customizations
     pub keymap: KeymapConfig,
+    /// Update checking settings
+    pub updates: UpdatesConfig,
 }
 
 /// Display-related settings
@@ -210,6 +212,55 @@ impl Default for KeymapConfig {
     }
 }
 
+/// Update checking settings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct UpdatesConfig {
+    /// Enable update checks.
+    pub enabled: bool,
+    /// Check for updates on startup.
+    pub check_on_startup: bool,
+    /// Release channel to query.
+    pub channel: UpdateChannel,
+    /// Update mode behavior.
+    pub mode: UpdateMode,
+    /// Minimum interval between checks (hours).
+    pub interval_hours: u64,
+    /// GitHub repository slug used for release checks.
+    pub github_repo: String,
+}
+
+impl Default for UpdatesConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            check_on_startup: true,
+            channel: UpdateChannel::Stable,
+            mode: UpdateMode::Auto,
+            interval_hours: 24,
+            github_repo: "fcoury/tsql".to_string(),
+        }
+    }
+}
+
+/// Release channel for update checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UpdateChannel {
+    Stable,
+    Prerelease,
+}
+
+/// Update behavior mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UpdateMode {
+    /// Auto mode currently behaves like notify-only in phase 1.
+    Auto,
+    NotifyOnly,
+    Off,
+}
+
 /// SQL generation / templating settings
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
@@ -281,6 +332,14 @@ wl_copy_trim_newline = true
 [keymap]
 vim_mode = true
 
+[updates]
+enabled = true
+check_on_startup = true
+channel = "stable"
+mode = "notify-only"
+interval_hours = 12
+github_repo = "fcoury/tsql"
+
 [[keymap.normal]]
 key = "ctrl+s"
 action = "save_query"
@@ -326,6 +385,14 @@ description = "Export results as CSV"
 
         assert_eq!(config.keymap.grid.len(), 1);
         assert_eq!(config.keymap.grid[0].key, "ctrl+e");
+
+        // Updates
+        assert!(config.updates.enabled);
+        assert!(config.updates.check_on_startup);
+        assert_eq!(config.updates.channel, UpdateChannel::Stable);
+        assert_eq!(config.updates.mode, UpdateMode::NotifyOnly);
+        assert_eq!(config.updates.interval_hours, 12);
+        assert_eq!(config.updates.github_repo, "fcoury/tsql");
     }
 
     #[test]
@@ -335,5 +402,6 @@ description = "Export results as CSV"
         assert!(toml_str.contains("[display]"));
         assert!(toml_str.contains("[editor]"));
         assert!(toml_str.contains("[connection]"));
+        assert!(toml_str.contains("[updates]"));
     }
 }

--- a/crates/tsql/src/config/schema.rs
+++ b/crates/tsql/src/config/schema.rs
@@ -226,6 +226,8 @@ pub struct UpdatesConfig {
     pub mode: UpdateMode,
     /// Minimum interval between checks (hours).
     pub interval_hours: u64,
+    /// Allow in-app apply only when running a standalone binary.
+    pub allow_apply_for_standalone: bool,
     /// GitHub repository slug used for release checks.
     pub github_repo: String,
 }
@@ -238,6 +240,7 @@ impl Default for UpdatesConfig {
             channel: UpdateChannel::Stable,
             mode: UpdateMode::Auto,
             interval_hours: 24,
+            allow_apply_for_standalone: true,
             github_repo: "fcoury/tsql".to_string(),
         }
     }
@@ -338,6 +341,7 @@ check_on_startup = true
 channel = "stable"
 mode = "notify-only"
 interval_hours = 12
+allow_apply_for_standalone = true
 github_repo = "fcoury/tsql"
 
 [[keymap.normal]]
@@ -392,6 +396,7 @@ description = "Export results as CSV"
         assert_eq!(config.updates.channel, UpdateChannel::Stable);
         assert_eq!(config.updates.mode, UpdateMode::NotifyOnly);
         assert_eq!(config.updates.interval_hours, 12);
+        assert!(config.updates.allow_apply_for_standalone);
         assert_eq!(config.updates.github_repo, "fcoury/tsql");
     }
 

--- a/crates/tsql/src/lib.rs
+++ b/crates/tsql/src/lib.rs
@@ -4,5 +4,6 @@ pub mod config;
 pub mod history;
 pub mod session;
 pub mod ui;
+pub mod update;
 pub mod util;
 pub mod vim;

--- a/crates/tsql/src/ui/confirm_prompt.rs
+++ b/crates/tsql/src/ui/confirm_prompt.rs
@@ -15,6 +15,7 @@ use ratatui::Frame;
 use tui_confirm_dialog_with_mouse::{ConfirmDialog, ConfirmDialogState};
 
 use crate::config::ConnectionEntry;
+use crate::update::UpdateInfo;
 
 /// Widget ID for the confirmation dialog (only one dialog is used at a time).
 const CONFIRM_DIALOG_ID: u16 = 0;
@@ -47,6 +48,8 @@ pub enum ConfirmContext {
     CloseConnectionForm,
     /// Switching to a new connection with unsaved query changes.
     SwitchConnection { entry: ConnectionEntry },
+    /// Applying an in-app binary update.
+    ApplyUpdate { info: UpdateInfo },
 }
 
 /// A reusable confirmation dialog for unsaved changes.
@@ -117,6 +120,7 @@ impl ConfirmPrompt {
             | ConfirmContext::SwitchConnection { .. } => " Unsaved Changes ",
             ConfirmContext::QuitAppClean => " Confirm Quit ",
             ConfirmContext::DeleteConnection { .. } => " Delete Connection ",
+            ConfirmContext::ApplyUpdate { .. } => " Apply Update ",
         }
     }
 

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -244,7 +244,7 @@ const COMMANDS: HelpSection = HelpSection::new(
         KeyBinding::new(":export <fmt> <path>", "Export results (csv/json/tsv)"),
         KeyBinding::new(":gen <type>", "Generate SQL (update/delete/insert)"),
         KeyBinding::new(":history", "Open history picker"),
-        KeyBinding::new(":update [check|status]", "Check update status"),
+        KeyBinding::new(":update [check|status|apply]", "Check/apply updates"),
         KeyBinding::new(":sbt / :sidebar-toggle", "Toggle sidebar"),
         KeyBinding::new(":q / :quit", "Quit application"),
         KeyBinding::new(":help / :?", "Show this help"),

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -244,6 +244,7 @@ const COMMANDS: HelpSection = HelpSection::new(
         KeyBinding::new(":export <fmt> <path>", "Export results (csv/json/tsv)"),
         KeyBinding::new(":gen <type>", "Generate SQL (update/delete/insert)"),
         KeyBinding::new(":history", "Open history picker"),
+        KeyBinding::new(":update [check|status]", "Check update status"),
         KeyBinding::new(":sbt / :sidebar-toggle", "Toggle sidebar"),
         KeyBinding::new(":q / :quit", "Quit application"),
         KeyBinding::new(":help / :?", "Show this help"),

--- a/crates/tsql/src/update/apply.rs
+++ b/crates/tsql/src/update/apply.rs
@@ -18,6 +18,11 @@ pub struct ApplyResult {
 }
 
 pub fn apply_update(info: &UpdateInfo) -> Result<ApplyResult> {
+    let current = std::env::current_exe().context("Failed to locate current executable")?;
+    apply_update_to_path(info, &current)
+}
+
+fn apply_update_to_path(info: &UpdateInfo, current_executable: &Path) -> Result<ApplyResult> {
     if cfg!(windows) {
         bail!("In-app apply is not supported on Windows yet");
     }
@@ -42,7 +47,7 @@ pub fn apply_update(info: &UpdateInfo) -> Result<ApplyResult> {
     verify_archive_checksum(&archive_path, &asset_filename, &checksum_text)?;
 
     let extracted_binary = extract_binary_from_archive(&archive_path, temp_dir.path())?;
-    let backup_path = replace_current_executable(&extracted_binary)?;
+    let backup_path = replace_executable_at_path(current_executable, &extracted_binary)?;
 
     Ok(ApplyResult {
         from: info.current.clone(),
@@ -165,11 +170,6 @@ fn extract_binary_from_archive(archive_path: &Path, out_dir: &Path) -> Result<Pa
     bail!("Could not find 'tsql' binary in release archive")
 }
 
-fn replace_current_executable(new_binary: &Path) -> Result<PathBuf> {
-    let current = std::env::current_exe().context("Failed to locate current executable")?;
-    replace_executable_at_path(&current, new_binary)
-}
-
 fn replace_executable_at_path(current: &Path, new_binary: &Path) -> Result<PathBuf> {
     let parent = current
         .parent()
@@ -286,8 +286,106 @@ fn filename_from_url(url: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::net::TcpListener;
+    use std::thread;
+
+    use semver::Version;
+
     use super::*;
     use tempfile::tempdir;
+
+    struct TestHttpServer {
+        base_url: String,
+        handle: Option<thread::JoinHandle<()>>,
+    }
+
+    impl Drop for TestHttpServer {
+        fn drop(&mut self) {
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn start_test_http_server(routes: HashMap<String, Vec<u8>>) -> TestHttpServer {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        listener
+            .set_nonblocking(true)
+            .expect("set nonblocking listener");
+        let address = listener.local_addr().expect("read bound address");
+
+        let handle = thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            let mut served = 0_usize;
+
+            while served < routes.len() && std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _peer)) => {
+                        served += 1;
+
+                        let mut request_buffer = [0_u8; 8192];
+                        let bytes_read = stream.read(&mut request_buffer).unwrap_or(0);
+                        let request = String::from_utf8_lossy(&request_buffer[..bytes_read]);
+                        let path = request
+                            .lines()
+                            .next()
+                            .and_then(|line| line.split_whitespace().nth(1))
+                            .unwrap_or("/");
+
+                        let (status, body): (&str, &[u8]) = if let Some(body) = routes.get(path) {
+                            ("200 OK", body)
+                        } else {
+                            ("404 Not Found", b"not found")
+                        };
+
+                        let response_headers = format!(
+                            "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            body.len()
+                        );
+
+                        let _ = stream.write_all(response_headers.as_bytes());
+                        let _ = stream.write_all(body);
+                        let _ = stream.flush();
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        TestHttpServer {
+            base_url: format!("http://{}", address),
+            handle: Some(handle),
+        }
+    }
+
+    fn build_test_tar_gz(binary_contents: &[u8]) -> Vec<u8> {
+        let gzip = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut archive = tar::Builder::new(gzip);
+
+        let mut header = tar::Header::new_gnu();
+        header
+            .set_path("tsql")
+            .expect("set tar entry path for test archive");
+        header.set_size(binary_contents.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        archive
+            .append(&header, binary_contents)
+            .expect("append binary to test tar archive");
+
+        let gzip = archive.into_inner().expect("finish test tar archive");
+        gzip.finish().expect("finish test gzip encoding")
+    }
+
+    fn sha256_hex_bytes(bytes: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        format!("{:x}", hasher.finalize())
+    }
 
     #[test]
     fn test_filename_from_url_extracts_last_segment() {
@@ -316,6 +414,98 @@ mod tests {
         assert_eq!(
             checksum,
             "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_apply_update_end_to_end_download_verify_extract_and_replace() {
+        let dir = tempdir().expect("tempdir");
+        let current = dir.path().join("tsql-current");
+        fs::write(&current, b"old-binary").expect("write current binary");
+
+        let archive_filename = "tsql-x86_64-unknown-linux-gnu.tar.gz";
+        let archive_bytes = build_test_tar_gz(b"new-binary");
+        let checksums = format!(
+            "{}  {}\n",
+            sha256_hex_bytes(&archive_bytes),
+            archive_filename
+        );
+
+        let mut routes = HashMap::new();
+        routes.insert(format!("/{}", archive_filename), archive_bytes);
+        routes.insert("/SHA256SUMS".to_string(), checksums.into_bytes());
+        let server = start_test_http_server(routes);
+
+        let info = UpdateInfo {
+            current: Version::new(0, 4, 2),
+            latest: Version::new(0, 4, 3),
+            notes_url: None,
+            asset_url: Some(format!("{}/{}", server.base_url, archive_filename)),
+            checksum_url: Some(format!("{}/SHA256SUMS", server.base_url)),
+        };
+
+        let result = apply_update_to_path(&info, &current).expect("apply should succeed");
+
+        assert_eq!(result.from, Version::new(0, 4, 2));
+        assert_eq!(result.to, Version::new(0, 4, 3));
+        assert_eq!(
+            fs::read_to_string(&current).expect("read installed binary"),
+            "new-binary"
+        );
+        assert_eq!(
+            fs::read_to_string(&result.backup_path).expect("read backup binary"),
+            "old-binary"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_apply_update_end_to_end_rejects_bad_checksum_without_replacing_binary() {
+        let dir = tempdir().expect("tempdir");
+        let current = dir.path().join("tsql-current");
+        fs::write(&current, b"old-binary").expect("write current binary");
+
+        let archive_filename = "tsql-x86_64-unknown-linux-gnu.tar.gz";
+        let archive_bytes = build_test_tar_gz(b"new-binary");
+        let checksums = format!("{:064x}  {}\n", 0_u8, archive_filename);
+
+        let mut routes = HashMap::new();
+        routes.insert(format!("/{}", archive_filename), archive_bytes);
+        routes.insert("/SHA256SUMS".to_string(), checksums.into_bytes());
+        let server = start_test_http_server(routes);
+
+        let info = UpdateInfo {
+            current: Version::new(0, 4, 2),
+            latest: Version::new(0, 4, 3),
+            notes_url: None,
+            asset_url: Some(format!("{}/{}", server.base_url, archive_filename)),
+            checksum_url: Some(format!("{}/SHA256SUMS", server.base_url)),
+        };
+
+        let error = apply_update_to_path(&info, &current).expect_err("checksum mismatch expected");
+        let error_message = format!("{error:#}");
+        assert!(
+            error_message.contains("Checksum mismatch"),
+            "unexpected error: {error_message}"
+        );
+        assert_eq!(
+            fs::read_to_string(&current).expect("read unchanged current binary"),
+            "old-binary"
+        );
+        let backup_count = fs::read_dir(dir.path())
+            .expect("read directory")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("tsql.backup.")
+            })
+            .count();
+        assert_eq!(
+            backup_count, 0,
+            "backup should not be created on checksum failure"
         );
     }
 

--- a/crates/tsql/src/update/apply.rs
+++ b/crates/tsql/src/update/apply.rs
@@ -1,0 +1,344 @@
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, bail, Context, Result};
+use flate2::read::GzDecoder;
+use sha2::{Digest, Sha256};
+use tar::Archive;
+
+use super::types::UpdateInfo;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyResult {
+    pub from: semver::Version,
+    pub to: semver::Version,
+    pub backup_path: PathBuf,
+}
+
+pub fn apply_update(info: &UpdateInfo) -> Result<ApplyResult> {
+    if cfg!(windows) {
+        bail!("In-app apply is not supported on Windows yet");
+    }
+
+    let asset_url = info
+        .asset_url
+        .as_deref()
+        .context("No release asset URL available for this update")?;
+    let checksum_url = info
+        .checksum_url
+        .as_deref()
+        .context("No checksum URL available for this update")?;
+    let asset_filename = filename_from_url(asset_url)
+        .context("Could not determine archive filename from asset URL")?;
+
+    let temp_dir = tempfile::tempdir().context("Failed to create temporary update directory")?;
+    let archive_path = temp_dir.path().join(&asset_filename);
+
+    download_to_path(asset_url, &archive_path)?;
+
+    let checksum_text = download_text(checksum_url)?;
+    verify_archive_checksum(&archive_path, &asset_filename, &checksum_text)?;
+
+    let extracted_binary = extract_binary_from_archive(&archive_path, temp_dir.path())?;
+    let backup_path = replace_current_executable(&extracted_binary)?;
+
+    Ok(ApplyResult {
+        from: info.current.clone(),
+        to: info.latest.clone(),
+        backup_path,
+    })
+}
+
+fn download_to_path(url: &str, destination: &Path) -> Result<()> {
+    let agent = build_agent();
+    let response = agent
+        .get(url)
+        .set("User-Agent", "tsql-updater")
+        .call()
+        .with_context(|| format!("Failed to download update archive from {}", url))?;
+
+    let mut reader = response.into_reader();
+    let mut output = fs::File::create(destination)
+        .with_context(|| format!("Failed to create {}", destination.display()))?;
+
+    io::copy(&mut reader, &mut output)
+        .with_context(|| format!("Failed to write archive to {}", destination.display()))?;
+    output
+        .flush()
+        .with_context(|| format!("Failed to flush {}", destination.display()))?;
+    Ok(())
+}
+
+fn download_text(url: &str) -> Result<String> {
+    let agent = build_agent();
+    let response = agent
+        .get(url)
+        .set("User-Agent", "tsql-updater")
+        .call()
+        .with_context(|| format!("Failed to download checksums from {}", url))?;
+
+    response
+        .into_string()
+        .with_context(|| format!("Failed to read checksum response from {}", url))
+}
+
+fn build_agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(5))
+        .timeout_read(Duration::from_secs(15))
+        .timeout_write(Duration::from_secs(15))
+        .build()
+}
+
+fn verify_archive_checksum(archive_path: &Path, filename: &str, checksums: &str) -> Result<()> {
+    let expected = checksum_for_asset(checksums, filename)
+        .ok_or_else(|| anyhow!("Checksum for '{}' not found in checksum file", filename))?;
+    let actual = sha256_hex(archive_path)?;
+
+    if expected != actual {
+        bail!(
+            "Checksum mismatch for '{}': expected {}, got {}",
+            filename,
+            expected,
+            actual
+        );
+    }
+    Ok(())
+}
+
+fn sha256_hex(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("Failed to open {} for checksum", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 16 * 1024];
+
+    loop {
+        let n = file
+            .read(&mut buffer)
+            .with_context(|| format!("Failed reading {}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buffer[..n]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn extract_binary_from_archive(archive_path: &Path, out_dir: &Path) -> Result<PathBuf> {
+    let file = fs::File::open(archive_path)
+        .with_context(|| format!("Failed to open archive {}", archive_path.display()))?;
+    let mut tar = Archive::new(GzDecoder::new(file));
+
+    let output_binary = out_dir.join("tsql.new");
+
+    for entry in tar.entries().context("Failed reading archive entries")? {
+        let mut entry = entry.context("Failed to read archive entry")?;
+        let path = entry.path().context("Failed to read archive entry path")?;
+
+        if path.file_name().is_some_and(|name| name == "tsql") {
+            entry.unpack(&output_binary).with_context(|| {
+                format!("Failed to unpack binary to {}", output_binary.display())
+            })?;
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = fs::metadata(&output_binary)
+                    .with_context(|| format!("Failed to stat {}", output_binary.display()))?
+                    .permissions();
+                perms.set_mode(0o755);
+                fs::set_permissions(&output_binary, perms).with_context(|| {
+                    format!(
+                        "Failed to set executable permissions on {}",
+                        output_binary.display()
+                    )
+                })?;
+            }
+
+            return Ok(output_binary);
+        }
+    }
+
+    bail!("Could not find 'tsql' binary in release archive")
+}
+
+fn replace_current_executable(new_binary: &Path) -> Result<PathBuf> {
+    let current = std::env::current_exe().context("Failed to locate current executable")?;
+    replace_executable_at_path(&current, new_binary)
+}
+
+fn replace_executable_at_path(current: &Path, new_binary: &Path) -> Result<PathBuf> {
+    let parent = current
+        .parent()
+        .ok_or_else(|| anyhow!("Current executable has no parent directory"))?;
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let backup_path = parent.join(format!("tsql.backup.{}", timestamp));
+
+    fs::rename(current, &backup_path).with_context(|| {
+        format!(
+            "Failed to move current binary from {} to {}",
+            current.display(),
+            backup_path.display()
+        )
+    })?;
+
+    if let Err(error) = fs::copy(new_binary, current).with_context(|| {
+        format!(
+            "Failed to install new binary from {} to {}",
+            new_binary.display(),
+            current.display()
+        )
+    }) {
+        let _ = fs::rename(&backup_path, current);
+        return Err(error);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(current)
+            .with_context(|| format!("Failed to stat {}", current.display()))?
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(current, perms)
+            .with_context(|| format!("Failed to set permissions on {}", current.display()))?;
+    }
+
+    Ok(backup_path)
+}
+
+fn checksum_for_asset(checksums: &str, filename: &str) -> Option<String> {
+    for line in checksums.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let mut parts = line.split_whitespace();
+        let hash = parts.next()?;
+        let raw_name = parts.next()?;
+        let raw_name = raw_name.trim_start_matches('*');
+
+        let matches = raw_name == filename
+            || Path::new(raw_name)
+                .file_name()
+                .is_some_and(|name| name == filename);
+
+        if matches {
+            return Some(hash.to_ascii_lowercase());
+        }
+    }
+    None
+}
+
+fn filename_from_url(url: &str) -> Option<String> {
+    let path = url::Url::parse(url).ok()?.path().to_string();
+    Path::new(&path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_filename_from_url_extracts_last_segment() {
+        let filename =
+            filename_from_url("https://example.com/releases/tsql-x86_64-unknown-linux-gnu.tar.gz")
+                .expect("filename should be parsed");
+        assert_eq!(filename, "tsql-x86_64-unknown-linux-gnu.tar.gz");
+    }
+
+    #[test]
+    fn test_checksum_for_asset_matches_standard_sha256sums_format() {
+        let checksums = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  tsql-aarch64-apple-darwin.tar.gz\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  tsql-x86_64-unknown-linux-gnu.tar.gz\n";
+        let checksum = checksum_for_asset(checksums, "tsql-x86_64-unknown-linux-gnu.tar.gz")
+            .expect("checksum should be found");
+        assert_eq!(
+            checksum,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+    }
+
+    #[test]
+    fn test_checksum_for_asset_supports_asterisk_prefixed_names() {
+        let checksums = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc *tsql-x86_64-unknown-linux-gnu.tar.gz\n";
+        let checksum = checksum_for_asset(checksums, "tsql-x86_64-unknown-linux-gnu.tar.gz")
+            .expect("checksum should be found");
+        assert_eq!(
+            checksum,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        );
+    }
+
+    #[test]
+    fn test_replace_executable_at_path_swaps_binary_and_creates_backup() {
+        let dir = tempdir().expect("tempdir");
+        let current = dir.path().join("tsql-current");
+        let new_binary = dir.path().join("tsql-new");
+
+        fs::write(&current, b"old-binary").expect("write current binary");
+        fs::write(&new_binary, b"new-binary").expect("write new binary");
+
+        let backup_path =
+            replace_executable_at_path(&current, &new_binary).expect("replace should succeed");
+
+        let installed = fs::read_to_string(&current).expect("read current binary");
+        assert_eq!(installed, "new-binary");
+
+        let backup = fs::read_to_string(&backup_path).expect("read backup binary");
+        assert_eq!(backup, "old-binary");
+    }
+
+    #[test]
+    fn test_replace_executable_at_path_rolls_back_when_copy_fails() {
+        let dir = tempdir().expect("tempdir");
+        let current = dir.path().join("tsql-current");
+        let missing_binary = dir.path().join("missing-binary");
+
+        fs::write(&current, b"old-binary").expect("write current binary");
+
+        let before_backup_count = fs::read_dir(dir.path())
+            .expect("read dir before")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("tsql.backup.")
+            })
+            .count();
+
+        let error = replace_executable_at_path(&current, &missing_binary)
+            .expect_err("replace should fail when source binary is missing");
+        let error_message = format!("{error:#}");
+        assert!(
+            error_message.contains("Failed to install new binary"),
+            "unexpected error: {error_message}"
+        );
+
+        let restored = fs::read_to_string(&current).expect("read restored binary");
+        assert_eq!(restored, "old-binary");
+
+        let after_backup_count = fs::read_dir(dir.path())
+            .expect("read dir after")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("tsql.backup.")
+            })
+            .count();
+        assert_eq!(before_backup_count, after_backup_count);
+    }
+}

--- a/crates/tsql/src/update/apply.rs
+++ b/crates/tsql/src/update/apply.rs
@@ -196,7 +196,14 @@ fn replace_executable_at_path(current: &Path, new_binary: &Path) -> Result<PathB
             current.display()
         )
     }) {
-        let _ = fs::rename(&backup_path, current);
+        if let Err(rollback_error) = rollback_to_backup(current, &backup_path) {
+            return Err(error.context(format!(
+                "Additionally, rollback failed while restoring {} from {}: {}",
+                current.display(),
+                backup_path.display(),
+                rollback_error
+            )));
+        }
         return Err(error);
     }
 
@@ -207,11 +214,43 @@ fn replace_executable_at_path(current: &Path, new_binary: &Path) -> Result<PathB
             .with_context(|| format!("Failed to stat {}", current.display()))?
             .permissions();
         perms.set_mode(0o755);
-        fs::set_permissions(current, perms)
-            .with_context(|| format!("Failed to set permissions on {}", current.display()))?;
+        if let Err(error) = fs::set_permissions(current, perms)
+            .with_context(|| format!("Failed to set permissions on {}", current.display()))
+        {
+            if let Err(rollback_error) = rollback_to_backup(current, &backup_path) {
+                return Err(error.context(format!(
+                    "Additionally, rollback after permission failure failed while restoring {} from {}: {}",
+                    current.display(),
+                    backup_path.display(),
+                    rollback_error
+                )));
+            }
+            return Err(error);
+        }
     }
 
     Ok(backup_path)
+}
+
+fn rollback_to_backup(current: &Path, backup_path: &Path) -> Result<()> {
+    if current.exists() {
+        fs::remove_file(current).with_context(|| {
+            format!(
+                "Failed to remove partially installed binary {}",
+                current.display()
+            )
+        })?;
+    }
+
+    fs::rename(backup_path, current).with_context(|| {
+        format!(
+            "Failed to restore backup from {} to {}",
+            backup_path.display(),
+            current.display()
+        )
+    })?;
+
+    Ok(())
 }
 
 fn checksum_for_asset(checksums: &str, filename: &str) -> Option<String> {

--- a/crates/tsql/src/update/checker.rs
+++ b/crates/tsql/src/update/checker.rs
@@ -1,0 +1,76 @@
+use semver::Version;
+
+use crate::config::UpdateChannel;
+
+use super::provider::ReleaseProvider;
+use super::types::{UpdateCheckOutcome, UpdateInfo};
+
+pub fn check_for_update(
+    provider: &dyn ReleaseProvider,
+    current: &Version,
+    channel: UpdateChannel,
+) -> UpdateCheckOutcome {
+    match provider.latest(channel) {
+        Ok(Some(release)) if release.version > *current => {
+            UpdateCheckOutcome::UpdateAvailable(UpdateInfo {
+                current: current.clone(),
+                latest: release.version,
+                notes_url: release.notes_url,
+                asset_url: release.asset_url,
+                checksum_url: release.checksum_url,
+            })
+        }
+        Ok(Some(_)) | Ok(None) => UpdateCheckOutcome::UpToDate {
+            current: current.clone(),
+        },
+        Err(error) => UpdateCheckOutcome::Error(format!("Update check failed: {}", error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::*;
+    use crate::update::provider::ReleaseCandidate;
+
+    struct StubProvider {
+        latest: Option<ReleaseCandidate>,
+    }
+
+    impl ReleaseProvider for StubProvider {
+        fn latest(&self, _channel: UpdateChannel) -> Result<Option<ReleaseCandidate>> {
+            Ok(self.latest.clone())
+        }
+    }
+
+    #[test]
+    fn test_check_for_update_reports_available_when_newer_version_exists() {
+        let provider = StubProvider {
+            latest: Some(ReleaseCandidate {
+                version: Version::new(0, 5, 0),
+                notes_url: Some("https://example.com/release".to_string()),
+                asset_url: None,
+                checksum_url: None,
+            }),
+        };
+
+        let outcome = check_for_update(&provider, &Version::new(0, 4, 2), UpdateChannel::Stable);
+        assert!(matches!(outcome, UpdateCheckOutcome::UpdateAvailable(_)));
+    }
+
+    #[test]
+    fn test_check_for_update_reports_up_to_date_when_equal_version() {
+        let provider = StubProvider {
+            latest: Some(ReleaseCandidate {
+                version: Version::new(0, 4, 2),
+                notes_url: None,
+                asset_url: None,
+                checksum_url: None,
+            }),
+        };
+
+        let outcome = check_for_update(&provider, &Version::new(0, 4, 2), UpdateChannel::Stable);
+        assert!(matches!(outcome, UpdateCheckOutcome::UpToDate { .. }));
+    }
+}

--- a/crates/tsql/src/update/checker.rs
+++ b/crates/tsql/src/update/checker.rs
@@ -23,7 +23,7 @@ pub fn check_for_update(
         Ok(Some(_)) | Ok(None) => UpdateCheckOutcome::UpToDate {
             current: current.clone(),
         },
-        Err(error) => UpdateCheckOutcome::Error(format!("Update check failed: {}", error)),
+        Err(error) => UpdateCheckOutcome::Error(error.to_string()),
     }
 }
 
@@ -38,9 +38,17 @@ mod tests {
         latest: Option<ReleaseCandidate>,
     }
 
+    struct FailingProvider;
+
     impl ReleaseProvider for StubProvider {
         fn latest(&self, _channel: UpdateChannel) -> Result<Option<ReleaseCandidate>> {
             Ok(self.latest.clone())
+        }
+    }
+
+    impl ReleaseProvider for FailingProvider {
+        fn latest(&self, _channel: UpdateChannel) -> Result<Option<ReleaseCandidate>> {
+            anyhow::bail!("Network error")
         }
     }
 
@@ -72,5 +80,12 @@ mod tests {
 
         let outcome = check_for_update(&provider, &Version::new(0, 4, 2), UpdateChannel::Stable);
         assert!(matches!(outcome, UpdateCheckOutcome::UpToDate { .. }));
+    }
+
+    #[test]
+    fn test_check_for_update_reports_error_on_provider_failure() {
+        let provider = FailingProvider;
+        let outcome = check_for_update(&provider, &Version::new(0, 4, 2), UpdateChannel::Stable);
+        assert!(matches!(outcome, UpdateCheckOutcome::Error(_)));
     }
 }

--- a/crates/tsql/src/update/detect.rs
+++ b/crates/tsql/src/update/detect.rs
@@ -1,0 +1,70 @@
+use std::path::Path;
+
+use super::types::InstallMethod;
+
+pub fn detect_install_method(path: &Path) -> InstallMethod {
+    let normalized = path.to_string_lossy().to_ascii_lowercase();
+
+    if normalized.contains("/cellar/tsql/") || normalized.contains("/homebrew/") {
+        InstallMethod::Homebrew
+    } else if normalized.contains("/.cargo/bin/") {
+        InstallMethod::CargoInstall
+    } else if normalized.starts_with("/usr/bin/")
+        || normalized.starts_with("/usr/local/bin/")
+        || normalized.contains("/snap/")
+    {
+        InstallMethod::SystemPackage
+    } else if path.is_absolute() {
+        InstallMethod::StandaloneBinary
+    } else {
+        InstallMethod::Unknown
+    }
+}
+
+pub fn detect_current_install_method() -> InstallMethod {
+    std::env::current_exe()
+        .ok()
+        .map(|path| detect_install_method(&path))
+        .unwrap_or(InstallMethod::Unknown)
+}
+
+pub fn upgrade_hint(method: InstallMethod) -> Option<&'static str> {
+    match method {
+        InstallMethod::Homebrew => Some("brew upgrade tsql"),
+        InstallMethod::CargoInstall => Some("cargo install --locked tsql"),
+        InstallMethod::SystemPackage => None,
+        InstallMethod::StandaloneBinary => None,
+        InstallMethod::Unknown => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_install_method_homebrew() {
+        let method = detect_install_method(Path::new("/opt/homebrew/Cellar/tsql/0.4.2/bin/tsql"));
+        assert_eq!(method, InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn test_detect_install_method_cargo_install() {
+        let method = detect_install_method(Path::new("/Users/alice/.cargo/bin/tsql"));
+        assert_eq!(method, InstallMethod::CargoInstall);
+    }
+
+    #[test]
+    fn test_detect_install_method_system_package() {
+        let method = detect_install_method(Path::new("/usr/bin/tsql"));
+        assert_eq!(method, InstallMethod::SystemPackage);
+    }
+
+    #[test]
+    fn test_upgrade_hint_for_homebrew() {
+        assert_eq!(
+            upgrade_hint(InstallMethod::Homebrew),
+            Some("brew upgrade tsql")
+        );
+    }
+}

--- a/crates/tsql/src/update/detect.rs
+++ b/crates/tsql/src/update/detect.rs
@@ -2,6 +2,36 @@ use std::path::Path;
 
 use super::types::InstallMethod;
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+pub fn current_target_triple() -> Option<&'static str> {
+    Some("aarch64-apple-darwin")
+}
+
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+pub fn current_target_triple() -> Option<&'static str> {
+    Some("x86_64-apple-darwin")
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+pub fn current_target_triple() -> Option<&'static str> {
+    Some("x86_64-unknown-linux-gnu")
+}
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+pub fn current_target_triple() -> Option<&'static str> {
+    Some("x86_64-pc-windows-msvc")
+}
+
+#[cfg(not(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "macos", target_arch = "x86_64"),
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "x86_64")
+)))]
+pub fn current_target_triple() -> Option<&'static str> {
+    None
+}
+
 pub fn detect_install_method(path: &Path) -> InstallMethod {
     let normalized = path.to_string_lossy().to_ascii_lowercase();
 
@@ -65,6 +95,14 @@ mod tests {
         assert_eq!(
             upgrade_hint(InstallMethod::Homebrew),
             Some("brew upgrade tsql")
+        );
+    }
+
+    #[test]
+    fn test_current_target_triple_is_known() {
+        assert!(
+            current_target_triple().is_some(),
+            "unsupported target for update apply"
         );
     }
 }

--- a/crates/tsql/src/update/detect.rs
+++ b/crates/tsql/src/update/detect.rs
@@ -91,6 +91,23 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_install_method_standalone_binary() {
+        let path = if cfg!(windows) {
+            Path::new("C:\\tools\\tsql.exe")
+        } else {
+            Path::new("/opt/mytools/tsql")
+        };
+        let method = detect_install_method(path);
+        assert_eq!(method, InstallMethod::StandaloneBinary);
+    }
+
+    #[test]
+    fn test_detect_install_method_relative_path_is_unknown() {
+        let method = detect_install_method(Path::new("bin/tsql"));
+        assert_eq!(method, InstallMethod::Unknown);
+    }
+
+    #[test]
     fn test_upgrade_hint_for_homebrew() {
         assert_eq!(
             upgrade_hint(InstallMethod::Homebrew),
@@ -100,9 +117,15 @@ mod tests {
 
     #[test]
     fn test_current_target_triple_is_known() {
+        let expected_known_target = cfg!(any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "macos", target_arch = "x86_64"),
+            all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "windows", target_arch = "x86_64")
+        ));
         assert!(
-            current_target_triple().is_some(),
-            "unsupported target for update apply"
+            current_target_triple().is_some() == expected_known_target,
+            "target triple support matrix mismatch"
         );
     }
 }

--- a/crates/tsql/src/update/mod.rs
+++ b/crates/tsql/src/update/mod.rs
@@ -1,11 +1,15 @@
+pub mod apply;
 pub mod checker;
 pub mod detect;
 pub mod provider;
 pub mod state;
 pub mod types;
 
+pub use apply::{apply_update, ApplyResult};
 pub use checker::check_for_update;
-pub use detect::{detect_current_install_method, detect_install_method, upgrade_hint};
+pub use detect::{
+    current_target_triple, detect_current_install_method, detect_install_method, upgrade_hint,
+};
 pub use provider::{GitHubReleasesProvider, ReleaseProvider};
 pub use state::UpdateState;
 pub use types::{InstallMethod, UpdateCheckOutcome, UpdateInfo, UpdatePolicy};

--- a/crates/tsql/src/update/mod.rs
+++ b/crates/tsql/src/update/mod.rs
@@ -1,0 +1,11 @@
+pub mod checker;
+pub mod detect;
+pub mod provider;
+pub mod state;
+pub mod types;
+
+pub use checker::check_for_update;
+pub use detect::{detect_current_install_method, detect_install_method, upgrade_hint};
+pub use provider::{GitHubReleasesProvider, ReleaseProvider};
+pub use state::UpdateState;
+pub use types::{InstallMethod, UpdateCheckOutcome, UpdateInfo, UpdatePolicy};

--- a/crates/tsql/src/update/provider.rs
+++ b/crates/tsql/src/update/provider.rs
@@ -124,21 +124,15 @@ fn select_archive_asset<'a>(
     assets: &'a [GitHubAsset],
     target_triple: Option<&str>,
 ) -> Option<&'a GitHubAsset> {
-    let matches_archive = |asset: &&GitHubAsset| {
-        asset.name.ends_with(".tar.gz")
-            || asset.name.ends_with(".tgz")
-            || asset.name.ends_with(".zip")
-            || asset.name.ends_with(".tar.xz")
-    };
+    let matches_archive =
+        |asset: &GitHubAsset| asset.name.ends_with(".tar.gz") || asset.name.ends_with(".tgz");
 
     if let Some(target) = target_triple {
         assets
             .iter()
-            .filter(matches_archive)
-            .find(|asset| asset.name.contains(target))
-            .or_else(|| assets.iter().filter(matches_archive).next())
+            .find(|asset| matches_archive(asset) && asset.name.contains(target))
     } else {
-        assets.iter().filter(matches_archive).next()
+        assets.iter().find(|asset| matches_archive(asset))
     }
 }
 
@@ -210,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_select_archive_asset_falls_back_to_first_archive() {
+    fn test_select_archive_asset_returns_none_when_target_is_missing() {
         let assets = vec![
             GitHubAsset {
                 name: "README.txt".to_string(),
@@ -222,8 +216,24 @@ mod tests {
             },
         ];
 
-        let selected = select_archive_asset(&assets, Some("no-such-target"))
-            .expect("first archive should be selected");
+        let selected = select_archive_asset(&assets, Some("no-such-target"));
+        assert!(selected.is_none(), "no target match should not fall back");
+    }
+
+    #[test]
+    fn test_select_archive_asset_without_target_uses_first_supported_archive() {
+        let assets = vec![
+            GitHubAsset {
+                name: "README.txt".to_string(),
+                browser_download_url: "readme".to_string(),
+            },
+            GitHubAsset {
+                name: "tsql-x86_64-unknown-linux-gnu.tar.gz".to_string(),
+                browser_download_url: "linux".to_string(),
+            },
+        ];
+
+        let selected = select_archive_asset(&assets, None).expect("archive should be selected");
         assert_eq!(selected.browser_download_url, "linux");
     }
 }

--- a/crates/tsql/src/update/provider.rs
+++ b/crates/tsql/src/update/provider.rs
@@ -5,6 +5,7 @@ use semver::Version;
 use serde::Deserialize;
 
 use crate::config::UpdateChannel;
+use crate::update::detect::current_target_triple;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseCandidate {
@@ -67,14 +68,7 @@ impl ReleaseProvider for GitHubReleasesProvider {
                 continue;
             };
 
-            let asset_url = release
-                .assets
-                .iter()
-                .find(|asset| {
-                    asset.name.ends_with(".tar.gz")
-                        || asset.name.ends_with(".zip")
-                        || asset.name.ends_with(".tar.xz")
-                })
+            let asset_url = select_archive_asset(&release.assets, current_target_triple())
                 .map(|asset| asset.browser_download_url.clone());
 
             let checksum_url = release
@@ -126,6 +120,28 @@ fn parse_tag_version(tag: &str) -> Option<Version> {
     Version::parse(trimmed).ok()
 }
 
+fn select_archive_asset<'a>(
+    assets: &'a [GitHubAsset],
+    target_triple: Option<&str>,
+) -> Option<&'a GitHubAsset> {
+    let matches_archive = |asset: &&GitHubAsset| {
+        asset.name.ends_with(".tar.gz")
+            || asset.name.ends_with(".tgz")
+            || asset.name.ends_with(".zip")
+            || asset.name.ends_with(".tar.xz")
+    };
+
+    if let Some(target) = target_triple {
+        assets
+            .iter()
+            .filter(matches_archive)
+            .find(|asset| asset.name.contains(target))
+            .or_else(|| assets.iter().filter(matches_archive).next())
+    } else {
+        assets.iter().filter(matches_archive).next()
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct GitHubRelease {
     tag_name: String,
@@ -173,5 +189,41 @@ mod tests {
                 .contains("GitHub API returned 403 Forbidden"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn test_select_archive_asset_prefers_target_triple() {
+        let assets = vec![
+            GitHubAsset {
+                name: "tsql-x86_64-unknown-linux-gnu.tar.gz".to_string(),
+                browser_download_url: "linux".to_string(),
+            },
+            GitHubAsset {
+                name: "tsql-aarch64-apple-darwin.tar.gz".to_string(),
+                browser_download_url: "mac".to_string(),
+            },
+        ];
+
+        let selected = select_archive_asset(&assets, Some("aarch64-apple-darwin"))
+            .expect("targeted asset should be selected");
+        assert_eq!(selected.browser_download_url, "mac");
+    }
+
+    #[test]
+    fn test_select_archive_asset_falls_back_to_first_archive() {
+        let assets = vec![
+            GitHubAsset {
+                name: "README.txt".to_string(),
+                browser_download_url: "readme".to_string(),
+            },
+            GitHubAsset {
+                name: "tsql-x86_64-unknown-linux-gnu.tar.gz".to_string(),
+                browser_download_url: "linux".to_string(),
+            },
+        ];
+
+        let selected = select_archive_asset(&assets, Some("no-such-target"))
+            .expect("first archive should be selected");
+        assert_eq!(selected.browser_download_url, "linux");
     }
 }

--- a/crates/tsql/src/update/provider.rs
+++ b/crates/tsql/src/update/provider.rs
@@ -1,0 +1,177 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use semver::Version;
+use serde::Deserialize;
+
+use crate::config::UpdateChannel;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseCandidate {
+    pub version: Version,
+    pub notes_url: Option<String>,
+    pub asset_url: Option<String>,
+    pub checksum_url: Option<String>,
+}
+
+pub trait ReleaseProvider: Send + Sync {
+    fn latest(&self, channel: UpdateChannel) -> Result<Option<ReleaseCandidate>>;
+}
+
+#[derive(Debug, Clone)]
+pub struct GitHubReleasesProvider {
+    repo: String,
+}
+
+impl GitHubReleasesProvider {
+    pub fn new(repo: String) -> Self {
+        Self { repo }
+    }
+}
+
+impl ReleaseProvider for GitHubReleasesProvider {
+    fn latest(&self, channel: UpdateChannel) -> Result<Option<ReleaseCandidate>> {
+        let url = format!(
+            "https://api.github.com/repos/{}/releases?per_page=20",
+            self.repo
+        );
+
+        let agent = ureq::AgentBuilder::new()
+            .timeout_connect(Duration::from_secs(4))
+            .timeout_read(Duration::from_secs(8))
+            .timeout_write(Duration::from_secs(8))
+            .build();
+
+        let response = agent
+            .get(&url)
+            .set("User-Agent", "tsql-update-checker")
+            .set("Accept", "application/vnd.github+json")
+            .call()
+            .map_err(|error| map_fetch_error(&self.repo, error))?;
+
+        let body = response
+            .into_string()
+            .context("failed to read GitHub releases response body")?;
+        let releases: Vec<GitHubRelease> =
+            serde_json::from_str(&body).context("failed to parse GitHub releases payload")?;
+
+        for release in releases {
+            if release.draft {
+                continue;
+            }
+            if matches!(channel, UpdateChannel::Stable) && release.prerelease {
+                continue;
+            }
+
+            let Some(version) = parse_tag_version(&release.tag_name) else {
+                continue;
+            };
+
+            let asset_url = release
+                .assets
+                .iter()
+                .find(|asset| {
+                    asset.name.ends_with(".tar.gz")
+                        || asset.name.ends_with(".zip")
+                        || asset.name.ends_with(".tar.xz")
+                })
+                .map(|asset| asset.browser_download_url.clone());
+
+            let checksum_url = release
+                .assets
+                .iter()
+                .find(|asset| {
+                    let name = asset.name.to_ascii_lowercase();
+                    name.starts_with("sha256") || name.contains("checksums")
+                })
+                .map(|asset| asset.browser_download_url.clone());
+
+            return Ok(Some(ReleaseCandidate {
+                version,
+                notes_url: Some(release.html_url),
+                asset_url,
+                checksum_url,
+            }));
+        }
+
+        Ok(None)
+    }
+}
+
+fn map_fetch_error(repo: &str, error: ureq::Error) -> anyhow::Error {
+    match error {
+        ureq::Error::Status(code, response) => {
+            let status_text = response.status_text();
+            anyhow!(
+                "Update check failed: GitHub API returned {} {} for {}",
+                code,
+                status_text,
+                repo
+            )
+        }
+        ureq::Error::Transport(error) => {
+            let message = error.to_string();
+            let lower = message.to_ascii_lowercase();
+            if lower.contains("timed out") || lower.contains("timeout") {
+                anyhow!("Update check timed out for {}", repo)
+            } else {
+                anyhow!("Update check network error for {}: {}", repo, message)
+            }
+        }
+    }
+}
+
+fn parse_tag_version(tag: &str) -> Option<Version> {
+    let trimmed = tag.trim().trim_start_matches('v');
+    Version::parse(trimmed).ok()
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    html_url: String,
+    draft: bool,
+    prerelease: bool,
+    #[serde(default)]
+    assets: Vec<GitHubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_tag_version_with_v_prefix() {
+        let version = parse_tag_version("v0.4.2").expect("valid semver");
+        assert_eq!(version, Version::new(0, 4, 2));
+    }
+
+    #[test]
+    fn test_parse_tag_version_without_v_prefix() {
+        let version = parse_tag_version("1.2.3").expect("valid semver");
+        assert_eq!(version, Version::new(1, 2, 3));
+    }
+
+    #[test]
+    fn test_parse_tag_version_invalid_returns_none() {
+        assert!(parse_tag_version("release-2026").is_none());
+    }
+
+    #[test]
+    fn test_map_fetch_error_status_is_descriptive() {
+        let response = ureq::Response::new(403, "Forbidden", "").expect("valid response");
+        let error = map_fetch_error("fcoury/tsql", ureq::Error::Status(403, response));
+        assert!(
+            error
+                .to_string()
+                .contains("GitHub API returned 403 Forbidden"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/crates/tsql/src/update/state.rs
+++ b/crates/tsql/src/update/state.rs
@@ -1,0 +1,118 @@
+use std::time::{Duration, Instant};
+
+use crate::config::{UpdateMode, UpdatesConfig};
+
+use super::types::{UpdateCheckOutcome, UpdatePolicy};
+
+#[derive(Debug, Clone)]
+pub struct UpdateState {
+    pub startup_check_started: bool,
+    pub check_in_flight: bool,
+    pub last_checked_at: Option<Instant>,
+    pub last_outcome: Option<UpdateCheckOutcome>,
+}
+
+impl Default for UpdateState {
+    fn default() -> Self {
+        Self {
+            startup_check_started: false,
+            check_in_flight: false,
+            last_checked_at: None,
+            last_outcome: None,
+        }
+    }
+}
+
+impl UpdateState {
+    pub fn policy(config: &UpdatesConfig) -> UpdatePolicy {
+        if !config.enabled || matches!(config.mode, UpdateMode::Off) {
+            return UpdatePolicy::Off;
+        }
+
+        match config.mode {
+            UpdateMode::Off => UpdatePolicy::Off,
+            UpdateMode::Auto | UpdateMode::NotifyOnly => UpdatePolicy::NotifyOnly,
+        }
+    }
+
+    pub fn should_check_on_startup(&self, config: &UpdatesConfig) -> bool {
+        if self.check_in_flight || self.startup_check_started {
+            return false;
+        }
+
+        config.check_on_startup && !matches!(Self::policy(config), UpdatePolicy::Off)
+    }
+
+    pub fn should_check_by_interval(&self, config: &UpdatesConfig, now: Instant) -> bool {
+        if self.check_in_flight || matches!(Self::policy(config), UpdatePolicy::Off) {
+            return false;
+        }
+
+        let interval = Duration::from_secs(config.interval_hours.saturating_mul(3600));
+
+        match self.last_checked_at {
+            None => true,
+            Some(last_checked_at) => now.duration_since(last_checked_at) >= interval,
+        }
+    }
+
+    pub fn mark_check_started(&mut self, from_startup: bool) {
+        self.check_in_flight = true;
+        if from_startup {
+            self.startup_check_started = true;
+        }
+    }
+
+    pub fn mark_check_finished(&mut self, outcome: UpdateCheckOutcome) {
+        self.check_in_flight = false;
+        self.last_checked_at = Some(Instant::now());
+        self.last_outcome = Some(outcome);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{UpdateChannel, UpdatesConfig};
+
+    #[test]
+    fn test_policy_is_off_when_disabled() {
+        let config = UpdatesConfig {
+            enabled: false,
+            check_on_startup: true,
+            channel: UpdateChannel::Stable,
+            mode: UpdateMode::Auto,
+            interval_hours: 24,
+            github_repo: "fcoury/tsql".to_string(),
+        };
+
+        assert_eq!(UpdateState::policy(&config), UpdatePolicy::Off);
+    }
+
+    #[test]
+    fn test_should_check_on_startup_only_once() {
+        let config = UpdatesConfig::default();
+        let mut state = UpdateState::default();
+
+        assert!(state.should_check_on_startup(&config));
+        state.mark_check_started(true);
+        assert!(!state.should_check_on_startup(&config));
+    }
+
+    #[test]
+    fn test_should_check_by_interval_respects_elapsed_time() {
+        let config = UpdatesConfig::default();
+        let now = Instant::now();
+
+        let mut state = UpdateState {
+            startup_check_started: true,
+            check_in_flight: false,
+            last_checked_at: Some(now - Duration::from_secs(3600 * 25)),
+            last_outcome: None,
+        };
+        assert!(state.should_check_by_interval(&config, now));
+
+        state.last_checked_at = Some(now - Duration::from_secs(3600));
+        assert!(!state.should_check_by_interval(&config, now));
+    }
+}

--- a/crates/tsql/src/update/state.rs
+++ b/crates/tsql/src/update/state.rs
@@ -111,17 +111,23 @@ mod tests {
     fn test_should_check_by_interval_respects_elapsed_time() {
         let config = UpdatesConfig::default();
         let now = Instant::now();
+        let well_after_interval = now
+            .checked_add(Duration::from_secs(3600 * 25))
+            .expect("instant add should be representable");
+        let within_interval = now
+            .checked_add(Duration::from_secs(3600))
+            .expect("instant add should be representable");
 
         let mut state = UpdateState {
             startup_check_started: true,
             check_in_flight: false,
-            last_checked_at: Some(now - Duration::from_secs(3600 * 25)),
+            last_checked_at: Some(now),
             last_outcome: None,
         };
-        assert!(state.should_check_by_interval(&config, now));
+        assert!(state.should_check_by_interval(&config, well_after_interval));
 
-        state.last_checked_at = Some(now - Duration::from_secs(3600));
-        assert!(!state.should_check_by_interval(&config, now));
+        state.last_checked_at = Some(now);
+        assert!(!state.should_check_by_interval(&config, within_interval));
     }
 
     #[test]

--- a/crates/tsql/src/update/state.rs
+++ b/crates/tsql/src/update/state.rs
@@ -49,15 +49,26 @@ impl UpdateState {
 
         match self.last_checked_at {
             None => true,
-            Some(last_checked_at) => now.duration_since(last_checked_at) >= interval,
+            Some(last_checked_at) => now.saturating_duration_since(last_checked_at) >= interval,
         }
     }
 
     pub fn apply_allowed(config: &UpdatesConfig, install_method: InstallMethod) -> bool {
-        config.enabled
+        !cfg!(windows)
+            && config.enabled
             && matches!(config.mode, UpdateMode::Auto)
             && config.allow_apply_for_standalone
             && matches!(install_method, InstallMethod::StandaloneBinary)
+    }
+
+    pub fn mark_startup_skipped(&mut self, now: Instant) {
+        if self.startup_check_started {
+            return;
+        }
+        self.startup_check_started = true;
+        if self.last_checked_at.is_none() {
+            self.last_checked_at = Some(now);
+        }
     }
 
     pub fn mark_check_started(&mut self, from_startup: bool) {
@@ -128,12 +139,30 @@ mod tests {
     }
 
     #[test]
+    fn test_should_check_by_interval_handles_future_last_checked() {
+        let config = UpdatesConfig::default();
+        let now = Instant::now();
+        let future = now
+            .checked_add(Duration::from_secs(3600))
+            .expect("instant add should be representable");
+        let state = UpdateState {
+            startup_check_started: true,
+            check_in_flight: false,
+            last_checked_at: Some(future),
+            last_outcome: None,
+        };
+
+        assert!(!state.should_check_by_interval(&config, now));
+    }
+
+    #[test]
     fn test_apply_allowed_only_for_auto_mode_standalone() {
         let config = UpdatesConfig::default();
-        assert!(UpdateState::apply_allowed(
-            &config,
-            InstallMethod::StandaloneBinary
-        ));
+        let expected = !cfg!(windows);
+        assert_eq!(
+            UpdateState::apply_allowed(&config, InstallMethod::StandaloneBinary),
+            expected
+        );
         assert!(!UpdateState::apply_allowed(
             &config,
             InstallMethod::Homebrew

--- a/crates/tsql/src/update/state.rs
+++ b/crates/tsql/src/update/state.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::config::{UpdateMode, UpdatesConfig};
 
-use super::types::{UpdateCheckOutcome, UpdatePolicy};
+use super::types::{InstallMethod, UpdateCheckOutcome, UpdatePolicy};
 
 #[derive(Debug, Clone)]
 pub struct UpdateState {
@@ -56,6 +56,13 @@ impl UpdateState {
         }
     }
 
+    pub fn apply_allowed(config: &UpdatesConfig, install_method: InstallMethod) -> bool {
+        config.enabled
+            && matches!(config.mode, UpdateMode::Auto)
+            && config.allow_apply_for_standalone
+            && matches!(install_method, InstallMethod::StandaloneBinary)
+    }
+
     pub fn mark_check_started(&mut self, from_startup: bool) {
         self.check_in_flight = true;
         if from_startup {
@@ -83,6 +90,7 @@ mod tests {
             channel: UpdateChannel::Stable,
             mode: UpdateMode::Auto,
             interval_hours: 24,
+            allow_apply_for_standalone: true,
             github_repo: "fcoury/tsql".to_string(),
         };
 
@@ -114,5 +122,18 @@ mod tests {
 
         state.last_checked_at = Some(now - Duration::from_secs(3600));
         assert!(!state.should_check_by_interval(&config, now));
+    }
+
+    #[test]
+    fn test_apply_allowed_only_for_auto_mode_standalone() {
+        let config = UpdatesConfig::default();
+        assert!(UpdateState::apply_allowed(
+            &config,
+            InstallMethod::StandaloneBinary
+        ));
+        assert!(!UpdateState::apply_allowed(
+            &config,
+            InstallMethod::Homebrew
+        ));
     }
 }

--- a/crates/tsql/src/update/state.rs
+++ b/crates/tsql/src/update/state.rs
@@ -29,10 +29,7 @@ impl UpdateState {
             return UpdatePolicy::Off;
         }
 
-        match config.mode {
-            UpdateMode::Off => UpdatePolicy::Off,
-            UpdateMode::Auto | UpdateMode::NotifyOnly => UpdatePolicy::NotifyOnly,
-        }
+        UpdatePolicy::NotifyOnly
     }
 
     pub fn should_check_on_startup(&self, config: &UpdatesConfig) -> bool {

--- a/crates/tsql/src/update/types.rs
+++ b/crates/tsql/src/update/types.rs
@@ -1,0 +1,34 @@
+use semver::Version;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallMethod {
+    Homebrew,
+    CargoInstall,
+    SystemPackage,
+    StandaloneBinary,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdatePolicy {
+    Off,
+    NotifyOnly,
+    ApplyAllowed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateInfo {
+    pub current: Version,
+    pub latest: Version,
+    pub notes_url: Option<String>,
+    pub asset_url: Option<String>,
+    pub checksum_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateCheckOutcome {
+    UpToDate { current: Version },
+    UpdateAvailable(UpdateInfo),
+    Error(String),
+    Disabled,
+}

--- a/crates/tsql/src/update/types.rs
+++ b/crates/tsql/src/update/types.rs
@@ -13,7 +13,6 @@ pub enum InstallMethod {
 pub enum UpdatePolicy {
     Off,
     NotifyOnly,
-    ApplyAllowed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -95,6 +95,15 @@ For each platform in the matrix:
 - Creates a GitHub Release with auto-generated notes
 - Uploads all binaries and checksums
 
+### Update Check Compatibility
+
+`tsql`'s in-app update checks read GitHub releases from `fcoury/tsql`.
+To keep update notifications working:
+
+- Use semver tags (for example `v0.4.3`)
+- Keep release artifacts attached (`.tar.gz` / `.zip`)
+- Keep `SHA256SUMS.txt` uploaded with each release
+
 ### Publish Job
 
 - Publishes `tui-syntax` to crates.io


### PR DESCRIPTION
## Summary

Implements Phase 2 of the auto-update work for `tsql` by adding an
in-app apply flow for standalone binary installs.

From a user perspective:
- You can run `:update apply` when an update is available.
- `tsql` asks for confirmation before applying.
- If apply succeeds, `tsql` reports the version transition.
- If apply fails, `tsql` reports an actionable error.

## What changed

- Added `:update apply` command handling and confirmation flow in the TUI.
- Added update apply state/event plumbing in the app loop.
- Added standalone update application engine:
  - download release archive
  - download checksum file
  - verify SHA256
  - extract `tsql` binary from `.tar.gz`
  - replace current executable with rollback on copy failure
- Added install-method and policy gates so apply is only allowed for
  standalone installs in `updates.mode = "auto"`.
- Added new config flag: `updates.allow_apply_for_standalone`.
- Updated docs/help text (`README.md`, `config.example.toml`, command help).

## Safety and scope

- In-app apply remains blocked for package-manager installs.
- In-app apply remains unsupported on Windows for now.

## Tests

- Added unit tests for checksum/filename parsing.
- Added mocked filesystem tests for executable replacement and rollback.
- Added app-level tests around `:update apply` command gating and prompts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app update checks with status reporting and interactive apply flow.
  * New :update command (check | status | apply); help lists the command.

* **Configuration**
  * New [updates] settings (enabled, check_on_startup, channel, mode, interval_hours, allow_apply_for_standalone, github_repo).
  * :update apply only allowed for standalone installs when mode is "auto"; apply disabled on unsupported OS.

* **Documentation**
  * Added release/update requirements and usage notes.

* **Reliability**
  * Apply process includes backup and rollback on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->