### PR TITLE
feat: add mongodb support and active-db status fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,12 +135,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+dependencies = [
+ "ahash",
+ "base64",
+ "bitvec",
+ "getrandom 0.2.16",
+ "getrandom 0.3.4",
+ "hex",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -246,6 +294,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +365,36 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -336,8 +443,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -355,15 +472,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -395,6 +543,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -468,6 +661,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -593,6 +798,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +852,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +883,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -696,8 +919,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -707,9 +932,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -745,6 +972,58 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "ring",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hmac"
@@ -926,12 +1205,30 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2 0.5.10",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itertools"
@@ -1059,6 +1356,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_magic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
+dependencies = [
+ "macro_magic_core",
+ "macro_magic_macros",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
+dependencies = [
+ "const-random",
+ "derive-syn-parse",
+ "macro_magic_core_macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_core_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
+dependencies = [
+ "macro_magic_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1439,99 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "mongocrypt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da0cd419a51a5fb44819e290fbdb0665a54f21dead8923446a799c7f4d26ad9"
+dependencies = [
+ "bson",
+ "mongocrypt-sys",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "mongocrypt-sys"
+version = "0.1.5+1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
+
+[[package]]
+name = "mongodb"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803dd859e8afa084c255a8effd8000ff86f7c8076a50cd6d8c99e8f3496f75c2"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bson",
+ "derive-where",
+ "derive_more",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hickory-proto",
+ "hickory-resolver",
+ "hmac",
+ "macro_magic",
+ "md-5",
+ "mongocrypt",
+ "mongodb-internal-macros",
+ "pbkdf2",
+ "percent-encoding",
+ "rand",
+ "rustc_version_runtime",
+ "rustls",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "sha1",
+ "sha2",
+ "socket2 0.6.1",
+ "stringprep",
+ "strsim",
+ "take_mut",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "typed-builder",
+ "uuid",
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "mongodb-internal-macros"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973ef3dd3dbc6f6e65bbdecfd9ec5e781b9e7493b0f369a7c62e35d8e5ae2c8"
+dependencies = [
+ "macro_magic",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1218,6 +1656,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "option-ext"
@@ -1253,6 +1695,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1303,6 +1754,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-protocol"
@@ -1395,6 +1852,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1506,6 +1969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1986,25 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
 ]
 
 [[package]]
@@ -1682,6 +2170,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +2205,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -1721,6 +2220,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+dependencies = [
+ "serde_core",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1746,6 +2267,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1818,6 +2350,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -1936,6 +2478,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,12 +2578,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2031,6 +2593,25 @@ name = "time-core"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinystr"
@@ -2088,7 +2669,8 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "signal-hook-registry",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2124,7 +2706,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand",
- "socket2",
+ "socket2 0.6.1",
  "tokio",
  "tokio-util",
  "whoami",
@@ -2174,6 +2756,7 @@ checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -2235,6 +2818,9 @@ name = "tracing-core"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "tree-sitter"
@@ -2309,7 +2895,9 @@ dependencies = [
  "dirs",
  "dotenvy",
  "flate2",
+ "futures-util",
  "keyring",
+ "mongodb",
  "nucleo-matcher",
  "percent-encoding",
  "ratatui",
@@ -2386,6 +2974,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,6 +3056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,6 +3111,7 @@ checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2616,6 +3231,12 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -2939,6 +3560,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,6 +3580,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x11rb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ ureq = { version = "2", features = ["json"] }
 sha2 = "0.10"
 flate2 = "1"
 tar = "0.4"
+futures-util = "0.3"
+mongodb = "3"
 
 # Secure password storage
 # Must enable platform-specific features for actual keychain storage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tsql
 
-A modern, keyboard-first PostgreSQL CLI with a TUI interface.
+A modern, keyboard-first PostgreSQL and MongoDB CLI with a TUI interface.
 
 [![CI](https://github.com/fcoury/tsql/actions/workflows/ci.yml/badge.svg)](https://github.com/fcoury/tsql/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/tsql.svg)](https://crates.io/crates/tsql)
@@ -22,7 +22,8 @@ If you like this crate show some support by [following fcoury (me) on X](https:/
 - **Results grid** - Scrollable, searchable data grid with column resizing, multi-row selection, and flexible yank (TSV/CSV/JSON/Markdown)
 - **Inline editing** - Edit cells directly in the grid with automatic SQL generation
 - **JSON support** - Detect, format, and edit JSON/JSONB columns with syntax highlighting
-- **psql compatibility** - Familiar commands like `\dt`, `\d`, `\dn`, `\l`, and more
+- **Postgres + MongoDB** - Connect with `postgres://...` or `mongodb://...` URLs
+- **Schema commands** - `psql`-style commands plus Mongo helpers (`:show dbs`, `:show collections`, `:describe`)
 - **Query history** - Persistent history with fuzzy search, pinning, and deletion
 - **External editor** - Open the current query in `$VISUAL` / `$EDITOR` with `vv`
 - **1Password integration** - Store an `op://` secret reference per connection instead of a plain password
@@ -53,6 +54,7 @@ Download pre-built binaries from the [GitHub Releases](https://github.com/fcoury
 ```bash
 # Connect with a connection URL
 tsql postgres://user:password@localhost:5432/mydb
+tsql mongodb://user:password@localhost:27017/mydb
 
 # Or set DATABASE_URL environment variable
 export DATABASE_URL=postgres://user:password@localhost:5432/mydb
@@ -178,6 +180,10 @@ tsql --debug-keys --mouse
 | `:\di`                          | List indexes        |
 | `:\l`                           | List databases      |
 | `:\du`                          | List roles          |
+| `:show dbs`                     | Mongo: list databases |
+| `:show collections`             | Mongo: list collections |
+| `:describe <collection>`        | Mongo: describe collection |
+| `:use <database>`               | Mongo: switch database |
 
 `:update apply` is only available in `updates.mode = "auto"` and only for
 standalone binary installs.
@@ -225,7 +231,7 @@ session (for example via `op signin`).
 
 ## Requirements
 
-- PostgreSQL 12 or later
+- PostgreSQL 12 or later, or MongoDB 6.0+
 - Terminal with 256-color support recommended
 
 ## Contributing

--- a/config.example.toml
+++ b/config.example.toml
@@ -75,6 +75,7 @@ persist_session = true
 [connection]
 # Default database URL (can be overridden by DATABASE_URL env var or CLI arg)
 # default_url = "postgres://user:password@localhost:5432/database"
+# default_url = "mongodb://user:password@localhost:27017/database"
 
 # Connection timeout in seconds
 connect_timeout_secs = 10

--- a/crates/tsql/Cargo.toml
+++ b/crates/tsql/Cargo.toml
@@ -40,6 +40,8 @@ ureq.workspace = true
 sha2.workspace = true
 flate2.workspace = true
 tar.workspace = true
+futures-util.workspace = true
+mongodb.workspace = true
 
 # Secure password storage
 keyring.workspace = true

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -576,6 +576,11 @@ impl PagedQueryState {
 
 /// Default page size for cursor-based queries.
 const DEFAULT_PAGE_SIZE: usize = 500;
+const REGULAR_QUERY_HEIGHT: u16 = 7;
+const STATUS_HEIGHT: u16 = 1;
+const MIN_GRID_HEIGHT: u16 = 3;
+const QUERY_BORDER_ROWS: u16 = 2;
+const QUERY_EXPANDED_MAX_RATIO_DENOM: u16 = 2; // 50%
 
 /// Check if a query is suitable for cursor-based paging.
 ///
@@ -594,6 +599,46 @@ fn is_pageable_query(query: &str) -> bool {
         return false; // Multiple statements
     }
     extract_table_from_query(query).is_some()
+}
+
+fn compute_query_panel_height(
+    main_height: u16,
+    mode: Mode,
+    non_insert_mode: QueryHeightMode,
+    editor_line_count: usize,
+) -> u16 {
+    let available_for_query = main_height.saturating_sub(STATUS_HEIGHT);
+    if available_for_query == 0 {
+        return 0;
+    }
+
+    // Preserve space for the status line and (when possible) a minimal grid.
+    let layout_safe_max = {
+        let max_with_min_grid = main_height.saturating_sub(STATUS_HEIGHT + MIN_GRID_HEIGHT);
+        if max_with_min_grid > 0 {
+            max_with_min_grid
+        } else {
+            available_for_query
+        }
+    };
+
+    let regular_height = REGULAR_QUERY_HEIGHT.min(layout_safe_max);
+
+    let ratio_cap = (main_height / QUERY_EXPANDED_MAX_RATIO_DENOM)
+        .max(1)
+        .min(layout_safe_max);
+    let maximized_height = ratio_cap.max(regular_height);
+
+    if mode == Mode::Insert {
+        let desired_content_height = (editor_line_count as u16).saturating_add(QUERY_BORDER_ROWS);
+        let desired_height = desired_content_height.max(regular_height);
+        return desired_height.min(maximized_height);
+    }
+
+    match non_insert_mode {
+        QueryHeightMode::Minimized => regular_height,
+        QueryHeightMode::Maximized => maximized_height,
+    }
 }
 
 /// Extract the table name from a simple SELECT query.
@@ -1748,6 +1793,8 @@ pub struct App {
     update_state: UpdateState,
     /// True while an update apply flow is running in the background.
     update_apply_in_flight: bool,
+    /// Query pane size mode used outside Insert mode.
+    query_height_mode: QueryHeightMode,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1762,6 +1809,12 @@ struct GridCellClick {
 enum CachedCursorStyle {
     BlinkingBar,
     SteadyBlock,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum QueryHeightMode {
+    Minimized,
+    Maximized,
 }
 
 /// Groups spinner and timing state for query execution UI.
@@ -1906,6 +1959,7 @@ impl App {
             query_ui: QueryRunUi::default(),
             update_state: UpdateState::default(),
             update_apply_in_flight: false,
+            query_height_mode: QueryHeightMode::Minimized,
         };
 
         // Load saved connections
@@ -2140,12 +2194,19 @@ impl App {
                     self.render_sidebar_area = None;
                 }
 
+                let query_height = compute_query_panel_height(
+                    main_area.height,
+                    self.mode,
+                    self.query_height_mode,
+                    self.editor.textarea.lines().len(),
+                );
+
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
-                        Constraint::Length(7),
-                        Constraint::Min(3),
-                        Constraint::Length(1),
+                        Constraint::Length(query_height),
+                        Constraint::Min(MIN_GRID_HEIGHT),
+                        Constraint::Length(STATUS_HEIGHT),
                     ])
                     .split(main_area);
 
@@ -2962,6 +3023,17 @@ impl App {
         if key.code == KeyCode::Char('e') && key.modifiers == KeyModifiers::CONTROL {
             self.execute_query();
             return false;
+        }
+
+        // Query pane height toggle (non-insert modes, independent of focus).
+        if self.mode != Mode::Insert {
+            let toggle_key = self.editor_normal_keymap.get_action(&key)
+                == Some(Action::ToggleQueryHeight)
+                || self.grid_keymap.get_action(&key) == Some(Action::ToggleQueryHeight);
+            if toggle_key {
+                self.toggle_query_height_mode();
+                return false;
+            }
         }
 
         if self.search.active {
@@ -3826,6 +3898,18 @@ impl App {
         } else {
             self.focus_schema();
         }
+    }
+
+    fn toggle_query_height_mode(&mut self) {
+        self.query_height_mode = match self.query_height_mode {
+            QueryHeightMode::Minimized => QueryHeightMode::Maximized,
+            QueryHeightMode::Maximized => QueryHeightMode::Minimized,
+        };
+        let label = match self.query_height_mode {
+            QueryHeightMode::Minimized => "minimized",
+            QueryHeightMode::Maximized => "maximized",
+        };
+        self.last_status = Some(format!("Query pane {label}"));
     }
 
     /// Focus on the Schema section of the sidebar, ensuring first item is selected
@@ -5410,7 +5494,7 @@ impl App {
                         command_tag: Some(format!("describe {}", collection_name)),
                         truncated: false,
                         elapsed: started.elapsed(),
-                        source_table: Some(collection_name),
+                        source_table: None,
                         primary_keys: Vec::new(),
                         col_types: vec!["string".to_string(), "string".to_string()],
                     };
@@ -5598,6 +5682,7 @@ impl App {
 
         if self.db.kind == Some(DbKind::Mongo) {
             let mut commands = Vec::new();
+            let mut skipped_empty_updates = 0usize;
             for row_idx in &row_indices {
                 let Some(row_values) = self.grid.rows.get(*row_idx) else {
                     continue;
@@ -5646,12 +5731,22 @@ impl App {
                                 set_obj.insert(k.clone(), v.clone());
                             }
                         }
-                        serde_json::json!({
-                            "op": "updateOne",
-                            "collection": table.clone(),
-                            "filter": serde_json::Value::Object(filter.clone()),
-                            "update": { "$set": serde_json::Value::Object(set_obj) }
-                        })
+                        if set_obj.is_empty() {
+                            skipped_empty_updates += 1;
+                            serde_json::json!({
+                                "_comment": format!(
+                                    "Skipped row {}: no non-key fields left for $set (all fields are key columns).",
+                                    row_idx + 1
+                                )
+                            })
+                        } else {
+                            serde_json::json!({
+                                "op": "updateOne",
+                                "collection": table.clone(),
+                                "filter": serde_json::Value::Object(filter.clone()),
+                                "update": { "$set": serde_json::Value::Object(set_obj) }
+                            })
+                        }
                     }
                     "delete" | "d" => serde_json::json!({
                         "op": "deleteOne",
@@ -5686,9 +5781,18 @@ impl App {
             self.focus = Focus::Query;
             self.mode = Mode::Normal;
             self.last_status = Some(format!(
-                "Generated {} Mongo command statement{}",
+                "Generated {} Mongo command statement{}{}",
                 row_indices.len(),
-                if row_indices.len() == 1 { "" } else { "s" }
+                if row_indices.len() == 1 { "" } else { "s" },
+                if skipped_empty_updates > 0 {
+                    format!(
+                        " ({} skipped update row{} with no non-key fields)",
+                        skipped_empty_updates,
+                        if skipped_empty_updates == 1 { "" } else { "s" }
+                    )
+                } else {
+                    String::new()
+                }
             ));
             return;
         }
@@ -9207,6 +9311,11 @@ fn calculate_editor_scroll(
         if cursor_row < scroll_row {
             scroll_row = cursor_row;
         }
+        // If viewport got taller, reveal as many lines above the cursor as possible.
+        let max_top_for_cursor = cursor_row.saturating_sub(viewport_height - 1);
+        if scroll_row > max_top_for_cursor {
+            scroll_row = max_top_for_cursor;
+        }
         // If cursor is below the viewport, scroll down
         let viewport_bottom = scroll_row + viewport_height;
         if cursor_row >= viewport_bottom {
@@ -9571,6 +9680,85 @@ mod tests {
         assert!(!app.update_state.check_in_flight);
         assert!(app.update_state.startup_check_started);
         assert!(app.update_state.last_checked_at.is_some());
+    }
+
+    #[test]
+    fn test_compute_query_panel_height_non_insert_mode_respects_min_and_max() {
+        let height = compute_query_panel_height(40, Mode::Normal, QueryHeightMode::Minimized, 100);
+        assert_eq!(height, REGULAR_QUERY_HEIGHT);
+
+        let height = compute_query_panel_height(40, Mode::Normal, QueryHeightMode::Maximized, 100);
+        assert_eq!(height, 20);
+    }
+
+    #[test]
+    fn test_compute_query_panel_height_expands_by_content_in_insert_mode() {
+        // Low content keeps regular height.
+        let low_content =
+            compute_query_panel_height(40, Mode::Insert, QueryHeightMode::Minimized, 2);
+        assert_eq!(low_content, REGULAR_QUERY_HEIGHT);
+
+        // High content expands, capped at 50% of main area.
+        let high_content =
+            compute_query_panel_height(40, Mode::Insert, QueryHeightMode::Minimized, 50);
+        assert_eq!(high_content, 20);
+    }
+
+    #[test]
+    fn test_compute_query_panel_height_respects_layout_safety_cap() {
+        // main_height=6 leaves 5 rows after status line.
+        // With min grid reservation (3), query max should be 2.
+        let height = compute_query_panel_height(6, Mode::Insert, QueryHeightMode::Minimized, 50);
+        assert_eq!(height, 2);
+    }
+
+    #[test]
+    fn test_calculate_editor_scroll_reveals_more_above_cursor_when_viewport_expands() {
+        // Cursor remained visible in the old viewport with scroll_row=8.
+        // With a taller viewport (height=6), we should scroll up to show more
+        // lines above the cursor while keeping it visible.
+        let scroll = calculate_editor_scroll(10, 0, (8, 0), 6, 80);
+        assert_eq!(scroll.0, 5);
+    }
+
+    #[test]
+    fn test_alt_m_toggles_query_height_mode_outside_insert_independent_of_focus() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+        app.connection_picker = None;
+        app.connection_manager = None;
+        app.focus = Focus::Sidebar(SidebarSection::Schema);
+        app.mode = Mode::Normal;
+        app.query_height_mode = QueryHeightMode::Minimized;
+
+        app.on_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::ALT));
+        assert_eq!(app.query_height_mode, QueryHeightMode::Maximized);
+
+        app.on_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::ALT));
+        assert_eq!(app.query_height_mode, QueryHeightMode::Minimized);
+    }
+
+    #[test]
+    fn test_alt_m_does_not_toggle_in_insert_mode() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+        app.connection_picker = None;
+        app.connection_manager = None;
+        app.mode = Mode::Insert;
+        app.query_height_mode = QueryHeightMode::Minimized;
+
+        app.on_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::ALT));
+        assert_eq!(app.query_height_mode, QueryHeightMode::Minimized);
     }
 
     // ========== CellEditor Tests ==========

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -1332,7 +1332,7 @@ fn mongo_result_from_documents(
             command_tag: Some("0 rows".to_string()),
             truncated,
             elapsed,
-            source_table,
+            source_table: None,
             primary_keys: Vec::new(),
             col_types: vec!["string".to_string()],
         };
@@ -5772,8 +5772,16 @@ impl App {
             let generated = commands
                 .into_iter()
                 .map(|c| serde_json::to_string_pretty(&c).unwrap_or_else(|_| c.to_string()))
-                .collect::<Vec<_>>()
-                .join("\n\n");
+                .collect::<Vec<_>>();
+
+            if generated.len() != 1 {
+                self.last_error = Some(
+                    "Mongo :gen currently produces one executable command at a time. Select a single row."
+                        .to_string(),
+                );
+                return;
+            }
+            let generated = generated.into_iter().next().unwrap_or_default();
 
             self.editor.textarea.select_all();
             self.editor.textarea.cut();
@@ -6484,6 +6492,10 @@ impl App {
                         }
                         Action::ToggleSidebar => {
                             self.toggle_sidebar();
+                            return;
+                        }
+                        Action::ToggleQueryHeight => {
+                            self.toggle_query_height_mode();
                             return;
                         }
                         _ => {}

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -5733,20 +5733,14 @@ impl App {
                         }
                         if set_obj.is_empty() {
                             skipped_empty_updates += 1;
-                            serde_json::json!({
-                                "_comment": format!(
-                                    "Skipped row {}: no non-key fields left for $set (all fields are key columns).",
-                                    row_idx + 1
-                                )
-                            })
-                        } else {
-                            serde_json::json!({
-                                "op": "updateOne",
-                                "collection": table.clone(),
-                                "filter": serde_json::Value::Object(filter.clone()),
-                                "update": { "$set": serde_json::Value::Object(set_obj) }
-                            })
+                            continue;
                         }
+                        serde_json::json!({
+                            "op": "updateOne",
+                            "collection": table.clone(),
+                            "filter": serde_json::Value::Object(filter.clone()),
+                            "update": { "$set": serde_json::Value::Object(set_obj) }
+                        })
                     }
                     "delete" | "d" => serde_json::json!({
                         "op": "deleteOne",
@@ -5767,6 +5761,14 @@ impl App {
                     }
                 };
                 commands.push(command);
+            }
+
+            if commands.is_empty() {
+                self.last_error = Some(
+                    "No executable commands generated: all selected rows have only key fields."
+                        .to_string(),
+                );
+                return;
             }
 
             let generated = commands
@@ -9756,7 +9758,7 @@ mod tests {
     }
 
     #[test]
-    fn test_alt_m_does_not_toggle_in_insert_mode() {
+    fn test_alt_m_toggles_in_insert_mode() {
         let (tx, rx) = mpsc::unbounded_channel();
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -9770,7 +9772,7 @@ mod tests {
         app.query_height_mode = QueryHeightMode::Minimized;
 
         app.on_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::ALT));
-        assert_eq!(app.query_height_mode, QueryHeightMode::Minimized);
+        assert_eq!(app.query_height_mode, QueryHeightMode::Maximized);
     }
 
     // ========== CellEditor Tests ==========

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -804,7 +804,74 @@ fn bson_to_grid_cell(value: &Bson) -> String {
     }
 }
 
-fn parse_grid_cell_to_bson(value: &str) -> Bson {
+fn parse_grid_cell_to_bson(value: &str, type_hint: Option<&str>, conservative: bool) -> Bson {
+    let normalized_hint = type_hint
+        .map(|s| s.trim().to_ascii_lowercase())
+        .unwrap_or_default();
+    if conservative {
+        match normalized_hint.as_str() {
+            "string" | "symbol" | "javascript" | "javascript-with-scope" => {
+                return Bson::String(value.to_string());
+            }
+            "objectid" => {
+                let trimmed = value.trim();
+                if trimmed.len() == 24 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+                    if let Ok(oid) = ObjectId::parse_str(trimmed) {
+                        return Bson::ObjectId(oid);
+                    }
+                }
+                return Bson::String(value.to_string());
+            }
+            "bool" | "boolean" => {
+                if value.trim().eq_ignore_ascii_case("true") {
+                    return Bson::Boolean(true);
+                }
+                if value.trim().eq_ignore_ascii_case("false") {
+                    return Bson::Boolean(false);
+                }
+                return Bson::String(value.to_string());
+            }
+            "int32" => {
+                if let Ok(v) = value.trim().parse::<i32>() {
+                    return Bson::Int32(v);
+                }
+                return Bson::String(value.to_string());
+            }
+            "int64" => {
+                if let Ok(v) = value.trim().parse::<i64>() {
+                    return Bson::Int64(v);
+                }
+                return Bson::String(value.to_string());
+            }
+            "double" | "decimal128" => {
+                if let Ok(v) = value.trim().parse::<f64>() {
+                    return Bson::Double(v);
+                }
+                return Bson::String(value.to_string());
+            }
+            "null" => {
+                if value.trim().eq_ignore_ascii_case("null") {
+                    return Bson::Null;
+                }
+                return Bson::String(value.to_string());
+            }
+            "array" | "object" => {
+                let trimmed = value.trim();
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                    if let Ok(b) = bson::to_bson(&json) {
+                        return b;
+                    }
+                }
+                return Bson::String(value.to_string());
+            }
+            _ => {
+                if !normalized_hint.is_empty() {
+                    return Bson::String(value.to_string());
+                }
+            }
+        }
+    }
+
     let trimmed = value.trim();
     if trimmed.eq_ignore_ascii_case("null") || trimmed.eq_ignore_ascii_case("NULL") {
         return Bson::Null;
@@ -885,23 +952,6 @@ enum MongoQuery {
         collection: String,
         filter: Document,
     },
-}
-
-impl MongoQuery {
-    fn collection_name(&self) -> &str {
-        match self {
-            MongoQuery::Find { collection, .. }
-            | MongoQuery::FindOne { collection, .. }
-            | MongoQuery::Aggregate { collection, .. }
-            | MongoQuery::CountDocuments { collection, .. }
-            | MongoQuery::InsertOne { collection, .. }
-            | MongoQuery::InsertMany { collection, .. }
-            | MongoQuery::UpdateOne { collection, .. }
-            | MongoQuery::UpdateMany { collection, .. }
-            | MongoQuery::DeleteOne { collection, .. }
-            | MongoQuery::DeleteMany { collection, .. } => collection,
-        }
-    }
 }
 
 fn json_value_to_document(value: &serde_json::Value) -> std::result::Result<Document, String> {
@@ -1308,6 +1358,7 @@ pub enum DbEvent {
     QueryCancelled,
     SchemaLoaded {
         tables: Vec<TableInfo>,
+        source_database: Option<String>,
     },
     /// A cell was successfully updated.
     CellUpdated {
@@ -4308,7 +4359,15 @@ impl App {
         };
 
         let mut set_doc = Document::new();
-        set_doc.insert(field_name, parse_grid_cell_to_bson(&new_value));
+        let field_type_hint = self
+            .grid
+            .col_types
+            .get(col)
+            .and_then(|t| (!t.is_empty()).then_some(t.as_str()));
+        set_doc.insert(
+            field_name,
+            parse_grid_cell_to_bson(&new_value, field_type_hint, true),
+        );
         let mut update = Document::new();
         update.insert("$set", Bson::Document(set_doc));
 
@@ -4330,7 +4389,12 @@ impl App {
         if let Some(id_idx) = self.grid.headers.iter().position(|h| h == "_id") {
             if let Some(id_value) = row_values.get(id_idx) {
                 let mut filter = Document::new();
-                filter.insert("_id", parse_grid_cell_to_bson(id_value));
+                let id_type_hint = self
+                    .grid
+                    .col_types
+                    .get(id_idx)
+                    .and_then(|t| (!t.is_empty()).then_some(t.as_str()));
+                filter.insert("_id", parse_grid_cell_to_bson(id_value, id_type_hint, true));
                 return Ok(filter);
             }
         }
@@ -4343,7 +4407,15 @@ impl App {
                     value = original;
                 }
             }
-            filter.insert(header.clone(), parse_grid_cell_to_bson(value));
+            let type_hint = self
+                .grid
+                .col_types
+                .get(idx)
+                .and_then(|t| (!t.is_empty()).then_some(t.as_str()));
+            filter.insert(
+                header.clone(),
+                parse_grid_cell_to_bson(value, type_hint, true),
+            );
         }
 
         Ok(filter)
@@ -5519,7 +5591,12 @@ impl App {
                 let mut full_doc = serde_json::Map::new();
                 for (i, header) in self.grid.headers.iter().enumerate() {
                     let cell = row_values.get(i).cloned().unwrap_or_default();
-                    let bson_value = parse_grid_cell_to_bson(&cell);
+                    let type_hint = self
+                        .grid
+                        .col_types
+                        .get(i)
+                        .and_then(|t| (!t.is_empty()).then_some(t.as_str()));
+                    let bson_value = parse_grid_cell_to_bson(&cell, type_hint, true);
                     let json_value = bson::from_bson::<serde_json::Value>(bson_value.clone())
                         .unwrap_or_else(|_| {
                             serde_json::Value::String(bson_to_grid_cell(&bson_value))
@@ -7348,7 +7425,10 @@ impl App {
                         });
                     }
 
-                    let _ = tx.send(DbEvent::SchemaLoaded { tables });
+                    let _ = tx.send(DbEvent::SchemaLoaded {
+                        tables,
+                        source_database: None,
+                    });
                 }
                 Err(_) => {
                     // Schema loading failed silently - not critical
@@ -7393,7 +7473,10 @@ impl App {
                             columns,
                         });
                     }
-                    let _ = tx.send(DbEvent::SchemaLoaded { tables });
+                    let _ = tx.send(DbEvent::SchemaLoaded {
+                        tables,
+                        source_database: Some(db_name.clone()),
+                    });
                 }
                 Err(e) => {
                     let _ = tx.send(DbEvent::QueryError {
@@ -8011,7 +8094,6 @@ impl App {
                 }
             };
 
-            let source_collection = parsed.collection_name().to_string();
             let db = client.database(&db_name);
 
             let result = match parsed {
@@ -8033,12 +8115,23 @@ impl App {
                         Ok(mut cursor) => {
                             let mut docs = Vec::new();
                             let mut truncated = false;
-                            while let Ok(Some(doc)) = cursor.try_next().await {
-                                if docs.len() >= max_rows {
-                                    truncated = true;
-                                    break;
+                            loop {
+                                match cursor.try_next().await {
+                                    Ok(Some(doc)) => {
+                                        if docs.len() >= max_rows {
+                                            truncated = true;
+                                            break;
+                                        }
+                                        docs.push(doc);
+                                    }
+                                    Ok(None) => break,
+                                    Err(e) => {
+                                        let _ = tx.send(DbEvent::QueryError {
+                                            error: format!("Mongo find cursor error: {e}"),
+                                        });
+                                        return;
+                                    }
                                 }
-                                docs.push(doc);
                             }
                             mongo_result_from_documents(
                                 docs,
@@ -8089,12 +8182,23 @@ impl App {
                         Ok(mut cursor) => {
                             let mut docs = Vec::new();
                             let mut truncated = false;
-                            while let Ok(Some(doc)) = cursor.try_next().await {
-                                if docs.len() >= max_rows {
-                                    truncated = true;
-                                    break;
+                            loop {
+                                match cursor.try_next().await {
+                                    Ok(Some(doc)) => {
+                                        if docs.len() >= max_rows {
+                                            truncated = true;
+                                            break;
+                                        }
+                                        docs.push(doc);
+                                    }
+                                    Ok(None) => break,
+                                    Err(e) => {
+                                        let _ = tx.send(DbEvent::QueryError {
+                                            error: format!("Mongo aggregate cursor error: {e}"),
+                                        });
+                                        return;
+                                    }
                                 }
-                                docs.push(doc);
                             }
                             mongo_result_from_documents(
                                 docs,
@@ -8120,7 +8224,7 @@ impl App {
                             command_tag: Some("countDocuments".to_string()),
                             truncated: false,
                             elapsed: started.elapsed(),
-                            source_table: Some(collection),
+                            source_table: None,
                             primary_keys: Vec::new(),
                             col_types: vec!["int64".to_string()],
                         },
@@ -8146,7 +8250,7 @@ impl App {
                                 command_tag: Some("insertOne".to_string()),
                                 truncated: false,
                                 elapsed: started.elapsed(),
-                                source_table: Some(collection),
+                                source_table: None,
                                 primary_keys: Vec::new(),
                                 col_types: vec!["string".to_string(), "objectId".to_string()],
                             }
@@ -8174,7 +8278,7 @@ impl App {
                             command_tag: Some("insertMany".to_string()),
                             truncated: false,
                             elapsed: started.elapsed(),
-                            source_table: Some(collection),
+                            source_table: None,
                             primary_keys: Vec::new(),
                             col_types: vec!["string".to_string(), "int64".to_string()],
                         },
@@ -8207,7 +8311,7 @@ impl App {
                             command_tag: Some("updateOne".to_string()),
                             truncated: false,
                             elapsed: started.elapsed(),
-                            source_table: Some(collection),
+                            source_table: None,
                             primary_keys: Vec::new(),
                             col_types: vec![
                                 "string".to_string(),
@@ -8244,7 +8348,7 @@ impl App {
                             command_tag: Some("updateMany".to_string()),
                             truncated: false,
                             elapsed: started.elapsed(),
-                            source_table: Some(collection),
+                            source_table: None,
                             primary_keys: Vec::new(),
                             col_types: vec![
                                 "string".to_string(),
@@ -8272,7 +8376,7 @@ impl App {
                             command_tag: Some("deleteOne".to_string()),
                             truncated: false,
                             elapsed: started.elapsed(),
-                            source_table: Some(collection),
+                            source_table: None,
                             primary_keys: Vec::new(),
                             col_types: vec!["string".to_string(), "int64".to_string()],
                         },
@@ -8296,7 +8400,7 @@ impl App {
                             command_tag: Some("deleteMany".to_string()),
                             truncated: false,
                             elapsed: started.elapsed(),
-                            source_table: Some(collection),
+                            source_table: None,
                             primary_keys: Vec::new(),
                             col_types: vec!["string".to_string(), "int64".to_string()],
                         },
@@ -8318,12 +8422,7 @@ impl App {
                 },
                 col_types: result.col_types.clone(),
             });
-            let _ = tx.send(DbEvent::QueryFinished {
-                result: QueryResult {
-                    source_table: Some(source_collection),
-                    ..result
-                },
-            });
+            let _ = tx.send(DbEvent::QueryFinished { result });
         });
     }
 
@@ -8551,7 +8650,15 @@ impl App {
                 self.query_ui.clear();
                 self.last_status = Some("Query cancelled".to_string());
             }
-            DbEvent::SchemaLoaded { tables } => {
+            DbEvent::SchemaLoaded {
+                tables,
+                source_database,
+            } => {
+                if self.db.kind == Some(DbKind::Mongo)
+                    && source_database.as_deref() != self.db.mongo_database.as_deref()
+                {
+                    return;
+                }
                 self.schema_cache.tables = tables;
                 self.schema_cache.loaded = true;
                 // Apply any pending schema expanded state from session restore
@@ -10331,6 +10438,73 @@ mod tests {
         assert!(
             status.contains("Mongo database \"admin\""),
             "expected conninfo to show active Mongo DB after :use; got: {status}"
+        );
+    }
+
+    #[test]
+    fn test_schema_loaded_ignores_stale_mongo_database_events() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+        app.connection_picker = None;
+        app.connection_manager = None;
+        app.db.kind = Some(DbKind::Mongo);
+        app.db.mongo_database = Some("analytics".to_string());
+
+        app.apply_db_event(DbEvent::SchemaLoaded {
+            tables: vec![TableInfo {
+                schema: "admin".to_string(),
+                name: "users".to_string(),
+                columns: vec![ColumnInfo {
+                    name: "_id".to_string(),
+                    data_type: "objectId".to_string(),
+                }],
+            }],
+            source_database: Some("admin".to_string()),
+        });
+
+        assert!(
+            app.schema_cache.tables.is_empty(),
+            "stale Mongo schema should be ignored"
+        );
+        assert!(
+            !app.schema_cache.loaded,
+            "stale Mongo schema should not mark cache as loaded"
+        );
+
+        app.apply_db_event(DbEvent::SchemaLoaded {
+            tables: vec![TableInfo {
+                schema: "analytics".to_string(),
+                name: "events".to_string(),
+                columns: vec![ColumnInfo {
+                    name: "_id".to_string(),
+                    data_type: "objectId".to_string(),
+                }],
+            }],
+            source_database: Some("analytics".to_string()),
+        });
+
+        assert!(app.schema_cache.loaded);
+        assert_eq!(app.schema_cache.tables.len(), 1);
+        assert_eq!(app.schema_cache.tables[0].name, "events");
+    }
+
+    #[test]
+    fn test_parse_grid_cell_to_bson_string_hint_is_conservative() {
+        let numeric = parse_grid_cell_to_bson("123", Some("string"), true);
+        assert!(
+            matches!(numeric, Bson::String(ref s) if s == "123"),
+            "string-typed cells should not be coerced to numbers"
+        );
+
+        let oid_like = parse_grid_cell_to_bson("507f1f77bcf86cd799439011", Some("string"), true);
+        assert!(
+            matches!(oid_like, Bson::String(ref s) if s == "507f1f77bcf86cd799439011"),
+            "string-typed cells should not be coerced to ObjectId"
         );
     }
 

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -843,9 +843,15 @@ fn parse_grid_cell_to_bson(value: &str, type_hint: Option<&str>, conservative: b
                 }
                 return Bson::String(value.to_string());
             }
-            "double" | "decimal128" => {
+            "double" => {
                 if let Ok(v) = value.trim().parse::<f64>() {
                     return Bson::Double(v);
+                }
+                return Bson::String(value.to_string());
+            }
+            "decimal128" => {
+                if let Ok(v) = value.trim().parse::<bson::Decimal128>() {
+                    return Bson::Decimal128(v);
                 }
                 return Bson::String(value.to_string());
             }
@@ -1155,21 +1161,30 @@ fn parse_mongo_query(query: &str) -> std::result::Result<MongoQuery, String> {
     }
 
     let rest = &trimmed[3..];
-    let (collection, after_collection) = rest
-        .split_once('.')
-        .ok_or_else(|| "Invalid mongosh query: expected db.<collection>.<op>(...)".to_string())?;
-    let open_paren = after_collection
+    let open_paren = rest
         .find('(')
         .ok_or_else(|| "Invalid mongosh query: missing '('".to_string())?;
-    let close_paren = after_collection
+    let close_paren = rest
         .rfind(')')
         .ok_or_else(|| "Invalid mongosh query: missing ')'".to_string())?;
-    if !after_collection[close_paren + 1..].trim().is_empty() {
+    if close_paren < open_paren {
+        return Err("Invalid mongosh query: malformed parentheses".to_string());
+    }
+    if !rest[close_paren + 1..].trim().is_empty() {
         return Err("Invalid mongosh query: unexpected trailing text".to_string());
     }
 
-    let op = after_collection[..open_paren].trim().to_lowercase();
-    let args_raw = &after_collection[open_paren + 1..close_paren];
+    let before_paren = rest[..open_paren].trim();
+    let dot_idx = before_paren
+        .rfind('.')
+        .ok_or_else(|| "Invalid mongosh query: expected db.<collection>.<op>(...)".to_string())?;
+    let collection = before_paren[..dot_idx].trim();
+    let op = before_paren[dot_idx + 1..].trim().to_lowercase();
+    if collection.is_empty() || op.is_empty() {
+        return Err("Invalid mongosh query: expected db.<collection>.<op>(...)".to_string());
+    }
+
+    let args_raw = &rest[open_paren + 1..close_paren];
     let args = split_top_level_args(args_raw);
     let empty = serde_json::json!({});
 
@@ -10506,6 +10521,30 @@ mod tests {
             matches!(oid_like, Bson::String(ref s) if s == "507f1f77bcf86cd799439011"),
             "string-typed cells should not be coerced to ObjectId"
         );
+    }
+
+    #[test]
+    fn test_parse_grid_cell_to_bson_decimal128_hint_preserves_decimal_type() {
+        let decimal =
+            parse_grid_cell_to_bson("12345678901234567890.1234", Some("decimal128"), true);
+        assert!(
+            matches!(decimal, Bson::Decimal128(_)),
+            "decimal128-typed cells should remain Decimal128 instead of Double"
+        );
+    }
+
+    #[test]
+    fn test_parse_mongo_query_supports_dotted_collection_names() {
+        let parsed = parse_mongo_query(r#"db.fs.chunks.find({"files_id": 1})"#).unwrap();
+        match parsed {
+            MongoQuery::Find {
+                collection, filter, ..
+            } => {
+                assert_eq!(collection, "fs.chunks");
+                assert!(filter.contains_key("files_id"));
+            }
+            _ => panic!("expected MongoQuery::Find"),
+        }
     }
 
     // ========== Connection Manager Issue Tests ==========

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Stdout};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -9,6 +10,8 @@ use crossterm::event::{
     MouseEventKind,
 };
 use crossterm::execute;
+use futures_util::TryStreamExt;
+use mongodb::bson::{self, doc, oid::ObjectId, Bson, Document};
 use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::Alignment;
@@ -34,7 +37,7 @@ use webpki_roots::TLS_SERVER_ROOTS;
 use super::state::{DbStatus, Focus, Mode, PanelDirection, SearchTarget, SidebarSection};
 use crate::config::{
     load_connections, save_connections, Action, ClipboardBackend, Config, ConnectionEntry,
-    ConnectionsFile, KeyBinding, Keymap, SslMode, UpdateMode,
+    ConnectionsFile, DbKind, KeyBinding, Keymap, SslMode, UpdateMode,
 };
 use crate::history::{History, HistoryEntry};
 use crate::session::SessionState;
@@ -745,13 +748,550 @@ fn extract_table_from_query(query: &str) -> Option<String> {
     }
 }
 
+fn is_mongo_connection_string(conn_str: &str) -> bool {
+    conn_str.starts_with("mongodb://") || conn_str.starts_with("mongodb+srv://")
+}
+
+fn mongo_database_from_connection_string(conn_str: &str) -> String {
+    if let Ok(url) = url::Url::parse(conn_str) {
+        let db = url.path().trim_start_matches('/').trim();
+        if !db.is_empty() {
+            return db.to_string();
+        }
+    }
+    "admin".to_string()
+}
+
+fn bson_type_name(value: &Bson) -> &'static str {
+    match value {
+        Bson::Double(_) => "double",
+        Bson::String(_) => "string",
+        Bson::Array(_) => "array",
+        Bson::Document(_) => "object",
+        Bson::Boolean(_) => "bool",
+        Bson::Null => "null",
+        Bson::RegularExpression(_) => "regex",
+        Bson::JavaScriptCode(_) => "javascript",
+        Bson::JavaScriptCodeWithScope(_) => "javascript-with-scope",
+        Bson::Int32(_) => "int32",
+        Bson::Int64(_) => "int64",
+        Bson::Timestamp(_) => "timestamp",
+        Bson::Binary(_) => "binary",
+        Bson::ObjectId(_) => "objectId",
+        Bson::DateTime(_) => "date",
+        Bson::Symbol(_) => "symbol",
+        Bson::Decimal128(_) => "decimal128",
+        Bson::Undefined => "undefined",
+        Bson::MaxKey => "maxKey",
+        Bson::MinKey => "minKey",
+        Bson::DbPointer(_) => "dbPointer",
+    }
+}
+
+fn bson_to_grid_cell(value: &Bson) -> String {
+    match value {
+        Bson::Null => "NULL".to_string(),
+        Bson::String(s) => s.clone(),
+        Bson::Boolean(v) => v.to_string(),
+        Bson::Int32(v) => v.to_string(),
+        Bson::Int64(v) => v.to_string(),
+        Bson::Double(v) => v.to_string(),
+        Bson::ObjectId(oid) => oid.to_hex(),
+        Bson::Document(_) | Bson::Array(_) => {
+            serde_json::to_string(value).unwrap_or_else(|_| format!("{value:?}"))
+        }
+        _ => format!("{value:?}"),
+    }
+}
+
+fn parse_grid_cell_to_bson(value: &str) -> Bson {
+    let trimmed = value.trim();
+    if trimmed.eq_ignore_ascii_case("null") || trimmed.eq_ignore_ascii_case("NULL") {
+        return Bson::Null;
+    }
+    if trimmed.eq_ignore_ascii_case("true") {
+        return Bson::Boolean(true);
+    }
+    if trimmed.eq_ignore_ascii_case("false") {
+        return Bson::Boolean(false);
+    }
+    if trimmed.len() == 24 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+        if let Ok(oid) = ObjectId::parse_str(trimmed) {
+            return Bson::ObjectId(oid);
+        }
+    }
+    if let Ok(v) = trimmed.parse::<i64>() {
+        return Bson::Int64(v);
+    }
+    if let Ok(v) = trimmed.parse::<f64>() {
+        return Bson::Double(v);
+    }
+    if (trimmed.starts_with('{') && trimmed.ends_with('}'))
+        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+    {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            if let Ok(b) = bson::to_bson(&json) {
+                return b;
+            }
+        }
+    }
+    Bson::String(value.to_string())
+}
+
+#[derive(Debug, Clone)]
+enum MongoQuery {
+    Find {
+        collection: String,
+        filter: Document,
+        projection: Option<Document>,
+        limit: Option<i64>,
+    },
+    FindOne {
+        collection: String,
+        filter: Document,
+        projection: Option<Document>,
+    },
+    Aggregate {
+        collection: String,
+        pipeline: Vec<Document>,
+    },
+    CountDocuments {
+        collection: String,
+        filter: Document,
+    },
+    InsertOne {
+        collection: String,
+        document: Document,
+    },
+    InsertMany {
+        collection: String,
+        documents: Vec<Document>,
+    },
+    UpdateOne {
+        collection: String,
+        filter: Document,
+        update: Document,
+    },
+    UpdateMany {
+        collection: String,
+        filter: Document,
+        update: Document,
+    },
+    DeleteOne {
+        collection: String,
+        filter: Document,
+    },
+    DeleteMany {
+        collection: String,
+        filter: Document,
+    },
+}
+
+impl MongoQuery {
+    fn collection_name(&self) -> &str {
+        match self {
+            MongoQuery::Find { collection, .. }
+            | MongoQuery::FindOne { collection, .. }
+            | MongoQuery::Aggregate { collection, .. }
+            | MongoQuery::CountDocuments { collection, .. }
+            | MongoQuery::InsertOne { collection, .. }
+            | MongoQuery::InsertMany { collection, .. }
+            | MongoQuery::UpdateOne { collection, .. }
+            | MongoQuery::UpdateMany { collection, .. }
+            | MongoQuery::DeleteOne { collection, .. }
+            | MongoQuery::DeleteMany { collection, .. } => collection,
+        }
+    }
+}
+
+fn json_value_to_document(value: &serde_json::Value) -> std::result::Result<Document, String> {
+    let bson = bson::to_bson(value).map_err(|e| format!("Invalid BSON value: {e}"))?;
+    if let Bson::Document(doc) = bson {
+        Ok(doc)
+    } else {
+        Err("Expected JSON object".to_string())
+    }
+}
+
+fn json_value_to_documents(
+    value: &serde_json::Value,
+) -> std::result::Result<Vec<Document>, String> {
+    let arr = value
+        .as_array()
+        .ok_or_else(|| "Expected JSON array".to_string())?;
+    arr.iter().map(json_value_to_document).collect()
+}
+
+fn split_top_level_args(input: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut depth_brace: usize = 0;
+    let mut depth_bracket: usize = 0;
+    let mut depth_paren: usize = 0;
+    let mut in_string = false;
+    let mut escape = false;
+
+    for ch in input.chars() {
+        if in_string {
+            current.push(ch);
+            if escape {
+                escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                escape = true;
+                continue;
+            }
+            if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_string = true;
+                current.push(ch);
+            }
+            '{' => {
+                depth_brace += 1;
+                current.push(ch);
+            }
+            '}' => {
+                depth_brace = depth_brace.saturating_sub(1);
+                current.push(ch);
+            }
+            '[' => {
+                depth_bracket += 1;
+                current.push(ch);
+            }
+            ']' => {
+                depth_bracket = depth_bracket.saturating_sub(1);
+                current.push(ch);
+            }
+            '(' => {
+                depth_paren += 1;
+                current.push(ch);
+            }
+            ')' => {
+                depth_paren = depth_paren.saturating_sub(1);
+                current.push(ch);
+            }
+            ',' if depth_brace == 0 && depth_bracket == 0 && depth_paren == 0 => {
+                let trimmed = current.trim();
+                if !trimmed.is_empty() {
+                    args.push(trimmed.to_string());
+                }
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    let trimmed = current.trim();
+    if !trimmed.is_empty() {
+        args.push(trimmed.to_string());
+    }
+
+    args
+}
+
+fn parse_mongo_query(query: &str) -> std::result::Result<MongoQuery, String> {
+    let trimmed = query.trim().trim_end_matches(';').trim();
+    if trimmed.is_empty() {
+        return Err("Empty Mongo query".to_string());
+    }
+
+    if trimmed.starts_with('{') {
+        let payload: serde_json::Value =
+            serde_json::from_str(trimmed).map_err(|e| format!("Invalid JSON command: {e}"))?;
+        let obj = payload
+            .as_object()
+            .ok_or_else(|| "Mongo command JSON must be an object".to_string())?;
+        let op = obj
+            .get("op")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Mongo command requires string field 'op'".to_string())?
+            .to_lowercase();
+        let collection = obj
+            .get("collection")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Mongo command requires string field 'collection'".to_string())?
+            .to_string();
+
+        let empty_obj = serde_json::json!({});
+        let filter_v = obj.get("filter").unwrap_or(&empty_obj);
+        let filter = json_value_to_document(filter_v)?;
+        let projection = obj
+            .get("projection")
+            .map(json_value_to_document)
+            .transpose()?;
+        let limit = obj.get("limit").and_then(|v| v.as_i64());
+
+        return match op.as_str() {
+            "find" => Ok(MongoQuery::Find {
+                collection,
+                filter,
+                projection,
+                limit,
+            }),
+            "findone" | "find_one" => Ok(MongoQuery::FindOne {
+                collection,
+                filter,
+                projection,
+            }),
+            "aggregate" => {
+                let pipeline_v = obj
+                    .get("pipeline")
+                    .ok_or_else(|| "aggregate requires field 'pipeline'".to_string())?;
+                let pipeline = json_value_to_documents(pipeline_v)?;
+                Ok(MongoQuery::Aggregate {
+                    collection,
+                    pipeline,
+                })
+            }
+            "countdocuments" | "count_documents" => {
+                Ok(MongoQuery::CountDocuments { collection, filter })
+            }
+            "insertone" | "insert_one" => {
+                let doc_v = obj
+                    .get("document")
+                    .ok_or_else(|| "insertOne requires field 'document'".to_string())?;
+                Ok(MongoQuery::InsertOne {
+                    collection,
+                    document: json_value_to_document(doc_v)?,
+                })
+            }
+            "insertmany" | "insert_many" => {
+                let docs_v = obj
+                    .get("documents")
+                    .ok_or_else(|| "insertMany requires field 'documents'".to_string())?;
+                Ok(MongoQuery::InsertMany {
+                    collection,
+                    documents: json_value_to_documents(docs_v)?,
+                })
+            }
+            "updateone" | "update_one" => {
+                let update_v = obj
+                    .get("update")
+                    .ok_or_else(|| "updateOne requires field 'update'".to_string())?;
+                Ok(MongoQuery::UpdateOne {
+                    collection,
+                    filter,
+                    update: json_value_to_document(update_v)?,
+                })
+            }
+            "updatemany" | "update_many" => {
+                let update_v = obj
+                    .get("update")
+                    .ok_or_else(|| "updateMany requires field 'update'".to_string())?;
+                Ok(MongoQuery::UpdateMany {
+                    collection,
+                    filter,
+                    update: json_value_to_document(update_v)?,
+                })
+            }
+            "deleteone" | "delete_one" => Ok(MongoQuery::DeleteOne { collection, filter }),
+            "deletemany" | "delete_many" => Ok(MongoQuery::DeleteMany { collection, filter }),
+            _ => Err(format!("Unsupported Mongo op '{op}'")),
+        };
+    }
+
+    if !trimmed.starts_with("db.") {
+        return Err(
+            "Mongo queries must use JSON command or mongosh-like db.collection.op(...) syntax"
+                .to_string(),
+        );
+    }
+
+    let rest = &trimmed[3..];
+    let (collection, after_collection) = rest
+        .split_once('.')
+        .ok_or_else(|| "Invalid mongosh query: expected db.<collection>.<op>(...)".to_string())?;
+    let open_paren = after_collection
+        .find('(')
+        .ok_or_else(|| "Invalid mongosh query: missing '('".to_string())?;
+    let close_paren = after_collection
+        .rfind(')')
+        .ok_or_else(|| "Invalid mongosh query: missing ')'".to_string())?;
+    if !after_collection[close_paren + 1..].trim().is_empty() {
+        return Err("Invalid mongosh query: unexpected trailing text".to_string());
+    }
+
+    let op = after_collection[..open_paren].trim().to_lowercase();
+    let args_raw = &after_collection[open_paren + 1..close_paren];
+    let args = split_top_level_args(args_raw);
+    let empty = serde_json::json!({});
+
+    let parse_arg = |idx: usize| -> std::result::Result<serde_json::Value, String> {
+        if let Some(arg) = args.get(idx) {
+            serde_json::from_str(arg).map_err(|e| format!("Invalid JSON argument {idx}: {e}"))
+        } else {
+            Ok(empty.clone())
+        }
+    };
+
+    match op.as_str() {
+        "find" => {
+            let filter = json_value_to_document(&parse_arg(0)?)?;
+            let projection = if args.len() > 1 {
+                Some(json_value_to_document(&parse_arg(1)?)?)
+            } else {
+                None
+            };
+            Ok(MongoQuery::Find {
+                collection: collection.to_string(),
+                filter,
+                projection,
+                limit: None,
+            })
+        }
+        "findone" => {
+            let filter = json_value_to_document(&parse_arg(0)?)?;
+            let projection = if args.len() > 1 {
+                Some(json_value_to_document(&parse_arg(1)?)?)
+            } else {
+                None
+            };
+            Ok(MongoQuery::FindOne {
+                collection: collection.to_string(),
+                filter,
+                projection,
+            })
+        }
+        "aggregate" => {
+            let pipeline = if let Some(arg0) = args.first() {
+                let value: serde_json::Value = serde_json::from_str(arg0)
+                    .map_err(|e| format!("Invalid pipeline JSON: {e}"))?;
+                json_value_to_documents(&value)?
+            } else {
+                Vec::new()
+            };
+            Ok(MongoQuery::Aggregate {
+                collection: collection.to_string(),
+                pipeline,
+            })
+        }
+        "countdocuments" => Ok(MongoQuery::CountDocuments {
+            collection: collection.to_string(),
+            filter: json_value_to_document(&parse_arg(0)?)?,
+        }),
+        "insertone" => Ok(MongoQuery::InsertOne {
+            collection: collection.to_string(),
+            document: json_value_to_document(&parse_arg(0)?)?,
+        }),
+        "insertmany" => {
+            let value = parse_arg(0)?;
+            Ok(MongoQuery::InsertMany {
+                collection: collection.to_string(),
+                documents: json_value_to_documents(&value)?,
+            })
+        }
+        "updateone" => Ok(MongoQuery::UpdateOne {
+            collection: collection.to_string(),
+            filter: json_value_to_document(&parse_arg(0)?)?,
+            update: json_value_to_document(&parse_arg(1)?)?,
+        }),
+        "updatemany" => Ok(MongoQuery::UpdateMany {
+            collection: collection.to_string(),
+            filter: json_value_to_document(&parse_arg(0)?)?,
+            update: json_value_to_document(&parse_arg(1)?)?,
+        }),
+        "deleteone" => Ok(MongoQuery::DeleteOne {
+            collection: collection.to_string(),
+            filter: json_value_to_document(&parse_arg(0)?)?,
+        }),
+        "deletemany" => Ok(MongoQuery::DeleteMany {
+            collection: collection.to_string(),
+            filter: json_value_to_document(&parse_arg(0)?)?,
+        }),
+        _ => Err(format!("Unsupported mongosh operation '{op}'")),
+    }
+}
+
+fn mongo_result_from_documents(
+    docs: Vec<Document>,
+    source_table: Option<String>,
+    elapsed: Duration,
+    truncated: bool,
+) -> QueryResult {
+    if docs.is_empty() {
+        return QueryResult {
+            headers: vec!["status".to_string()],
+            rows: vec![vec!["No documents".to_string()]],
+            command_tag: Some("0 rows".to_string()),
+            truncated,
+            elapsed,
+            source_table,
+            primary_keys: Vec::new(),
+            col_types: vec!["string".to_string()],
+        };
+    }
+
+    let mut seen = HashSet::new();
+    let mut headers = Vec::new();
+    for doc in &docs {
+        for key in doc.keys() {
+            if seen.insert(key.clone()) {
+                headers.push(key.clone());
+            }
+        }
+    }
+
+    let mut rows = Vec::with_capacity(docs.len());
+    for doc in &docs {
+        let mut row = Vec::with_capacity(headers.len());
+        for header in &headers {
+            let value = doc.get(header).map(bson_to_grid_cell).unwrap_or_default();
+            row.push(value);
+        }
+        rows.push(row);
+    }
+
+    let mut type_map: HashMap<String, String> = HashMap::new();
+    for header in &headers {
+        for doc in &docs {
+            if let Some(v) = doc.get(header) {
+                type_map.insert(header.clone(), bson_type_name(v).to_string());
+                break;
+            }
+        }
+    }
+    let col_types = headers
+        .iter()
+        .map(|h| type_map.get(h).cloned().unwrap_or_default())
+        .collect::<Vec<_>>();
+
+    let primary_keys = if headers.iter().any(|h| h == "_id") {
+        vec!["_id".to_string()]
+    } else {
+        Vec::new()
+    };
+
+    QueryResult {
+        command_tag: Some(format!("{} rows", rows.len())),
+        headers,
+        rows,
+        truncated,
+        elapsed,
+        source_table,
+        primary_keys,
+        col_types,
+    }
+}
+
 pub type SharedClient = Arc<Mutex<Client>>;
+pub type SharedMongoClient = Arc<mongodb::Client>;
 
 pub enum DbEvent {
     Connected {
         client: SharedClient,
         cancel_token: CancelToken,
         connected_with_tls: bool,
+    },
+    MongoConnected {
+        client: SharedMongoClient,
+        database: String,
     },
     ConnectError {
         error: String,
@@ -807,8 +1347,11 @@ pub enum DbEvent {
 
 pub struct DbSession {
     pub status: DbStatus,
+    pub kind: Option<DbKind>,
     pub conn_str: Option<String>,
     pub client: Option<SharedClient>,
+    pub mongo_client: Option<SharedMongoClient>,
+    pub mongo_database: Option<String>,
     pub cancel_token: Option<CancelToken>,
     pub last_command_tag: Option<String>,
     pub last_elapsed: Option<Duration>,
@@ -823,8 +1366,11 @@ impl DbSession {
     pub fn new() -> Self {
         Self {
             status: DbStatus::Disconnected,
+            kind: None,
             conn_str: None,
             client: None,
+            mongo_client: None,
+            mongo_database: None,
             cancel_token: None,
             last_command_tag: None,
             last_elapsed: None,
@@ -3334,7 +3880,14 @@ impl App {
             return;
         }
 
-        if !self.grid.has_valid_pk() {
+        if self.db.kind == Some(DbKind::Mongo) {
+            if !self.grid.headers.iter().any(|h| h == "_id") {
+                self.last_status = Some(
+                    "No _id column detected; Mongo updates will use best-effort field matching."
+                        .to_string(),
+                );
+            }
+        } else if !self.grid.has_valid_pk() {
             self.last_status = Some(
                 "No primary key detected; updates will match the first row by values.".to_string(),
             );
@@ -3622,6 +4175,11 @@ impl App {
 
     /// Commit a JSON edit to the database.
     fn commit_json_edit(&mut self, new_value: String, row: usize, col: usize) {
+        if self.db.kind == Some(DbKind::Mongo) {
+            self.commit_mongo_edit(new_value, row, col, None);
+            return;
+        }
+
         // Generate UPDATE SQL (similar to commit_cell_edit)
         let table = match &self.grid.source_table {
             Some(t) => t.clone(),
@@ -3672,6 +4230,12 @@ impl App {
             return;
         }
 
+        if self.db.kind == Some(DbKind::Mongo) {
+            self.cell_editor.close();
+            self.commit_mongo_edit(new_value, row, col, Some(original_value.as_str()));
+            return;
+        }
+
         // Generate UPDATE SQL
         let table = match &self.grid.source_table {
             Some(t) => t.clone(),
@@ -3712,6 +4276,139 @@ impl App {
         // Close editor and execute update
         self.cell_editor.close();
         self.execute_cell_update(update_sql, row, col, new_value);
+    }
+
+    fn commit_mongo_edit(
+        &mut self,
+        new_value: String,
+        row: usize,
+        col: usize,
+        edited_original_value: Option<&str>,
+    ) {
+        let collection = match &self.grid.source_table {
+            Some(t) => t.clone(),
+            None => {
+                self.last_error = Some("Cannot update: unknown source collection".to_string());
+                return;
+            }
+        };
+        let field_name = match self.grid.headers.get(col) {
+            Some(name) => name.clone(),
+            None => {
+                self.last_error = Some("Cannot update: invalid column".to_string());
+                return;
+            }
+        };
+        let filter = match self.build_mongo_update_filter(row, col, edited_original_value) {
+            Ok(f) => f,
+            Err(e) => {
+                self.last_error = Some(e);
+                return;
+            }
+        };
+
+        let mut set_doc = Document::new();
+        set_doc.insert(field_name, parse_grid_cell_to_bson(&new_value));
+        let mut update = Document::new();
+        update.insert("$set", Bson::Document(set_doc));
+
+        self.execute_mongo_cell_update(collection, filter, update, row, col, new_value);
+    }
+
+    fn build_mongo_update_filter(
+        &self,
+        row: usize,
+        edited_col: usize,
+        edited_original_value: Option<&str>,
+    ) -> Result<Document, String> {
+        let row_values = self
+            .grid
+            .rows
+            .get(row)
+            .ok_or_else(|| "Cannot update: invalid row".to_string())?;
+
+        if let Some(id_idx) = self.grid.headers.iter().position(|h| h == "_id") {
+            if let Some(id_value) = row_values.get(id_idx) {
+                let mut filter = Document::new();
+                filter.insert("_id", parse_grid_cell_to_bson(id_value));
+                return Ok(filter);
+            }
+        }
+
+        let mut filter = Document::new();
+        for (idx, header) in self.grid.headers.iter().enumerate() {
+            let mut value = row_values.get(idx).map(|s| s.as_str()).unwrap_or("NULL");
+            if idx == edited_col {
+                if let Some(original) = edited_original_value {
+                    value = original;
+                }
+            }
+            filter.insert(header.clone(), parse_grid_cell_to_bson(value));
+        }
+
+        Ok(filter)
+    }
+
+    fn execute_mongo_cell_update(
+        &mut self,
+        collection: String,
+        filter: Document,
+        update: Document,
+        row: usize,
+        col: usize,
+        new_value: String,
+    ) {
+        let Some(client) = self.db.mongo_client.clone() else {
+            self.last_error = Some("Not connected".to_string());
+            return;
+        };
+        if self.db.running {
+            self.last_error = Some("Another query is running".to_string());
+            return;
+        }
+        let db_name = self
+            .db
+            .mongo_database
+            .clone()
+            .unwrap_or_else(|| "admin".to_string());
+
+        self.db.running = true;
+        self.last_status = Some("Updating...".to_string());
+        self.query_ui.start();
+
+        let tx = self.db_events_tx.clone();
+        self.rt.spawn(async move {
+            let db = client.database(&db_name);
+            let coll = db.collection::<Document>(&collection);
+            match coll.update_one(filter, update).await {
+                Ok(res) => {
+                    if res.matched_count == 1 {
+                        let _ = tx.send(DbEvent::CellUpdated {
+                            row,
+                            col,
+                            value: new_value,
+                        });
+                    } else if res.matched_count == 0 {
+                        let _ = tx.send(DbEvent::QueryError {
+                            error: "Update matched 0 documents (document may have changed)"
+                                .to_string(),
+                        });
+                    } else {
+                        let _ = tx.send(DbEvent::QueryError {
+                            error: format!(
+                                "Update matched {} documents (ambiguous best-effort match)",
+                                res.matched_count
+                            ),
+                        });
+                    }
+                }
+                Err(e) => {
+                    let _ = tx.send(DbEvent::QueryError {
+                        error: format!("Mongo update error: {e}"),
+                    });
+                }
+            }
+        });
     }
 
     fn execute_cell_update(&mut self, sql: String, row: usize, col: usize, new_value: String) {
@@ -3964,6 +4661,9 @@ impl App {
             }
             "disconnect" | "dc" => {
                 self.db.client = None;
+                self.db.mongo_client = None;
+                self.db.mongo_database = None;
+                self.db.kind = None;
                 self.db.cancel_token = None;
                 self.db.status = DbStatus::Disconnected;
                 self.db.running = false;
@@ -3979,36 +4679,118 @@ impl App {
             "gen" | "generate" => {
                 self.handle_gen_command(args);
             }
+            "show" => {
+                if self.db.kind != Some(DbKind::Mongo) {
+                    self.last_status = Some(
+                        "Mongo command ':show ...' is only available for Mongo connections"
+                            .to_string(),
+                    );
+                } else {
+                    match args {
+                        "dbs" | "databases" => self.execute_mongo_show_databases(),
+                        "collections" => self.execute_mongo_show_collections(),
+                        _ => {
+                            self.last_status =
+                                Some("Usage: :show dbs | :show collections".to_string());
+                        }
+                    }
+                }
+            }
+            "describe" => {
+                if self.db.kind != Some(DbKind::Mongo) {
+                    self.last_status = Some(
+                        "':describe <collection>' is only available for Mongo connections"
+                            .to_string(),
+                    );
+                } else if args.is_empty() {
+                    self.last_status = Some("Usage: :describe <collection>".to_string());
+                } else {
+                    self.execute_mongo_describe_collection(args);
+                }
+            }
+            "use" => {
+                if self.db.kind != Some(DbKind::Mongo) {
+                    self.last_status = Some(
+                        "':use <database>' is only available for Mongo connections".to_string(),
+                    );
+                } else if args.is_empty() {
+                    self.last_status = Some("Usage: :use <database>".to_string());
+                } else {
+                    self.db.mongo_database = Some(args.to_string());
+                    self.last_status = Some(format!("Switched to Mongo database '{}'", args));
+                    self.load_schema();
+                }
+            }
             // psql-style backslash commands
             "\\dt" | "dt" => {
-                self.execute_meta_query(META_QUERY_TABLES, None);
+                if self.db.kind == Some(DbKind::Mongo) {
+                    self.execute_mongo_show_collections();
+                } else {
+                    self.execute_meta_query(META_QUERY_TABLES, None);
+                }
             }
             "\\dn" | "dn" => {
-                self.execute_meta_query(META_QUERY_SCHEMAS, None);
+                if self.db.kind == Some(DbKind::Mongo) {
+                    self.last_status = Some("Use ':show dbs' for Mongo databases".to_string());
+                } else {
+                    self.execute_meta_query(META_QUERY_SCHEMAS, None);
+                }
             }
             "\\d" | "d" => {
-                if args.is_empty() {
-                    // \d without args is same as \dt
-                    self.execute_meta_query(META_QUERY_TABLES, None);
+                if self.db.kind == Some(DbKind::Mongo) {
+                    if args.is_empty() {
+                        self.execute_mongo_show_collections();
+                    } else {
+                        self.execute_mongo_describe_collection(args);
+                    }
                 } else {
-                    // \d <table> - describe table
-                    self.execute_meta_query(META_QUERY_DESCRIBE, Some(args));
+                    if args.is_empty() {
+                        // \d without args is same as \dt
+                        self.execute_meta_query(META_QUERY_TABLES, None);
+                    } else {
+                        // \d <table> - describe table
+                        self.execute_meta_query(META_QUERY_DESCRIBE, Some(args));
+                    }
                 }
             }
             "\\di" | "di" => {
-                self.execute_meta_query(META_QUERY_INDEXES, None);
+                if self.db.kind == Some(DbKind::Mongo) {
+                    self.last_status =
+                        Some("Mongo index listing via :\\di is not implemented yet".to_string());
+                } else {
+                    self.execute_meta_query(META_QUERY_INDEXES, None);
+                }
             }
             "\\l" | "l" => {
-                self.execute_meta_query(META_QUERY_DATABASES, None);
+                if self.db.kind == Some(DbKind::Mongo) {
+                    self.execute_mongo_show_databases();
+                } else {
+                    self.execute_meta_query(META_QUERY_DATABASES, None);
+                }
             }
             "\\du" | "du" => {
-                self.execute_meta_query(META_QUERY_ROLES, None);
+                if self.db.kind == Some(DbKind::Mongo) {
+                    self.last_status =
+                        Some("Mongo users listing via :\\du is not implemented yet".to_string());
+                } else {
+                    self.execute_meta_query(META_QUERY_ROLES, None);
+                }
             }
             "\\dv" | "dv" => {
-                self.execute_meta_query(META_QUERY_VIEWS, None);
+                if self.db.kind == Some(DbKind::Mongo) {
+                    self.last_status =
+                        Some("Mongo views listing via :\\dv is not implemented yet".to_string());
+                } else {
+                    self.execute_meta_query(META_QUERY_VIEWS, None);
+                }
             }
             "\\df" | "df" => {
-                self.execute_meta_query(META_QUERY_FUNCTIONS, None);
+                if self.db.kind == Some(DbKind::Mongo) {
+                    self.last_status =
+                        Some("Mongo functions via :\\df are not applicable".to_string());
+                } else {
+                    self.execute_meta_query(META_QUERY_FUNCTIONS, None);
+                }
             }
             "\\conninfo" | "conninfo" => {
                 self.show_connection_info();
@@ -4414,6 +5196,148 @@ impl App {
         });
     }
 
+    fn execute_mongo_show_databases(&mut self) {
+        let Some(client) = self.db.mongo_client.clone() else {
+            self.last_error = Some("Not connected to Mongo.".to_string());
+            return;
+        };
+        if self.db.running {
+            self.last_status = Some("Query already running".to_string());
+            return;
+        }
+
+        self.db.running = true;
+        self.last_status = Some("Running...".to_string());
+        self.query_ui.start();
+
+        let tx = self.db_events_tx.clone();
+        let started = Instant::now();
+        self.rt.spawn(async move {
+            match client.list_database_names().await {
+                Ok(names) => {
+                    let rows = names.into_iter().map(|n| vec![n]).collect::<Vec<_>>();
+                    let result = QueryResult {
+                        headers: vec!["name".to_string()],
+                        rows,
+                        command_tag: Some("show dbs".to_string()),
+                        truncated: false,
+                        elapsed: started.elapsed(),
+                        source_table: None,
+                        primary_keys: Vec::new(),
+                        col_types: vec!["string".to_string()],
+                    };
+                    let _ = tx.send(DbEvent::QueryFinished { result });
+                }
+                Err(e) => {
+                    let _ = tx.send(DbEvent::QueryError {
+                        error: format!("Mongo show dbs error: {e}"),
+                    });
+                }
+            }
+        });
+    }
+
+    fn execute_mongo_show_collections(&mut self) {
+        let Some(client) = self.db.mongo_client.clone() else {
+            self.last_error = Some("Not connected to Mongo.".to_string());
+            return;
+        };
+        if self.db.running {
+            self.last_status = Some("Query already running".to_string());
+            return;
+        }
+
+        let db_name = self
+            .db
+            .mongo_database
+            .clone()
+            .unwrap_or_else(|| "admin".to_string());
+        self.db.running = true;
+        self.last_status = Some("Running...".to_string());
+        self.query_ui.start();
+
+        let tx = self.db_events_tx.clone();
+        let started = Instant::now();
+        self.rt.spawn(async move {
+            let db = client.database(&db_name);
+            match db.list_collection_names().await {
+                Ok(names) => {
+                    let rows = names.into_iter().map(|n| vec![n]).collect::<Vec<_>>();
+                    let result = QueryResult {
+                        headers: vec!["collection".to_string()],
+                        rows,
+                        command_tag: Some("show collections".to_string()),
+                        truncated: false,
+                        elapsed: started.elapsed(),
+                        source_table: None,
+                        primary_keys: Vec::new(),
+                        col_types: vec!["string".to_string()],
+                    };
+                    let _ = tx.send(DbEvent::QueryFinished { result });
+                }
+                Err(e) => {
+                    let _ = tx.send(DbEvent::QueryError {
+                        error: format!("Mongo show collections error: {e}"),
+                    });
+                }
+            }
+        });
+    }
+
+    fn execute_mongo_describe_collection(&mut self, collection_name: &str) {
+        let Some(client) = self.db.mongo_client.clone() else {
+            self.last_error = Some("Not connected to Mongo.".to_string());
+            return;
+        };
+        if self.db.running {
+            self.last_status = Some("Query already running".to_string());
+            return;
+        }
+
+        let db_name = self
+            .db
+            .mongo_database
+            .clone()
+            .unwrap_or_else(|| "admin".to_string());
+        let collection_name = collection_name.to_string();
+        self.db.running = true;
+        self.last_status = Some("Running...".to_string());
+        self.query_ui.start();
+
+        let tx = self.db_events_tx.clone();
+        let started = Instant::now();
+        self.rt.spawn(async move {
+            let db = client.database(&db_name);
+            let coll = db.collection::<Document>(&collection_name);
+            match coll.find_one(doc! {}).await {
+                Ok(sample) => {
+                    let mut rows = Vec::new();
+                    if let Some(doc) = sample {
+                        for (field, value) in doc {
+                            rows.push(vec![field, bson_type_name(&value).to_string()]);
+                        }
+                    }
+                    let result = QueryResult {
+                        headers: vec!["field".to_string(), "type".to_string()],
+                        rows,
+                        command_tag: Some(format!("describe {}", collection_name)),
+                        truncated: false,
+                        elapsed: started.elapsed(),
+                        source_table: Some(collection_name),
+                        primary_keys: Vec::new(),
+                        col_types: vec!["string".to_string(), "string".to_string()],
+                    };
+                    let _ = tx.send(DbEvent::QueryFinished { result });
+                }
+                Err(e) => {
+                    let _ = tx.send(DbEvent::QueryError {
+                        error: format!("Mongo describe error: {e}"),
+                    });
+                }
+            }
+        });
+    }
+
     fn handle_export_command(&mut self, args: &str) {
         if self.grid.rows.is_empty() {
             self.last_error = Some("No data to export".to_string());
@@ -4488,15 +5412,33 @@ impl App {
             }
             DbStatus::Connected => {
                 if let Some(ref conn_str) = self.db.conn_str {
-                    let info = ConnectionInfo::parse(conn_str);
+                    let mut info = ConnectionInfo::parse(conn_str);
+                    if self.db.kind == Some(DbKind::Mongo) {
+                        if let Some(active_db) = self.db.mongo_database.as_ref() {
+                            info.database = Some(active_db.clone());
+                        }
+                    }
                     let user = info.user.as_deref().unwrap_or("unknown");
                     let host = info.host.as_deref().unwrap_or("localhost");
-                    let port = info.port.unwrap_or(5432);
+                    let port = info.port.unwrap_or_else(|| {
+                        if self.db.kind == Some(DbKind::Mongo) {
+                            27017
+                        } else {
+                            5432
+                        }
+                    });
                     let database = info.database.as_deref().unwrap_or("unknown");
-                    self.last_status = Some(format!(
-                        "Connected to database \"{}\" as user \"{}\" on host \"{}\" port {}.",
-                        database, user, host, port
-                    ));
+                    if self.db.kind == Some(DbKind::Mongo) {
+                        self.last_status = Some(format!(
+                            "Connected to Mongo database \"{}\" as user \"{}\" on host \"{}\" port {}.",
+                            database, user, host, port
+                        ));
+                    } else {
+                        self.last_status = Some(format!(
+                            "Connected to database \"{}\" as user \"{}\" on host \"{}\" port {}.",
+                            database, user, host, port
+                        ));
+                    }
                 } else {
                     self.last_status =
                         Some("Connected (no connection string available).".to_string());
@@ -4566,6 +5508,98 @@ impl App {
                 None
             }
         });
+
+        if self.db.kind == Some(DbKind::Mongo) {
+            let mut commands = Vec::new();
+            for row_idx in &row_indices {
+                let Some(row_values) = self.grid.rows.get(*row_idx) else {
+                    continue;
+                };
+
+                let mut full_doc = serde_json::Map::new();
+                for (i, header) in self.grid.headers.iter().enumerate() {
+                    let cell = row_values.get(i).cloned().unwrap_or_default();
+                    let bson_value = parse_grid_cell_to_bson(&cell);
+                    let json_value = bson::from_bson::<serde_json::Value>(bson_value.clone())
+                        .unwrap_or_else(|_| {
+                            serde_json::Value::String(bson_to_grid_cell(&bson_value))
+                        });
+                    full_doc.insert(header.clone(), json_value);
+                }
+
+                let filter_keys = key_columns
+                    .as_ref()
+                    .cloned()
+                    .or_else(|| {
+                        if self.grid.headers.iter().any(|h| h == "_id") {
+                            Some(vec!["_id".to_string()])
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| self.grid.headers.clone());
+
+                let mut filter = serde_json::Map::new();
+                for key in &filter_keys {
+                    if let Some(value) = full_doc.get(key) {
+                        filter.insert(key.clone(), value.clone());
+                    }
+                }
+
+                let command = match gen_type.as_str() {
+                    "update" | "u" => {
+                        let mut set_obj = serde_json::Map::new();
+                        for (k, v) in &full_doc {
+                            if !filter_keys.iter().any(|fk| fk == k) {
+                                set_obj.insert(k.clone(), v.clone());
+                            }
+                        }
+                        serde_json::json!({
+                            "op": "updateOne",
+                            "collection": table.clone(),
+                            "filter": serde_json::Value::Object(filter.clone()),
+                            "update": { "$set": serde_json::Value::Object(set_obj) }
+                        })
+                    }
+                    "delete" | "d" => serde_json::json!({
+                        "op": "deleteOne",
+                        "collection": table.clone(),
+                        "filter": serde_json::Value::Object(filter.clone())
+                    }),
+                    "insert" | "i" => serde_json::json!({
+                        "op": "insertOne",
+                        "collection": table.clone(),
+                        "document": serde_json::Value::Object(full_doc.clone())
+                    }),
+                    _ => {
+                        self.last_error = Some(format!(
+                            "Unknown generate type: {}. Use update, delete, or insert.",
+                            gen_type
+                        ));
+                        return;
+                    }
+                };
+                commands.push(command);
+            }
+
+            let generated = commands
+                .into_iter()
+                .map(|c| serde_json::to_string_pretty(&c).unwrap_or_else(|_| c.to_string()))
+                .collect::<Vec<_>>()
+                .join("\n\n");
+
+            self.editor.textarea.select_all();
+            self.editor.textarea.cut();
+            self.editor.textarea.insert_str(&generated);
+            self.focus = Focus::Query;
+            self.mode = Mode::Normal;
+            self.last_status = Some(format!(
+                "Generated {} Mongo command statement{}",
+                row_indices.len(),
+                if row_indices.len() == 1 { "" } else { "s" }
+            ));
+            return;
+        }
 
         let sql = match gen_type.as_str() {
             "update" | "u" => {
@@ -5363,8 +6397,11 @@ impl App {
 
     pub fn start_connect(&mut self, conn_str: String) {
         self.db.status = DbStatus::Connecting;
+        self.db.kind = None;
         self.db.conn_str = Some(conn_str.clone());
         self.db.client = None;
+        self.db.mongo_client = None;
+        self.db.mongo_database = None;
         self.db.running = false;
         self.query_ui.clear();
         self.db.connected_with_tls = false;
@@ -5375,6 +6412,32 @@ impl App {
         let rt = self.rt.clone();
 
         self.rt.spawn(async move {
+            if is_mongo_connection_string(&conn_str) {
+                match mongodb::Client::with_uri_str(&conn_str).await {
+                    Ok(client) => {
+                        let db_name = mongo_database_from_connection_string(&conn_str);
+                        // Best-effort ping to fail fast for invalid credentials/transport.
+                        let ping_db = client.database("admin");
+                        if let Err(e) = ping_db.run_command(doc! { "ping": 1 }).await {
+                            let _ = tx.send(DbEvent::ConnectError {
+                                error: format!("Mongo connection error: {e}"),
+                            });
+                            return;
+                        }
+                        let _ = tx.send(DbEvent::MongoConnected {
+                            client: Arc::new(client),
+                            database: db_name,
+                        });
+                    }
+                    Err(e) => {
+                        let _ = tx.send(DbEvent::ConnectError {
+                            error: format!("Mongo connection error: {e}"),
+                        });
+                    }
+                }
+                return;
+            }
+
             let ssl_mode = match resolve_ssl_mode(&conn_str) {
                 Ok(m) => m,
                 Err(msg) => {
@@ -5832,11 +6895,53 @@ impl App {
                 };
 
                 let sql = match completed.action {
-                    KeySequenceAction::SchemaTableSelect => self.build_select_template(&ctx),
-                    KeySequenceAction::SchemaTableInsert => self.build_insert_template(&ctx),
-                    KeySequenceAction::SchemaTableUpdate => self.build_update_template(&ctx),
-                    KeySequenceAction::SchemaTableDelete => self.build_delete_template(&ctx),
-                    KeySequenceAction::SchemaTableName => self.format_table_name_only(&ctx.table),
+                    KeySequenceAction::SchemaTableSelect => {
+                        if self.db.kind == Some(DbKind::Mongo) {
+                            format!(
+                                "{{\n  \"op\": \"find\",\n  \"collection\": \"{}\",\n  \"filter\": {{}},\n  \"limit\": {}\n}}",
+                                ctx.table, self.config.sql.default_select_limit
+                            )
+                        } else {
+                            self.build_select_template(&ctx)
+                        }
+                    }
+                    KeySequenceAction::SchemaTableInsert => {
+                        if self.db.kind == Some(DbKind::Mongo) {
+                            format!(
+                                "{{\n  \"op\": \"insertOne\",\n  \"collection\": \"{}\",\n  \"document\": {{}}\n}}",
+                                ctx.table
+                            )
+                        } else {
+                            self.build_insert_template(&ctx)
+                        }
+                    }
+                    KeySequenceAction::SchemaTableUpdate => {
+                        if self.db.kind == Some(DbKind::Mongo) {
+                            format!(
+                                "{{\n  \"op\": \"updateMany\",\n  \"collection\": \"{}\",\n  \"filter\": {{}},\n  \"update\": {{\"$set\": {{}}}}\n}}",
+                                ctx.table
+                            )
+                        } else {
+                            self.build_update_template(&ctx)
+                        }
+                    }
+                    KeySequenceAction::SchemaTableDelete => {
+                        if self.db.kind == Some(DbKind::Mongo) {
+                            format!(
+                                "{{\n  \"op\": \"deleteMany\",\n  \"collection\": \"{}\",\n  \"filter\": {{}}\n}}",
+                                ctx.table
+                            )
+                        } else {
+                            self.build_delete_template(&ctx)
+                        }
+                    }
+                    KeySequenceAction::SchemaTableName => {
+                        if self.db.kind == Some(DbKind::Mongo) {
+                            ctx.table.clone()
+                        } else {
+                            self.format_table_name_only(&ctx.table)
+                        }
+                    }
                     _ => return,
                 };
 
@@ -6058,17 +7163,6 @@ impl App {
 
                 let tx = self.db_events_tx.clone();
                 self.rt.spawn(async move {
-                    let ssl_mode = match resolve_ssl_mode(&url) {
-                        Ok(m) => m,
-                        Err(msg) => {
-                            let _ = tx.send(DbEvent::TestConnectionResult {
-                                success: false,
-                                message: format!("Connection failed: {msg}"),
-                            });
-                            return;
-                        }
-                    };
-
                     let send_ok = |tx: &mpsc::UnboundedSender<DbEvent>| {
                         let _ = tx.send(DbEvent::TestConnectionResult {
                             success: true,
@@ -6081,6 +7175,41 @@ impl App {
                             success: false,
                             message: format!("Connection failed: {}", format_pg_error(&e)),
                         });
+                    };
+                    if entry.kind == DbKind::Mongo {
+                        match mongodb::Client::with_uri_str(&url).await {
+                            Ok(client) => match client
+                                .database("admin")
+                                .run_command(doc! { "ping": 1 })
+                                .await
+                            {
+                                Ok(_) => send_ok(&tx),
+                                Err(e) => {
+                                    let _ = tx.send(DbEvent::TestConnectionResult {
+                                        success: false,
+                                        message: format!("Connection failed: {}", e),
+                                    });
+                                }
+                            },
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::TestConnectionResult {
+                                    success: false,
+                                    message: format!("Connection failed: {}", e),
+                                });
+                            }
+                        }
+                        return;
+                    }
+
+                    let ssl_mode = match resolve_ssl_mode(&url) {
+                        Ok(m) => m,
+                        Err(msg) => {
+                            let _ = tx.send(DbEvent::TestConnectionResult {
+                                success: false,
+                                message: format!("Connection failed: {msg}"),
+                            });
+                            return;
+                        }
                     };
 
                     match ssl_mode {
@@ -6147,6 +7276,11 @@ impl App {
     }
 
     fn load_schema(&mut self) {
+        if self.db.kind == Some(DbKind::Mongo) {
+            self.load_mongo_schema();
+            return;
+        }
+
         let Some(client) = self.db.client.clone() else {
             return;
         };
@@ -6218,6 +7352,53 @@ impl App {
                 }
                 Err(_) => {
                     // Schema loading failed silently - not critical
+                }
+            }
+        });
+    }
+
+    fn load_mongo_schema(&mut self) {
+        let Some(client) = self.db.mongo_client.clone() else {
+            return;
+        };
+        let db_name = self
+            .db
+            .mongo_database
+            .clone()
+            .unwrap_or_else(|| "admin".to_string());
+        let tx = self.db_events_tx.clone();
+
+        self.rt.spawn(async move {
+            let db = client.database(&db_name);
+            let mut tables = Vec::new();
+
+            match db.list_collection_names().await {
+                Ok(collections) => {
+                    for collection_name in collections {
+                        let coll = db.collection::<Document>(&collection_name);
+                        let sample = coll.find_one(doc! {}).await.ok().flatten();
+                        let columns = sample
+                            .map(|doc| {
+                                doc.iter()
+                                    .map(|(k, v)| ColumnInfo {
+                                        name: k.clone(),
+                                        data_type: bson_type_name(v).to_string(),
+                                    })
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default();
+                        tables.push(TableInfo {
+                            schema: db_name.clone(),
+                            name: collection_name,
+                            columns,
+                        });
+                    }
+                    let _ = tx.send(DbEvent::SchemaLoaded { tables });
+                }
+                Err(e) => {
+                    let _ = tx.send(DbEvent::QueryError {
+                        error: format!("Mongo schema load failed: {e}"),
+                    });
                 }
             }
         });
@@ -6356,19 +7537,6 @@ impl App {
             .map(|s| ConnectionInfo::parse(s).format(50));
         self.history.push(query.clone(), conn_info);
 
-        let Some(client) = self.db.client.clone() else {
-            self.last_error =
-                Some("Not connected. Use :connect <url> or set DATABASE_URL.".to_string());
-            return;
-        };
-
-        // If a previous paged query is still active, abandon it so we can run a new one.
-        // Dropping `paged_query` closes the fetch-more channel; the background cursor task
-        // will see `recv().await` return None, issue `CLOSE tsql_cursor`, and exit.
-        if self.paged_query.is_some() {
-            self.paged_query = None;
-        }
-
         // Only block if a query is actively running (not just an idle paged cursor)
         if self.db.running {
             self.last_status = Some("Query already running".to_string());
@@ -6380,8 +7548,42 @@ impl App {
         self.query_ui.start();
 
         let tx = self.db_events_tx.clone();
-        let source_table = extract_table_from_query(&query);
         let max_rows = effective_max_rows(self.config.connection.max_rows);
+
+        if self.db.kind == Some(DbKind::Mongo) {
+            let Some(client) = self.db.mongo_client.clone() else {
+                self.last_error =
+                    Some("Not connected. Use :connect <mongodb://...> first.".to_string());
+                self.db.running = false;
+                self.query_ui.clear();
+                return;
+            };
+            let db_name = self
+                .db
+                .mongo_database
+                .clone()
+                .unwrap_or_else(|| "admin".to_string());
+            self.paged_query = None;
+            self.execute_query_mongo(client, db_name, query, max_rows, tx);
+            return;
+        }
+
+        let Some(client) = self.db.client.clone() else {
+            self.last_error =
+                Some("Not connected. Use :connect <url> or set DATABASE_URL.".to_string());
+            self.db.running = false;
+            self.query_ui.clear();
+            return;
+        };
+
+        // If a previous paged query is still active, abandon it so we can run a new one.
+        // Dropping `paged_query` closes the fetch-more channel; the background cursor task
+        // will see `recv().await` return None, issue `CLOSE tsql_cursor`, and exit.
+        if self.paged_query.is_some() {
+            self.paged_query = None;
+        }
+
+        let source_table = extract_table_from_query(&query);
         let page_size = DEFAULT_PAGE_SIZE;
 
         // Use cursor-based paging for simple SELECT queries
@@ -6790,6 +7992,341 @@ impl App {
         });
     }
 
+    fn execute_query_mongo(
+        &self,
+        client: SharedMongoClient,
+        db_name: String,
+        query: String,
+        max_rows: usize,
+        tx: mpsc::UnboundedSender<DbEvent>,
+    ) {
+        let started = Instant::now();
+
+        self.rt.spawn(async move {
+            let parsed = match parse_mongo_query(&query) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    let _ = tx.send(DbEvent::QueryError { error: e });
+                    return;
+                }
+            };
+
+            let source_collection = parsed.collection_name().to_string();
+            let db = client.database(&db_name);
+
+            let result = match parsed {
+                MongoQuery::Find {
+                    collection,
+                    filter,
+                    projection,
+                    limit,
+                } => {
+                    let coll = db.collection::<Document>(&collection);
+                    let mut action = coll.find(filter);
+                    if let Some(proj) = projection {
+                        action = action.projection(proj);
+                    }
+                    if let Some(limit) = limit {
+                        action = action.limit(limit);
+                    }
+                    match action.await {
+                        Ok(mut cursor) => {
+                            let mut docs = Vec::new();
+                            let mut truncated = false;
+                            while let Ok(Some(doc)) = cursor.try_next().await {
+                                if docs.len() >= max_rows {
+                                    truncated = true;
+                                    break;
+                                }
+                                docs.push(doc);
+                            }
+                            mongo_result_from_documents(
+                                docs,
+                                Some(collection),
+                                started.elapsed(),
+                                truncated,
+                            )
+                        }
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo find error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+                MongoQuery::FindOne {
+                    collection,
+                    filter,
+                    projection,
+                } => {
+                    let coll = db.collection::<Document>(&collection);
+                    let mut action = coll.find_one(filter);
+                    if let Some(proj) = projection {
+                        action = action.projection(proj);
+                    }
+                    match action.await {
+                        Ok(doc) => mongo_result_from_documents(
+                            doc.into_iter().collect(),
+                            Some(collection),
+                            started.elapsed(),
+                            false,
+                        ),
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo findOne error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+                MongoQuery::Aggregate {
+                    collection,
+                    pipeline,
+                } => {
+                    let coll = db.collection::<Document>(&collection);
+                    match coll.aggregate(pipeline).await {
+                        Ok(mut cursor) => {
+                            let mut docs = Vec::new();
+                            let mut truncated = false;
+                            while let Ok(Some(doc)) = cursor.try_next().await {
+                                if docs.len() >= max_rows {
+                                    truncated = true;
+                                    break;
+                                }
+                                docs.push(doc);
+                            }
+                            mongo_result_from_documents(
+                                docs,
+                                Some(collection),
+                                started.elapsed(),
+                                truncated,
+                            )
+                        }
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo aggregate error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+                MongoQuery::CountDocuments { collection, filter } => {
+                    let coll = db.collection::<Document>(&collection);
+                    match coll.count_documents(filter).await {
+                        Ok(count) => QueryResult {
+                            headers: vec!["count".to_string()],
+                            rows: vec![vec![count.to_string()]],
+                            command_tag: Some("countDocuments".to_string()),
+                            truncated: false,
+                            elapsed: started.elapsed(),
+                            source_table: Some(collection),
+                            primary_keys: Vec::new(),
+                            col_types: vec!["int64".to_string()],
+                        },
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo countDocuments error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+                MongoQuery::InsertOne {
+                    collection,
+                    document,
+                } => {
+                    let coll = db.collection::<Document>(&collection);
+                    match coll.insert_one(document).await {
+                        Ok(res) => {
+                            let inserted_id = bson_to_grid_cell(&res.inserted_id);
+                            QueryResult {
+                                headers: vec!["status".to_string(), "inserted_id".to_string()],
+                                rows: vec![vec!["insertOne".to_string(), inserted_id]],
+                                command_tag: Some("insertOne".to_string()),
+                                truncated: false,
+                                elapsed: started.elapsed(),
+                                source_table: Some(collection),
+                                primary_keys: Vec::new(),
+                                col_types: vec!["string".to_string(), "objectId".to_string()],
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo insertOne error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+                MongoQuery::InsertMany {
+                    collection,
+                    documents,
+                } => {
+                    let coll = db.collection::<Document>(&collection);
+                    match coll.insert_many(documents).await {
+                        Ok(res) => QueryResult {
+                            headers: vec!["status".to_string(), "inserted_count".to_string()],
+                            rows: vec![vec![
+                                "insertMany".to_string(),
+                                res.inserted_ids.len().to_string(),
+                            ]],
+                            command_tag: Some("insertMany".to_string()),
+                            truncated: false,
+                            elapsed: started.elapsed(),
+                            source_table: Some(collection),
+                            primary_keys: Vec::new(),
+                            col_types: vec!["string".to_string(), "int64".to_string()],
+                        },
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo insertMany error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+                MongoQuery::UpdateOne {
+                    collection,
+                    filter,
+                    update,
+                } => {
+                    let coll = db.collection::<Document>(&collection);
+                    match coll.update_one(filter, update).await {
+                        Ok(res) => QueryResult {
+                            headers: vec![
+                                "status".to_string(),
+                                "matched".to_string(),
+                                "modified".to_string(),
+                            ],
+                            rows: vec![vec![
+                                "updateOne".to_string(),
+                                res.matched_count.to_string(),
+                                res.modified_count.to_string(),
+                            ]],
+                            command_tag: Some("updateOne".to_string()),
+                            truncated: false,
+                            elapsed: started.elapsed(),
+                            source_table: Some(collection),
+                            primary_keys: Vec::new(),
+                            col_types: vec![
+                                "string".to_string(),
+                                "int64".to_string(),
+                                "int64".to_string(),
+                            ],
+                        },
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo updateOne error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+                MongoQuery::UpdateMany {
+                    collection,
+                    filter,
+                    update,
+                } => {
+                    let coll = db.collection::<Document>(&collection);
+                    match coll.update_many(filter, update).await {
+                        Ok(res) => QueryResult {
+                            headers: vec![
+                                "status".to_string(),
+                                "matched".to_string(),
+                                "modified".to_string(),
+                            ],
+                            rows: vec![vec![
+                                "updateMany".to_string(),
+                                res.matched_count.to_string(),
+                                res.modified_count.to_string(),
+                            ]],
+                            command_tag: Some("updateMany".to_string()),
+                            truncated: false,
+                            elapsed: started.elapsed(),
+                            source_table: Some(collection),
+                            primary_keys: Vec::new(),
+                            col_types: vec![
+                                "string".to_string(),
+                                "int64".to_string(),
+                                "int64".to_string(),
+                            ],
+                        },
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo updateMany error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+                MongoQuery::DeleteOne { collection, filter } => {
+                    let coll = db.collection::<Document>(&collection);
+                    match coll.delete_one(filter).await {
+                        Ok(res) => QueryResult {
+                            headers: vec!["status".to_string(), "deleted".to_string()],
+                            rows: vec![vec![
+                                "deleteOne".to_string(),
+                                res.deleted_count.to_string(),
+                            ]],
+                            command_tag: Some("deleteOne".to_string()),
+                            truncated: false,
+                            elapsed: started.elapsed(),
+                            source_table: Some(collection),
+                            primary_keys: Vec::new(),
+                            col_types: vec!["string".to_string(), "int64".to_string()],
+                        },
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo deleteOne error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+                MongoQuery::DeleteMany { collection, filter } => {
+                    let coll = db.collection::<Document>(&collection);
+                    match coll.delete_many(filter).await {
+                        Ok(res) => QueryResult {
+                            headers: vec!["status".to_string(), "deleted".to_string()],
+                            rows: vec![vec![
+                                "deleteMany".to_string(),
+                                res.deleted_count.to_string(),
+                            ]],
+                            command_tag: Some("deleteMany".to_string()),
+                            truncated: false,
+                            elapsed: started.elapsed(),
+                            source_table: Some(collection),
+                            primary_keys: Vec::new(),
+                            col_types: vec!["string".to_string(), "int64".to_string()],
+                        },
+                        Err(e) => {
+                            let _ = tx.send(DbEvent::QueryError {
+                                error: format!("Mongo deleteMany error: {e}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+            };
+
+            let _ = tx.send(DbEvent::MetadataLoaded {
+                primary_keys: if result.headers.iter().any(|h| h == "_id") {
+                    vec!["_id".to_string()]
+                } else {
+                    Vec::new()
+                },
+                col_types: result.col_types.clone(),
+            });
+            let _ = tx.send(DbEvent::QueryFinished {
+                result: QueryResult {
+                    source_table: Some(source_collection),
+                    ..result
+                },
+            });
+        });
+    }
+
     /// Check if we should fetch more rows for a paged query.
     /// Called after grid navigation to implement auto-fetch on scroll.
     fn maybe_fetch_more_rows(&mut self) {
@@ -6831,6 +8368,13 @@ impl App {
         let paged_loading = self.paged_query.as_ref().is_some_and(|p| p.loading);
 
         if !self.db.running && !paged_loading {
+            return;
+        }
+
+        if self.db.kind == Some(DbKind::Mongo) {
+            self.last_status = Some(
+                "Mongo cancellation is not yet supported; wait for query completion".to_string(),
+            );
             return;
         }
 
@@ -6881,7 +8425,10 @@ impl App {
                 connected_with_tls,
             } => {
                 self.db.status = DbStatus::Connected;
+                self.db.kind = Some(DbKind::Postgres);
                 self.db.client = Some(client);
+                self.db.mongo_client = None;
+                self.db.mongo_database = None;
                 self.db.cancel_token = Some(cancel_token);
                 self.db.running = false;
                 self.db.connected_with_tls = connected_with_tls;
@@ -6890,9 +8437,28 @@ impl App {
                 // Load schema for completion
                 self.load_schema();
             }
+            DbEvent::MongoConnected { client, database } => {
+                self.db.status = DbStatus::Connected;
+                self.db.kind = Some(DbKind::Mongo);
+                self.db.client = None;
+                self.db.mongo_client = Some(client);
+                self.db.mongo_database = Some(database.clone());
+                self.db.cancel_token = None;
+                self.db.running = false;
+                self.db.in_transaction = false;
+                self.db.connected_with_tls = true;
+                self.query_ui.clear();
+                self.last_status = Some(format!(
+                    "Connected to Mongo ({database}), loading schema..."
+                ));
+                self.load_schema();
+            }
             DbEvent::ConnectError { error } => {
                 self.db.status = DbStatus::Error;
+                self.db.kind = None;
                 self.db.client = None;
+                self.db.mongo_client = None;
+                self.db.mongo_database = None;
                 self.db.running = false;
                 self.query_ui.clear();
                 self.current_connection_name = None;
@@ -6901,7 +8467,10 @@ impl App {
             }
             DbEvent::ConnectionLost { error } => {
                 self.db.status = DbStatus::Error;
+                self.db.kind = None;
                 self.db.client = None;
+                self.db.mongo_client = None;
+                self.db.mongo_database = None;
                 self.db.running = false;
                 self.query_ui.clear();
                 self.current_connection_name = None;
@@ -6939,8 +8508,11 @@ impl App {
                     .with_col_types(result.col_types);
                 self.grid_state = GridState::default();
 
-                // Update command_tag to reflect actual row count
-                self.db.last_command_tag = Some(format!("{} rows", self.grid.rows.len()));
+                // Prefer engine-provided command tag, fallback to row count.
+                self.db.last_command_tag = result
+                    .command_tag
+                    .clone()
+                    .or_else(|| Some(format!("{} rows", self.grid.rows.len())));
 
                 // Update paged query state with initial load
                 if let Some(ref mut paged) = self.paged_query {
@@ -7110,7 +8682,12 @@ impl App {
         // Connection info
         let conn_segment = if self.db.status == DbStatus::Connected {
             if let Some(ref conn_str) = self.db.conn_str {
-                let info = ConnectionInfo::parse(conn_str);
+                let mut info = ConnectionInfo::parse(conn_str);
+                if self.db.kind == Some(DbKind::Mongo) {
+                    if let Some(active_db) = self.db.mongo_database.as_ref() {
+                        info.database = Some(active_db.clone());
+                    }
+                }
                 // Allow up to 30 chars for connection, will be auto-truncated if needed
                 info.format(30)
             } else {
@@ -8729,6 +10306,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_mongo_use_updates_conninfo_database() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+        app.connection_picker = None;
+        app.connection_manager = None;
+
+        app.db.status = DbStatus::Connected;
+        app.db.kind = Some(DbKind::Mongo);
+        app.db.conn_str = Some("mongodb://localhost:27017/tsql_smoke".to_string());
+        app.db.mongo_database = Some("tsql_smoke".to_string());
+
+        app.execute_command("use admin");
+        assert_eq!(app.db.mongo_database.as_deref(), Some("admin"));
+
+        app.execute_command("conninfo");
+        let status = app.last_status.unwrap_or_default();
+        assert!(
+            status.contains("Mongo database \"admin\""),
+            "expected conninfo to show active Mongo DB after :use; got: {status}"
+        );
+    }
+
     // ========== Connection Manager Issue Tests ==========
 
     /// Helper to type a string into the app by simulating key presses
@@ -8783,7 +10388,8 @@ mod tests {
         // Use a unique name based on test timestamp
         type_string(&mut app, "testconn_unique_12345");
 
-        // Tab to User field
+        // Tab to Type, then User field
+        app.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
         app.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
         type_string(&mut app, "postgres");
 

--- a/crates/tsql/src/config/connections.rs
+++ b/crates/tsql/src/config/connections.rs
@@ -14,6 +14,15 @@ use url::Url;
 /// Service name for keyring storage
 const KEYRING_SERVICE: &str = "tsql";
 
+/// Database engine kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum DbKind {
+    #[default]
+    Postgres,
+    Mongo,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum SslMode {
@@ -164,8 +173,14 @@ impl std::fmt::Display for ConnectionColor {
 /// A saved database connection entry
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConnectionEntry {
+    /// Database engine kind (defaults to Postgres for backward compatibility).
+    #[serde(default)]
+    pub kind: DbKind,
     /// Unique name for this connection
     pub name: String,
+    /// Full connection URI (used primarily for MongoDB).
+    #[serde(default)]
+    pub uri: Option<String>,
     /// Database host
     pub host: String,
     /// Database port (default: 5432)
@@ -205,7 +220,9 @@ fn default_port() -> u16 {
 impl Default for ConnectionEntry {
     fn default() -> Self {
         Self {
+            kind: DbKind::Postgres,
             name: String::new(),
+            uri: None,
             host: "localhost".to_string(),
             port: 5432,
             database: String::new(),
@@ -230,11 +247,27 @@ impl ConnectionEntry {
         }
     }
 
-    /// Build a PostgreSQL connection URL from the entry fields
+    /// Build a connection URL from the entry fields.
     ///
     /// If `password` is provided, it will be included in the URL.
     /// Otherwise, the URL will not contain authentication.
     pub fn to_url(&self, password: Option<&str>) -> String {
+        if self.kind == DbKind::Mongo {
+            if let Some(uri) = self.uri.as_ref() {
+                if let Some(pwd) = password {
+                    if let Ok(mut parsed) = Url::parse(uri) {
+                        // Best effort: set password only when username exists.
+                        if !parsed.username().is_empty() {
+                            let _ = parsed.set_password(Some(pwd));
+                            return parsed.to_string();
+                        }
+                    }
+                }
+                return uri.clone();
+            }
+            return "mongodb://localhost".to_string();
+        }
+
         let mut url = "postgres://".to_string();
 
         // Add user
@@ -266,22 +299,30 @@ impl ConnectionEntry {
         url
     }
 
-    /// Parse a PostgreSQL URL and create a ConnectionEntry
+    /// Parse a URL and create a ConnectionEntry.
     ///
     /// Returns the entry and the password if one was found in the URL.
     pub fn from_url(name: &str, url_str: &str) -> Result<(Self, Option<String>)> {
         let url = Url::parse(url_str).context("Invalid URL format")?;
-
-        if url.scheme() != "postgres" && url.scheme() != "postgresql" {
-            return Err(anyhow!("URL must use postgres:// or postgresql:// scheme"));
-        }
+        let kind = match url.scheme() {
+            "postgres" | "postgresql" => DbKind::Postgres,
+            "mongodb" | "mongodb+srv" => DbKind::Mongo,
+            _ => {
+                return Err(anyhow!(
+                    "URL must use postgres://, postgresql://, mongodb://, or mongodb+srv:// scheme"
+                ))
+            }
+        };
 
         let host = url
             .host_str()
             .ok_or_else(|| anyhow!("URL must contain a host"))?
             .to_string();
 
-        let port = url.port().unwrap_or(5432);
+        let port = match kind {
+            DbKind::Postgres => url.port().unwrap_or(5432),
+            DbKind::Mongo => url.port().unwrap_or(27017),
+        };
 
         let database = url.path().trim_start_matches('/').to_string();
         if database.is_empty() {
@@ -290,9 +331,13 @@ impl ConnectionEntry {
 
         let user = if url.username().is_empty() {
             // Try to get from environment or use a default
+            let fallback = match kind {
+                DbKind::Postgres => "postgres",
+                DbKind::Mongo => "mongo",
+            };
             std::env::var("USER")
                 .or_else(|_| std::env::var("USERNAME"))
-                .unwrap_or_else(|_| "postgres".to_string())
+                .unwrap_or_else(|_| fallback.to_string())
         } else {
             url.username().to_string()
         };
@@ -306,16 +351,30 @@ impl ConnectionEntry {
         // If password is in URL, we have a password; if not, assume no password required
         let no_password_required = password.is_none();
 
-        let ssl_mode = url.query_pairs().find_map(|(k, v)| {
-            if k.eq_ignore_ascii_case("sslmode") {
-                SslMode::parse(&v)
-            } else {
-                None
-            }
-        });
+        let ssl_mode = if kind == DbKind::Postgres {
+            url.query_pairs().find_map(|(k, v)| {
+                if k.eq_ignore_ascii_case("sslmode") {
+                    SslMode::parse(&v)
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        };
+
+        let sanitized_uri = if kind == DbKind::Mongo {
+            let mut clean = url.clone();
+            let _ = clean.set_password(None);
+            Some(clean.to_string())
+        } else {
+            None
+        };
 
         let entry = ConnectionEntry {
+            kind,
             name: name.to_string(),
+            uri: sanitized_uri,
             host,
             port,
             database,
@@ -549,6 +608,12 @@ impl ConnectionEntry {
 
     /// Format connection for display (without password)
     pub fn display_string(&self) -> String {
+        if self.kind == DbKind::Mongo {
+            return self
+                .uri
+                .clone()
+                .unwrap_or_else(|| "mongodb://localhost".to_string());
+        }
         format!(
             "{}@{}:{}/{}",
             self.user, self.host, self.port, self.database
@@ -557,6 +622,22 @@ impl ConnectionEntry {
 
     /// Short display format for status line
     pub fn short_display(&self) -> String {
+        if self.kind == DbKind::Mongo {
+            let uri = self
+                .uri
+                .as_deref()
+                .unwrap_or("mongodb://localhost")
+                .to_string();
+            if let Ok(parsed) = Url::parse(&uri) {
+                let host = parsed.host_str().unwrap_or("localhost");
+                let db = parsed.path().trim_start_matches('/');
+                if db.is_empty() {
+                    return format!("mongodb://{}", host);
+                }
+                return format!("mongodb://{}/{}", host, db);
+            }
+            return uri;
+        }
         if self.port == 5432 {
             format!("{}@{}/{}", self.user, self.host, self.database)
         } else {
@@ -575,17 +656,32 @@ impl ConnectionEntry {
         if self.name.contains(char::is_whitespace) {
             return Err(anyhow!("Connection name cannot contain whitespace"));
         }
-        if self.host.is_empty() {
-            return Err(anyhow!("Host cannot be empty"));
-        }
-        if self.database.is_empty() {
-            return Err(anyhow!("Database name cannot be empty"));
-        }
-        if self.user.is_empty() {
-            return Err(anyhow!("Username cannot be empty"));
-        }
-        if self.port == 0 {
-            return Err(anyhow!("Port cannot be 0"));
+        match self.kind {
+            DbKind::Postgres => {
+                if self.host.is_empty() {
+                    return Err(anyhow!("Host cannot be empty"));
+                }
+                if self.database.is_empty() {
+                    return Err(anyhow!("Database name cannot be empty"));
+                }
+                if self.user.is_empty() {
+                    return Err(anyhow!("Username cannot be empty"));
+                }
+                if self.port == 0 {
+                    return Err(anyhow!("Port cannot be 0"));
+                }
+            }
+            DbKind::Mongo => {
+                let Some(uri) = self.uri.as_deref() else {
+                    return Err(anyhow!("Mongo connections require a URI"));
+                };
+                let parsed = Url::parse(uri).context("Invalid Mongo URI format")?;
+                if parsed.scheme() != "mongodb" && parsed.scheme() != "mongodb+srv" {
+                    return Err(anyhow!(
+                        "Mongo URI must use mongodb:// or mongodb+srv:// scheme"
+                    ));
+                }
+            }
         }
         if let Some(fav) = self.favorite {
             if fav == 0 || fav > 9 {
@@ -841,6 +937,7 @@ mod tests {
     #[test]
     fn test_connection_entry_default() {
         let entry = ConnectionEntry::default();
+        assert_eq!(entry.kind, DbKind::Postgres);
         assert_eq!(entry.host, "localhost");
         assert_eq!(entry.port, 5432);
         assert_eq!(entry.color, ConnectionColor::None);
@@ -1038,6 +1135,56 @@ mod tests {
     fn test_connection_from_url_no_database() {
         let result = ConnectionEntry::from_url("test", "postgres://user@localhost/");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_connection_from_url_mongodb_parses_kind_and_sanitizes_uri() {
+        let (entry, password) = ConnectionEntry::from_url(
+            "mongo",
+            "mongodb://admin:secret@mongo.example.com:27018/sample?authSource=admin",
+        )
+        .unwrap();
+        assert_eq!(entry.kind, DbKind::Mongo);
+        assert_eq!(entry.host, "mongo.example.com");
+        assert_eq!(entry.port, 27018);
+        assert_eq!(entry.database, "sample");
+        assert_eq!(entry.user, "admin");
+        assert_eq!(password.as_deref(), Some("secret"));
+        assert!(entry.uri.is_some());
+        let uri = entry.uri.as_deref().unwrap_or("");
+        assert!(!uri.contains("secret"));
+        assert!(uri.contains("authSource=admin"));
+    }
+
+    #[test]
+    fn test_connection_to_url_mongodb_includes_password_for_runtime_connection() {
+        let entry = ConnectionEntry {
+            kind: DbKind::Mongo,
+            name: "mongo".to_string(),
+            uri: Some("mongodb://admin@mongo.example.com:27018/sample".to_string()),
+            host: "mongo.example.com".to_string(),
+            port: 27018,
+            database: "sample".to_string(),
+            user: "admin".to_string(),
+            ..Default::default()
+        };
+        let url = entry.to_url(Some("secret"));
+        assert_eq!(url, "mongodb://admin:secret@mongo.example.com:27018/sample");
+    }
+
+    #[test]
+    fn test_connection_validate_mongodb_requires_uri() {
+        let entry = ConnectionEntry {
+            kind: DbKind::Mongo,
+            name: "mongo".to_string(),
+            uri: None,
+            host: "mongo.example.com".to_string(),
+            port: 27017,
+            database: "sample".to_string(),
+            user: "admin".to_string(),
+            ..Default::default()
+        };
+        assert!(entry.validate().is_err());
     }
 
     #[test]

--- a/crates/tsql/src/config/connections.rs
+++ b/crates/tsql/src/config/connections.rs
@@ -183,7 +183,11 @@ pub struct ConnectionEntry {
     pub uri: Option<String>,
     /// Database host
     pub host: String,
-    /// Database port (default: 5432)
+    /// Database port.
+    ///
+    /// Defaults via `default_port` (5432), which is Postgres-centric.
+    /// For Mongo connections, the port in `uri` is authoritative and this
+    /// field is mostly legacy/backward-compat metadata.
     #[serde(default = "default_port")]
     pub port: u16,
     /// Database name
@@ -214,6 +218,7 @@ pub struct ConnectionEntry {
 }
 
 fn default_port() -> u16 {
+    // Postgres default. Mongo defaults come from the parsed URI.
     5432
 }
 

--- a/crates/tsql/src/config/connections.rs
+++ b/crates/tsql/src/config/connections.rs
@@ -325,19 +325,17 @@ impl ConnectionEntry {
         };
 
         let database = url.path().trim_start_matches('/').to_string();
-        if database.is_empty() {
+        if kind == DbKind::Postgres && database.is_empty() {
             return Err(anyhow!("URL must contain a database name"));
         }
 
         let user = if url.username().is_empty() {
-            // Try to get from environment or use a default
-            let fallback = match kind {
-                DbKind::Postgres => "postgres",
-                DbKind::Mongo => "mongo",
-            };
-            std::env::var("USER")
-                .or_else(|_| std::env::var("USERNAME"))
-                .unwrap_or_else(|_| fallback.to_string())
+            match kind {
+                DbKind::Postgres => std::env::var("USER")
+                    .or_else(|_| std::env::var("USERNAME"))
+                    .unwrap_or_else(|_| "postgres".to_string()),
+                DbKind::Mongo => String::new(),
+            }
         } else {
             url.username().to_string()
         };
@@ -1154,6 +1152,25 @@ mod tests {
         let uri = entry.uri.as_deref().unwrap_or("");
         assert!(!uri.contains("secret"));
         assert!(uri.contains("authSource=admin"));
+    }
+
+    #[test]
+    fn test_connection_from_url_mongodb_without_username_keeps_empty_user() {
+        let (entry, password) =
+            ConnectionEntry::from_url("mongo", "mongodb://mongo.example.com:27017/sample").unwrap();
+        assert_eq!(entry.kind, DbKind::Mongo);
+        assert_eq!(entry.user, "");
+        assert!(password.is_none());
+    }
+
+    #[test]
+    fn test_connection_from_url_mongodb_without_database_is_allowed() {
+        let (entry, password) = ConnectionEntry::from_url("mongo", "mongodb://localhost").unwrap();
+        assert_eq!(entry.kind, DbKind::Mongo);
+        assert_eq!(entry.database, "");
+        assert_eq!(entry.user, "");
+        assert!(password.is_none());
+        assert!(entry.uri.is_some());
     }
 
     #[test]

--- a/crates/tsql/src/config/keymap.rs
+++ b/crates/tsql/src/config/keymap.rs
@@ -98,6 +98,7 @@ pub enum Action {
 
     // Sidebar
     ToggleSidebar,
+    ToggleQueryHeight,
 
     // Goto sequences (triggered by g + key)
     GotoFirst,
@@ -175,6 +176,7 @@ impl Action {
             Action::TestConnection => "Test connection",
             Action::ClearField => "Clear current field",
             Action::ToggleSidebar => "Toggle sidebar",
+            Action::ToggleQueryHeight => "Toggle query pane height (min/max)",
             Action::GotoFirst => "Go to first row/document start",
             Action::GotoEditor => "Go to query editor",
             Action::GotoConnections => "Go to connections sidebar",
@@ -281,6 +283,7 @@ impl FromStr for Action {
 
             // Sidebar
             "toggle_sidebar" => Ok(Action::ToggleSidebar),
+            "toggle_query_height" => Ok(Action::ToggleQueryHeight),
 
             // Goto sequences
             "goto_first" => Ok(Action::GotoFirst),
@@ -607,6 +610,10 @@ impl Keymap {
             KeyBinding::new(KeyCode::Char('i'), KeyModifiers::NONE),
             Action::FocusQuery,
         );
+        km.bind(
+            KeyBinding::new(KeyCode::Char('m'), KeyModifiers::ALT),
+            Action::ToggleQueryHeight,
+        );
 
         // Display
         km.bind(
@@ -770,6 +777,10 @@ impl Keymap {
         km.bind(
             KeyBinding::new(KeyCode::Tab, KeyModifiers::NONE),
             Action::ToggleFocus,
+        );
+        km.bind(
+            KeyBinding::new(KeyCode::Char('m'), KeyModifiers::ALT),
+            Action::ToggleQueryHeight,
         );
 
         // Show history picker
@@ -990,6 +1001,10 @@ mod tests {
         // Check search
         let slash = KeyBinding::new(KeyCode::Char('/'), KeyModifiers::NONE);
         assert_eq!(km.get(&slash), Some(&Action::StartSearch));
+
+        // Query height toggle
+        let alt_m = KeyBinding::new(KeyCode::Char('m'), KeyModifiers::ALT);
+        assert_eq!(km.get(&alt_m), Some(&Action::ToggleQueryHeight));
     }
 
     #[test]
@@ -1027,6 +1042,10 @@ mod tests {
         assert_eq!(
             "goto_results".parse::<Action>().unwrap(),
             Action::GotoResults
+        );
+        assert_eq!(
+            "toggle_query_height".parse::<Action>().unwrap(),
+            Action::ToggleQueryHeight
         );
     }
 

--- a/crates/tsql/src/config/keymap.rs
+++ b/crates/tsql/src/config/keymap.rs
@@ -1020,6 +1020,14 @@ mod tests {
     }
 
     #[test]
+    fn test_default_editor_normal_keymap() {
+        let km = Keymap::default_editor_normal_keymap();
+
+        let alt_m = KeyBinding::new(KeyCode::Char('m'), KeyModifiers::ALT);
+        assert_eq!(km.get(&alt_m), Some(&Action::ToggleQueryHeight));
+    }
+
+    #[test]
     fn test_action_from_str() {
         assert_eq!("move_up".parse::<Action>().unwrap(), Action::MoveUp);
         assert_eq!("move_down".parse::<Action>().unwrap(), Action::MoveDown);

--- a/crates/tsql/src/config/keymap.rs
+++ b/crates/tsql/src/config/keymap.rs
@@ -835,6 +835,10 @@ impl Keymap {
             KeyBinding::new(KeyCode::Char('e'), KeyModifiers::CONTROL),
             Action::ExecuteQuery,
         );
+        km.bind(
+            KeyBinding::new(KeyCode::Char('m'), KeyModifiers::ALT),
+            Action::ToggleQueryHeight,
+        );
 
         // Standard editing shortcuts
         km.bind(
@@ -1003,6 +1007,14 @@ mod tests {
         assert_eq!(km.get(&slash), Some(&Action::StartSearch));
 
         // Query height toggle
+        let alt_m = KeyBinding::new(KeyCode::Char('m'), KeyModifiers::ALT);
+        assert_eq!(km.get(&alt_m), Some(&Action::ToggleQueryHeight));
+    }
+
+    #[test]
+    fn test_default_editor_insert_keymap() {
+        let km = Keymap::default_editor_insert_keymap();
+
         let alt_m = KeyBinding::new(KeyCode::Char('m'), KeyModifiers::ALT);
         assert_eq!(km.get(&alt_m), Some(&Action::ToggleQueryHeight));
     }

--- a/crates/tsql/src/config/mod.rs
+++ b/crates/tsql/src/config/mod.rs
@@ -12,7 +12,7 @@ mod schema;
 
 pub use connections::{
     connections_path, load_connections, save_connections, ConnectionColor, ConnectionEntry,
-    ConnectionsFile, SslMode,
+    ConnectionsFile, DbKind, SslMode,
 };
 pub use keymap::{Action, KeyBinding, Keymap};
 pub use schema::{

--- a/crates/tsql/src/main.rs
+++ b/crates/tsql/src/main.rs
@@ -139,13 +139,14 @@ fn build_url_from_libpq_env() -> LibpqEnvResult {
 }
 
 fn print_usage() {
-    eprintln!("tsql - A modern PostgreSQL CLI");
+    eprintln!("tsql - A modern SQL and MongoDB CLI");
     eprintln!();
     eprintln!("Usage: tsql [OPTIONS] [CONNECTION_URL]");
     eprintln!();
     eprintln!("Arguments:");
-    eprintln!("  [CONNECTION_URL]  PostgreSQL connection URL");
+    eprintln!("  [CONNECTION_URL]  Connection URL");
     eprintln!("                    (e.g., postgres://user:pass@host:5432/dbname)");
+    eprintln!("                    (or mongodb://user:pass@host:27017/dbname)");
     eprintln!();
     eprintln!("Options:");
     eprintln!("  -h, --help        Print this help message");
@@ -171,6 +172,7 @@ fn print_usage() {
     eprintln!();
     eprintln!("Examples:");
     eprintln!("  tsql postgres://localhost/mydb");
+    eprintln!("  tsql mongodb://localhost:27017/mydb");
     eprintln!("  DATABASE_URL=postgres://localhost/mydb tsql");
     eprintln!("  tsql --debug-keys");
     eprintln!("  tsql --debug-keys --mouse");

--- a/crates/tsql/src/ui/connection_form.rs
+++ b/crates/tsql/src/ui/connection_form.rs
@@ -13,14 +13,16 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
+use url::Url;
 
-use crate::config::{Action, ConnectionColor, ConnectionEntry, Keymap, SslMode};
+use crate::config::{Action, ConnectionColor, ConnectionEntry, DbKind, Keymap, SslMode};
 
 /// Which field is currently focused in the form
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FormField {
     #[default]
     Name,
+    Kind,
     Host,
     Port,
     Database,
@@ -35,10 +37,11 @@ pub enum FormField {
 
 impl FormField {
     /// Get the next field in tab order
-    /// Order: Name → User → Password → OnePasswordRef → SavePassword → SSL Mode → Host → Port → Database → Color → UrlPaste
+    /// Order: Name → Kind → User → Password → OnePasswordRef → SavePassword → SSL Mode → Host → Port → Database → Color → UrlPaste
     pub fn next(self) -> Self {
         match self {
-            FormField::Name => FormField::User,
+            FormField::Name => FormField::Kind,
+            FormField::Kind => FormField::User,
             FormField::User => FormField::Password,
             FormField::Password => FormField::OnePasswordRef,
             FormField::OnePasswordRef => FormField::SavePassword,
@@ -56,7 +59,8 @@ impl FormField {
     pub fn prev(self) -> Self {
         match self {
             FormField::Name => FormField::UrlPaste,
-            FormField::User => FormField::Name,
+            FormField::Kind => FormField::Name,
+            FormField::User => FormField::Kind,
             FormField::Password => FormField::User,
             FormField::OnePasswordRef => FormField::Password,
             FormField::SavePassword => FormField::OnePasswordRef,
@@ -105,6 +109,8 @@ pub enum ConnectionFormAction {
 pub struct ConnectionFormModal {
     /// Current field values
     name: String,
+    kind: DbKind,
+    mongo_uri: Option<String>,
     host: String,
     port: String,
     database: String,
@@ -160,6 +166,8 @@ pub struct ConnectionFormModal {
 #[derive(Clone)]
 struct OriginalFormValues {
     name: String,
+    kind: DbKind,
+    mongo_uri: Option<String>,
     host: String,
     port: String,
     database: String,
@@ -186,6 +194,8 @@ impl ConnectionFormModal {
     pub fn with_keymap_and_onepassword(keymap: Keymap, onepassword_enabled: bool) -> Self {
         Self {
             name: String::new(),
+            kind: DbKind::Postgres,
+            mongo_uri: None,
             host: "localhost".to_string(),
             port: "5432".to_string(),
             database: String::new(),
@@ -253,6 +263,8 @@ impl ConnectionFormModal {
 
         let original_values = OriginalFormValues {
             name: entry.name.clone(),
+            kind: entry.kind,
+            mongo_uri: entry.uri.clone(),
             host: entry.host.clone(),
             port: entry.port.to_string(),
             database: entry.database.clone(),
@@ -269,6 +281,8 @@ impl ConnectionFormModal {
 
         Self {
             name: entry.name.clone(),
+            kind: entry.kind,
+            mongo_uri: entry.uri.clone(),
             host: entry.host.clone(),
             port: entry.port.to_string(),
             database: entry.database.clone(),
@@ -311,6 +325,8 @@ impl ConnectionFormModal {
         // For new connections, check if any required field has content
         if self.original_values.is_none() {
             return !self.name.is_empty()
+                || self.kind != DbKind::Postgres
+                || self.mongo_uri.is_some()
                 || !self.user.is_empty()
                 || !self.password.is_empty()
                 || !self.op_ref.is_empty()
@@ -323,6 +339,8 @@ impl ConnectionFormModal {
         // For editing, compare with original values
         if let Some(ref orig) = self.original_values {
             return self.name != orig.name
+                || self.kind != orig.kind
+                || self.mongo_uri != orig.mongo_uri
                 || self.host != orig.host
                 || self.port != orig.port
                 || self.database != orig.database
@@ -410,6 +428,12 @@ impl ConnectionFormModal {
                 ConnectionFormAction::Continue
             }
 
+            // Enter on kind cycles
+            (KeyCode::Enter, KeyModifiers::NONE) if self.focused == FormField::Kind => {
+                self.cycle_kind(1);
+                ConnectionFormAction::Continue
+            }
+
             // Enter on color cycles to next
             (KeyCode::Enter, KeyModifiers::NONE) if self.focused == FormField::Color => {
                 self.cycle_color(1);
@@ -434,6 +458,12 @@ impl ConnectionFormModal {
                 ConnectionFormAction::Continue
             }
 
+            // Space cycles kind
+            (KeyCode::Char(' '), KeyModifiers::NONE) if self.focused == FormField::Kind => {
+                self.cycle_kind(1);
+                ConnectionFormAction::Continue
+            }
+
             // Space cycles ssl mode
             (KeyCode::Char(' '), KeyModifiers::NONE) if self.focused == FormField::SslMode => {
                 self.cycle_ssl_mode(1);
@@ -447,6 +477,16 @@ impl ConnectionFormModal {
             }
             (KeyCode::Right, KeyModifiers::NONE) if self.focused == FormField::Color => {
                 self.cycle_color(1);
+                ConnectionFormAction::Continue
+            }
+
+            // Left/Right on kind cycles
+            (KeyCode::Left, KeyModifiers::NONE) if self.focused == FormField::Kind => {
+                self.cycle_kind(-1);
+                ConnectionFormAction::Continue
+            }
+            (KeyCode::Right, KeyModifiers::NONE) if self.focused == FormField::Kind => {
+                self.cycle_kind(1);
                 ConnectionFormAction::Continue
             }
 
@@ -526,7 +566,9 @@ impl ConnectionFormModal {
             FormField::Password => Some((&mut self.password, &mut self.password_cursor)),
             FormField::OnePasswordRef => Some((&mut self.op_ref, &mut self.op_ref_cursor)),
             FormField::UrlPaste => Some((&mut self.url_paste, &mut self.url_paste_cursor)),
-            FormField::SavePassword | FormField::SslMode | FormField::Color => None,
+            FormField::Kind | FormField::SavePassword | FormField::SslMode | FormField::Color => {
+                None
+            }
         }
     }
 
@@ -603,10 +645,152 @@ impl ConnectionFormModal {
             .unwrap_or(ConnectionColor::None);
     }
 
+    fn cycle_kind(&mut self, direction: i32) {
+        const ORDER: [DbKind; 2] = [DbKind::Postgres, DbKind::Mongo];
+        let current_idx = ORDER.iter().position(|k| *k == self.kind).unwrap_or(0) as i32;
+        let next_idx = ((current_idx + direction).rem_euclid(ORDER.len() as i32)) as usize;
+        self.kind = ORDER[next_idx];
+        match self.kind {
+            DbKind::Postgres => {
+                self.mongo_uri = None;
+                if self.port.is_empty() || self.port == "27017" {
+                    self.port = "5432".to_string();
+                    self.port_cursor = self.port.len();
+                }
+            }
+            DbKind::Mongo => {
+                if self.port.is_empty() || self.port == "5432" {
+                    self.port = "27017".to_string();
+                    self.port_cursor = self.port.len();
+                }
+                self.mongo_uri = Some(self.build_mongo_uri(None));
+            }
+        }
+    }
+
     fn cycle_ssl_mode(&mut self, direction: i32) {
+        if self.kind == DbKind::Mongo {
+            return;
+        }
         let len = SslMode::COUNT as i32;
         self.ssl_mode_index = ((self.ssl_mode_index as i32 + direction).rem_euclid(len)) as usize;
         self.ssl_mode = SslMode::from_index(self.ssl_mode_index);
+    }
+
+    fn mongo_scheme(&self) -> &'static str {
+        if self
+            .mongo_uri
+            .as_deref()
+            .is_some_and(|uri| uri.starts_with("mongodb+srv://"))
+        {
+            "mongodb+srv"
+        } else {
+            "mongodb"
+        }
+    }
+
+    fn build_mongo_uri(&self, password: Option<&str>) -> String {
+        let base = self.mongo_uri.as_deref().unwrap_or("mongodb://localhost");
+        let mut url = Url::parse(base)
+            .ok()
+            .or_else(|| Url::parse("mongodb://localhost").ok())
+            .expect("static Mongo URL should parse");
+
+        let host = if self.host.trim().is_empty() {
+            "localhost"
+        } else {
+            self.host.trim()
+        };
+        let _ = url.set_host(Some(host));
+
+        let scheme = self.mongo_scheme();
+        if scheme == "mongodb+srv" {
+            let _ = url.set_port(None);
+        } else {
+            let parsed_port = self.port.parse::<u16>().ok();
+            let port = parsed_port.or(url.port()).unwrap_or(27017);
+            let _ = url.set_port(Some(port));
+        }
+
+        let user = self.user.trim();
+        if user.is_empty() {
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+        } else {
+            let _ = url.set_username(user);
+            let _ = url.set_password(password);
+        }
+
+        if self.database.trim().is_empty() {
+            url.set_path("/");
+        } else {
+            url.set_path(&format!("/{}", self.database.trim()));
+        }
+
+        let mut built = url.to_string();
+        if scheme == "mongodb+srv" && built.starts_with("mongodb://") {
+            built = built.replacen("mongodb://", "mongodb+srv://", 1);
+        }
+        built
+    }
+
+    fn build_entry(&self, name: String, password_for_uri: Option<&str>) -> ConnectionEntry {
+        let op_ref = self.op_ref.trim();
+        let has_op_ref = !op_ref.is_empty();
+        let no_password_required = self.password.is_empty() && !self.save_password && !has_op_ref;
+
+        match self.kind {
+            DbKind::Postgres => {
+                let port = self.port.parse::<u16>().unwrap_or(5432);
+                ConnectionEntry {
+                    kind: DbKind::Postgres,
+                    name,
+                    uri: None,
+                    host: self.host.clone(),
+                    port,
+                    database: self.database.clone(),
+                    user: self.user.clone(),
+                    password_in_keychain: self.save_password && !self.password.is_empty(),
+                    password_env: None,
+                    password_onepassword: if has_op_ref {
+                        Some(op_ref.to_string())
+                    } else {
+                        None
+                    },
+                    no_password_required,
+                    color: self.color,
+                    favorite: None,
+                    ssl_mode: match self.ssl_mode {
+                        SslMode::Disable => None,
+                        other => Some(other),
+                    },
+                }
+            }
+            DbKind::Mongo => ConnectionEntry {
+                kind: DbKind::Mongo,
+                name,
+                uri: Some(self.build_mongo_uri(password_for_uri)),
+                host: if self.host.trim().is_empty() {
+                    "localhost".to_string()
+                } else {
+                    self.host.trim().to_string()
+                },
+                port: self.port.parse::<u16>().unwrap_or(27017),
+                database: self.database.clone(),
+                user: self.user.clone(),
+                password_in_keychain: self.save_password && !self.password.is_empty(),
+                password_env: None,
+                password_onepassword: if has_op_ref {
+                    Some(op_ref.to_string())
+                } else {
+                    None
+                },
+                no_password_required,
+                color: self.color,
+                favorite: None,
+                ssl_mode: None,
+            },
+        }
     }
 
     fn process_url_paste(&mut self) -> ConnectionFormAction {
@@ -618,6 +802,8 @@ impl ConnectionFormModal {
         match ConnectionEntry::from_url("temp", &self.url_paste) {
             Ok((entry, password)) => {
                 // Populate fields from parsed URL
+                self.kind = entry.kind;
+                self.mongo_uri = entry.uri.clone();
                 self.host = entry.host;
                 self.port = entry.port.to_string();
                 self.database = entry.database;
@@ -669,51 +855,29 @@ impl ConnectionFormModal {
             self.focused = FormField::Host;
             return ConnectionFormAction::StatusMessage("Host is required".to_string());
         }
-        if self.database.is_empty() {
-            self.focused = FormField::Database;
-            return ConnectionFormAction::StatusMessage("Database is required".to_string());
-        }
-        if self.user.is_empty() {
-            self.focused = FormField::User;
-            return ConnectionFormAction::StatusMessage("User is required".to_string());
-        }
-
-        let port: u16 = match self.port.parse() {
-            Ok(p) if p > 0 => p,
-            _ => {
-                self.focused = FormField::Port;
-                return ConnectionFormAction::StatusMessage("Invalid port number".to_string());
+        if self.kind == DbKind::Postgres {
+            if self.database.is_empty() {
+                self.focused = FormField::Database;
+                return ConnectionFormAction::StatusMessage("Database is required".to_string());
             }
-        };
+            if self.user.is_empty() {
+                self.focused = FormField::User;
+                return ConnectionFormAction::StatusMessage("User is required".to_string());
+            }
+        }
 
-        // Auto-detect if no password is required:
-        // If password is empty and user didn't choose to save to keychain,
-        // assume the connection doesn't require a password
-        let op_ref = self.op_ref.trim();
-        let has_op_ref = !op_ref.is_empty();
-        let no_password_required = self.password.is_empty() && !self.save_password && !has_op_ref;
+        let needs_port = self.kind == DbKind::Postgres || self.mongo_scheme() != "mongodb+srv";
+        if needs_port {
+            match self.port.parse::<u16>() {
+                Ok(p) if p > 0 => p,
+                _ => {
+                    self.focused = FormField::Port;
+                    return ConnectionFormAction::StatusMessage("Invalid port number".to_string());
+                }
+            };
+        }
 
-        let entry = ConnectionEntry {
-            name: self.name.clone(),
-            host: self.host.clone(),
-            port,
-            database: self.database.clone(),
-            user: self.user.clone(),
-            password_in_keychain: self.save_password && !self.password.is_empty(),
-            password_env: None,
-            password_onepassword: if has_op_ref {
-                Some(op_ref.to_string())
-            } else {
-                None
-            },
-            no_password_required,
-            color: self.color,
-            favorite: None, // Preserve from original if editing
-            ssl_mode: match self.ssl_mode {
-                SslMode::Disable => None,
-                other => Some(other),
-            },
-        };
+        let entry = self.build_entry(self.name.clone(), None);
 
         let password = if self.password.is_empty() {
             None
@@ -734,62 +898,54 @@ impl ConnectionFormModal {
         if self.host.is_empty() {
             return ConnectionFormAction::StatusMessage("Host is required for test".to_string());
         }
-        if self.database.is_empty() {
-            return ConnectionFormAction::StatusMessage(
-                "Database is required for test".to_string(),
-            );
-        }
-        if self.user.is_empty() {
-            return ConnectionFormAction::StatusMessage("User is required for test".to_string());
-        }
-
-        let port: u16 = match self.port.parse() {
-            Ok(p) if p > 0 => p,
-            _ => {
-                return ConnectionFormAction::StatusMessage("Invalid port number".to_string());
+        if self.kind == DbKind::Postgres {
+            if self.database.is_empty() {
+                return ConnectionFormAction::StatusMessage(
+                    "Database is required for test".to_string(),
+                );
             }
-        };
+            if self.user.is_empty() {
+                return ConnectionFormAction::StatusMessage(
+                    "User is required for test".to_string(),
+                );
+            }
+        }
 
-        let op_ref = self.op_ref.trim();
-        let has_op_ref = !op_ref.is_empty();
-        let no_password_required = self.password.is_empty() && !self.save_password && !has_op_ref;
+        let needs_port = self.kind == DbKind::Postgres || self.mongo_scheme() != "mongodb+srv";
+        if needs_port {
+            match self.port.parse::<u16>() {
+                Ok(p) if p > 0 => p,
+                _ => {
+                    return ConnectionFormAction::StatusMessage("Invalid port number".to_string());
+                }
+            };
+        }
 
-        let entry = ConnectionEntry {
-            name: "test".to_string(),
-            host: self.host.clone(),
-            port,
-            database: self.database.clone(),
-            user: self.user.clone(),
-            password_in_keychain: false,
-            password_env: None,
-            password_onepassword: if has_op_ref {
-                Some(op_ref.to_string())
-            } else {
-                None
-            },
-            no_password_required,
-            color: ConnectionColor::None,
-            favorite: None,
-            ssl_mode: match self.ssl_mode {
-                SslMode::Disable => None,
-                other => Some(other),
-            },
-        };
-
-        let password = if self.password.is_empty() {
+        let test_password = if self.password.is_empty() {
             None
         } else {
             Some(self.password.clone())
         };
-
-        ConnectionFormAction::TestConnection { entry, password }
+        let entry = self.build_entry("test".to_string(), test_password.as_deref());
+        let mut entry = ConnectionEntry {
+            password_in_keychain: false,
+            color: ConnectionColor::None,
+            ..entry
+        };
+        if entry.kind == DbKind::Mongo {
+            entry.ssl_mode = None;
+        }
+        ConnectionFormAction::TestConnection {
+            entry,
+            password: test_password,
+        }
     }
 
     /// Render the connection form modal.
     pub fn render(&self, frame: &mut Frame, area: Rect) {
         // Calculate modal size
         let modal_width = 60u16.min(area.width - 4);
-        let modal_height = 20u16.min(area.height - 2);
+        let modal_height = 21u16.min(area.height - 2);
         let modal_x = (area.width - modal_width) / 2;
         let modal_y = (area.height - modal_height) / 2;
 
@@ -817,9 +973,10 @@ impl ConnectionFormModal {
         frame.render_widget(block, modal_area);
 
         // Layout the form fields.
-        // Order: Name → User → Password → [OnePasswordRef] → SavePassword → SSL Mode → Host → Port → Database → Color → UrlPaste
+        // Order: Name → Kind → User → Password → [OnePasswordRef] → SavePassword → SSL Mode → Host → Port → Database → Color → UrlPaste
         let mut constraints = vec![
             Constraint::Length(1), // Name
+            Constraint::Length(1), // Kind
             Constraint::Length(1), // Separator
             Constraint::Length(1), // User
             Constraint::Length(1), // Password
@@ -851,6 +1008,8 @@ impl ConnectionFormModal {
             self.name_cursor,
             FormField::Name,
         );
+        i += 1;
+        self.render_kind_field(frame, chunks[i]);
         i += 1;
         self.render_separator(frame, chunks[i]);
         i += 1;
@@ -1030,6 +1189,43 @@ impl ConnectionFormModal {
         frame.render_widget(widget, chunks[1]);
     }
 
+    fn render_kind_field(&self, frame: &mut Frame, area: Rect) {
+        let is_focused = self.focused == FormField::Kind;
+        let label_width = 10;
+
+        let chunks =
+            Layout::horizontal([Constraint::Length(label_width), Constraint::Min(1)]).split(area);
+
+        let label_style = if is_focused {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        let label_widget = Paragraph::new("Type:").style(label_style);
+        frame.render_widget(label_widget, chunks[0]);
+
+        let kind_name = match self.kind {
+            DbKind::Postgres => "Postgres",
+            DbKind::Mongo => "MongoDB",
+        };
+        let mut spans = vec![];
+        if is_focused {
+            spans.push(Span::styled("◀ ", Style::default().fg(Color::DarkGray)));
+        }
+        spans.push(Span::styled(
+            format!("{:<11}", kind_name),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ));
+        if is_focused {
+            spans.push(Span::styled(" ▶", Style::default().fg(Color::DarkGray)));
+        }
+
+        let widget = Paragraph::new(Line::from(spans));
+        frame.render_widget(widget, chunks[1]);
+    }
+
     fn render_color_field(&self, frame: &mut Frame, area: Rect) {
         let is_focused = self.focused == FormField::Color;
         let label_width = 10;
@@ -1082,18 +1278,30 @@ impl ConnectionFormModal {
         let label_widget = Paragraph::new("SSL:").style(label_style);
         frame.render_widget(label_widget, chunks[0]);
 
-        let mode_name = self.ssl_mode.as_str();
+        let mode_name = if self.kind == DbKind::Mongo {
+            "n/a"
+        } else {
+            self.ssl_mode.as_str()
+        };
         let mut spans = vec![];
-        if is_focused {
+        if is_focused && self.kind == DbKind::Postgres {
             spans.push(Span::styled("◀ ", Style::default().fg(Color::DarkGray)));
         }
         spans.push(Span::styled(
             format!("{:<11}", mode_name), // 11 chars to fit "verify-full"
             Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
+                .fg(if self.kind == DbKind::Mongo {
+                    Color::DarkGray
+                } else {
+                    Color::White
+                })
+                .add_modifier(if self.kind == DbKind::Mongo {
+                    Modifier::empty()
+                } else {
+                    Modifier::BOLD
+                }),
         ));
-        if is_focused {
+        if is_focused && self.kind == DbKind::Postgres {
             spans.push(Span::styled(" ▶", Style::default().fg(Color::DarkGray)));
         }
 
@@ -1120,7 +1328,7 @@ impl ConnectionFormModal {
         // Value with cursor or placeholder
         let (value_spans, style) = if self.url_paste.is_empty() && !is_focused {
             (
-                vec![Span::raw("postgres://user:pass@host/db")],
+                vec![Span::raw("postgres://... or mongodb://...")],
                 Style::default().fg(Color::DarkGray),
             )
         } else if is_focused {
@@ -1193,8 +1401,9 @@ mod tests {
 
     #[test]
     fn test_form_field_navigation() {
-        // Order: Name → User → Password → OnePasswordRef → SavePassword → SSL Mode → Host → Port → Database → Color → UrlPaste
-        assert_eq!(FormField::Name.next(), FormField::User);
+        // Order: Name → Kind → User → Password → OnePasswordRef → SavePassword → SSL Mode → Host → Port → Database → Color → UrlPaste
+        assert_eq!(FormField::Name.next(), FormField::Kind);
+        assert_eq!(FormField::Kind.next(), FormField::User);
         assert_eq!(FormField::User.next(), FormField::Password);
         assert_eq!(FormField::Password.next(), FormField::OnePasswordRef);
         assert_eq!(FormField::OnePasswordRef.next(), FormField::SavePassword);
@@ -1202,7 +1411,8 @@ mod tests {
         assert_eq!(FormField::SslMode.next(), FormField::Host);
         assert_eq!(FormField::UrlPaste.next(), FormField::Name);
         assert_eq!(FormField::Name.prev(), FormField::UrlPaste);
-        assert_eq!(FormField::User.prev(), FormField::Name);
+        assert_eq!(FormField::Kind.prev(), FormField::Name);
+        assert_eq!(FormField::User.prev(), FormField::Kind);
         assert_eq!(FormField::Password.prev(), FormField::User);
         assert_eq!(FormField::OnePasswordRef.prev(), FormField::Password);
         assert_eq!(FormField::SavePassword.prev(), FormField::OnePasswordRef);
@@ -1212,6 +1422,7 @@ mod tests {
     #[test]
     fn test_new_form_defaults() {
         let form = ConnectionFormModal::new();
+        assert_eq!(form.kind, DbKind::Postgres);
         assert_eq!(form.host, "localhost");
         assert_eq!(form.port, "5432");
         assert!(!form.editing);
@@ -1246,7 +1457,7 @@ mod tests {
         assert_eq!(form.focused, FormField::Name);
 
         form.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
-        assert_eq!(form.focused, FormField::User); // New order: Name → User
+        assert_eq!(form.focused, FormField::Kind); // New order: Name → Kind
 
         form.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
         assert_eq!(form.focused, FormField::Name);
@@ -1259,6 +1470,9 @@ mod tests {
             false,
         );
         assert_eq!(form.focused, FormField::Name);
+
+        form.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(form.focused, FormField::Kind);
 
         form.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
         assert_eq!(form.focused, FormField::User);
@@ -1284,6 +1498,9 @@ mod tests {
             true,
         );
         assert_eq!(form.focused, FormField::Name);
+
+        form.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(form.focused, FormField::Kind);
 
         form.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
         assert_eq!(form.focused, FormField::User);
@@ -1445,7 +1662,76 @@ mod tests {
         assert_eq!(form.database, "production");
         assert_eq!(form.user, "admin");
         assert_eq!(form.password, "secret");
+        assert_eq!(form.kind, DbKind::Postgres);
         assert!(form.url_paste.is_empty());
+    }
+
+    #[test]
+    fn test_url_paste_mongodb_sets_kind_and_uri() {
+        let mut form = ConnectionFormModal::new();
+        form.focused = FormField::UrlPaste;
+        form.url_paste =
+            "mongodb://admin:secret@mongo.example.com:27018/sample?authSource=admin".to_string();
+
+        let action = form.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(matches!(action, ConnectionFormAction::StatusMessage(_)));
+        assert_eq!(form.kind, DbKind::Mongo);
+        assert_eq!(form.host, "mongo.example.com");
+        assert_eq!(form.port, "27018");
+        assert_eq!(form.database, "sample");
+        assert_eq!(form.user, "admin");
+        assert_eq!(form.password, "secret");
+        let uri = form.mongo_uri.as_deref().unwrap_or("");
+        assert!(uri.starts_with("mongodb://admin@mongo.example.com:27018/sample"));
+        assert!(!uri.contains("secret"));
+    }
+
+    #[test]
+    fn test_save_mongodb_preserves_uri() {
+        let mut form = ConnectionFormModal::new();
+        form.name = "mongo1".to_string();
+        form.kind = DbKind::Mongo;
+        form.host = "mongo.example.com".to_string();
+        form.port = "27018".to_string();
+        form.database = "sample".to_string();
+        form.user = "admin".to_string();
+        form.mongo_uri =
+            Some("mongodb://admin@mongo.example.com:27018/sample?authSource=admin".to_string());
+
+        let action = form.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
+        match action {
+            ConnectionFormAction::Save { entry, .. } => {
+                assert_eq!(entry.kind, DbKind::Mongo);
+                assert!(entry.uri.is_some());
+                let uri = entry.uri.as_deref().unwrap_or("");
+                assert!(uri.contains("authSource=admin"));
+                assert!(!uri.contains(":secret@"));
+            }
+            other => panic!("Expected Save action, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_test_connection_mongodb_includes_password_in_runtime_url() {
+        let mut form = ConnectionFormModal::new();
+        form.kind = DbKind::Mongo;
+        form.host = "mongo.example.com".to_string();
+        form.port = "27018".to_string();
+        form.database = "sample".to_string();
+        form.user = "admin".to_string();
+        form.password = "secret".to_string();
+        form.mongo_uri = Some("mongodb://admin@mongo.example.com:27018/sample".to_string());
+
+        let action = form.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+        match action {
+            ConnectionFormAction::TestConnection { entry, password } => {
+                assert_eq!(entry.kind, DbKind::Mongo);
+                assert_eq!(password.as_deref(), Some("secret"));
+                let url = entry.to_url(password.as_deref());
+                assert!(url.contains("mongodb://admin:secret@mongo.example.com:27018/sample"));
+            }
+            other => panic!("Expected TestConnection action, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -76,6 +76,7 @@ const GLOBAL: HelpSection = HelpSection::new(
     "Global",
     &[
         KeyBinding::new("Tab", "Switch focus (Query/Grid)"),
+        KeyBinding::new("Alt+M", "Toggle query pane height (min/max)"),
         KeyBinding::new("Esc", "Return to normal mode / close popup"),
         KeyBinding::new("q", "Quit application"),
         KeyBinding::new("?", "Toggle this help  (/ to filter inside)"),

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -252,8 +252,12 @@ const COMMANDS: HelpSection = HelpSection::new(
 );
 
 const SCHEMA_COMMANDS: HelpSection = HelpSection::new(
-    "Schema Commands (psql-style)",
+    "Schema Commands",
     &[
+        KeyBinding::new(":show dbs", "Mongo: list databases"),
+        KeyBinding::new(":show collections", "Mongo: list collections"),
+        KeyBinding::new(":describe <collection>", "Mongo: describe collection"),
+        KeyBinding::new(":use <database>", "Mongo: switch active database"),
         KeyBinding::new(":\\dt", "List tables"),
         KeyBinding::new(":\\d <table>", "Describe table"),
         KeyBinding::new(":\\dn", "List schemas"),

--- a/crates/tsql/src/ui/highlighted_editor.rs
+++ b/crates/tsql/src/ui/highlighted_editor.rs
@@ -261,6 +261,11 @@ fn calculate_scroll_offset(
         if cursor_row < scroll_row {
             scroll_row = cursor_row;
         }
+        // If viewport got taller, reveal as many lines above the cursor as possible.
+        let max_top_for_cursor = cursor_row.saturating_sub(viewport_height - 1);
+        if scroll_row > max_top_for_cursor {
+            scroll_row = max_top_for_cursor;
+        }
         // If cursor is below the viewport, scroll down
         let viewport_bottom = scroll_row + viewport_height;
         if cursor_row >= viewport_bottom {
@@ -714,5 +719,11 @@ mod tests {
             pos.x < area.x + area.width,
             "Cursor x should be within viewport"
         );
+    }
+
+    #[test]
+    fn test_calculate_scroll_offset_reveals_more_above_cursor_when_viewport_expands() {
+        let (scroll_row, _scroll_col) = calculate_scroll_offset(10, 0, (8, 0), 6, 80);
+        assert_eq!(scroll_row, 5);
     }
 }

--- a/crates/tsql/src/ui/status_line.rs
+++ b/crates/tsql/src/ui/status_line.rs
@@ -69,15 +69,21 @@ pub struct ConnectionInfo {
 }
 
 impl ConnectionInfo {
-    /// Parse a PostgreSQL connection string
+    /// Parse a database connection string.
     /// Supports formats:
     /// - postgres://user:pass@host:port/database?params
     /// - postgresql://user:pass@host:port/database
+    /// - mongodb://user:pass@host:port/database?params
+    /// - mongodb+srv://user:pass@host/database?params
     /// - host=localhost user=postgres dbname=mydb port=5432
     pub fn parse(conn_str: &str) -> Self {
         let mut info = ConnectionInfo::default();
 
-        if conn_str.starts_with("postgres://") || conn_str.starts_with("postgresql://") {
+        if conn_str.starts_with("postgres://")
+            || conn_str.starts_with("postgresql://")
+            || conn_str.starts_with("mongodb://")
+            || conn_str.starts_with("mongodb+srv://")
+        {
             // URL format
             info.parse_url(conn_str);
         } else {
@@ -93,6 +99,8 @@ impl ConnectionInfo {
         let without_scheme = conn_str
             .strip_prefix("postgres://")
             .or_else(|| conn_str.strip_prefix("postgresql://"))
+            .or_else(|| conn_str.strip_prefix("mongodb://"))
+            .or_else(|| conn_str.strip_prefix("mongodb+srv://"))
             .unwrap_or(conn_str);
 
         // Split off query params


### PR DESCRIPTION
## Summary

This PR adds end-to-end MongoDB support in `tsql`.

- Adds MongoDB connection modeling (`DbKind`, URI-aware connection entries)
- Adds MongoDB connection, schema loading, and query execution runtime paths
- Adds Mongo command support (`:show dbs`, `:show collections`, `:describe`, `:use`)
- Updates connection form to support Postgres/Mongo selection and Mongo URI flows
- Extends docs/help/usage text for MongoDB support
- Adds tests for Mongo URL parsing, form behavior, and runtime command behavior

## Bug fix

Fixes the active-DB display mismatch after `:use` for Mongo connections by
making status/conninfo read the active runtime Mongo database.

Fixes #29.

## Verification

- `cargo fmt --all`
- `cargo check -p tsql`
- `cargo test -p tsql connection_form -- --nocapture`
- `cargo test -p tsql mongodb -- --nocapture`
- `cargo test --lib --bins -p tsql`
- manual tmux smoke test against local MongoDB (`:show collections`, `:describe`,
  `:show dbs`, `db.users.find(...)`, `:use`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MongoDB supported alongside PostgreSQL (connect, query, describe, switch DB).
  * New CLI commands: :show dbs, :show collections, :describe <collection>, :use <database>.
  * Connection form lets you choose Postgres or Mongo and accepts Mongo URIs.

* **Documentation**
  * README, Quick Start, CLI help and examples updated for MongoDB (including sample URI and requirements).

* **Improvements**
  * Status line and connection parsing recognize Mongo URLs.
  * Alt+M toggles query pane height.
  * Editor scrolling better reveals lines above the cursor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->