### PR TITLE
[codex] add ai query assistant and connection duplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +115,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -170,7 +204,7 @@ dependencies = [
  "indexmap",
  "js-sys",
  "once_cell",
- "rand",
+ "rand 0.9.2",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -236,10 +270,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -271,6 +317,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -657,10 +713,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -695,6 +766,17 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -875,6 +957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +1028,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,7 +1108,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.9.2",
  "ring",
  "thiserror 2.0.17",
  "tinyvec",
@@ -1017,7 +1130,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.9.2",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.17",
@@ -1032,6 +1145,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.1",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1231,6 +1444,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1469,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1356,6 +1601,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "macro_magic"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1669,28 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1500,7 +1773,7 @@ dependencies = [
  "mongodb-internal-macros",
  "pbkdf2",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "rustc_version_runtime",
  "rustls",
  "rustversion",
@@ -1542,6 +1815,25 @@ checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1662,10 +1954,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1731,6 +2038,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,7 +2101,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.9.2",
  "sha2",
  "stringprep",
 ]
@@ -1839,6 +2166,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,12 +2244,33 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1876,7 +2280,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1940,6 +2353,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,10 +2402,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
+name = "rig-core"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437fa2a15825caf2505411bbe55b05c8eb122e03934938b38f9ecaa1d6ded7c8"
+dependencies = [
+ "as-any",
+ "async-stream",
+ "base64",
+ "bytes",
+ "eventsource-stream",
+ "fastrand",
+ "futures",
+ "futures-timer",
+ "glob",
+ "http",
+ "mime",
+ "mime_guess",
+ "nanoid",
+ "ordered-float",
+ "pin-project-lite",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
 
 [[package]]
 name = "ring"
@@ -1987,6 +2496,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2064,13 +2579,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2097,12 +2652,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -2193,6 +2791,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2456,6 +3065,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,7 +3323,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.9.2",
  "socket2 0.6.1",
  "tokio",
  "tokio-util",
@@ -2804,13 +3422,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2820,6 +3495,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -2885,6 +3572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tsql"
 version = "0.5.0"
 dependencies = [
@@ -2901,6 +3594,7 @@ dependencies = [
  "nucleo-matcher",
  "percent-encoding",
  "ratatui",
+ "rig-core",
  "rustls",
  "semver",
  "serde",
@@ -2968,7 +3662,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaa316a028becd2f2cdd0f702d762c4847a908b4a37e193e5f45555f2d09c145"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "ratatui",
  "regex",
 ]
@@ -2998,6 +3692,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -3122,6 +3822,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3144,9 +3863,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3156,10 +3875,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.106"
+name = "wasm-bindgen-futures"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3167,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3180,21 +3913,53 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.83"
+name = "wasm-streams"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3253,6 +4018,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3321,6 +4095,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3362,6 +4145,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3414,6 +4212,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3432,6 +4236,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -3447,6 +4257,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3480,6 +4296,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -3495,6 +4317,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3516,6 +4344,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -3531,6 +4365,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.86"
 [workspace.dependencies]
 # Shared dependencies
 anyhow = "1"
+rig = { package = "rig-core", version = "0.31.0" }
 arboard = "3"
 crossterm = "0.28"
 ratatui = "0.29"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ If you like this crate show some support by [following fcoury (me) on X](https:/
 - **Postgres + MongoDB** - Connect with `postgres://...` or `mongodb://...` URLs
 - **Schema commands** - `psql`-style commands plus Mongo helpers (`:show dbs`, `:show collections`, `:describe`)
 - **Query history** - Persistent history with fuzzy search, pinning, and deletion
+- **AI query assistant** - Draft DB-aware queries with follow-ups and one-key accept (`:ai` / `Ctrl+G`)
 - **External editor** - Open the current query in `$VISUAL` / `$EDITOR` with `vv`
 - **1Password integration** - Store an `op://` secret reference per connection instead of a plain password
 - **Update checks** - Notify of new versions with install-method specific upgrade hints, plus optional in-app apply for standalone installs when `updates.mode = "auto"`
@@ -100,6 +101,7 @@ Once connected:
 | `vv`      | Open query in `$VISUAL` / `$EDITOR`, reload on exit |
 | `/`       | Search                                              |
 | `Ctrl-r`  | Fuzzy history search                                |
+| `Ctrl-g`  | Open AI query assistant                             |
 | `Enter`   | Execute query                                       |
 | `:`       | Command mode                                        |
 
@@ -170,6 +172,7 @@ tsql --debug-keys --mouse
 | ------------------------------- | ------------------- |
 | `:connect <url>`                | Connect to database |
 | `:disconnect`                   | Disconnect          |
+| `:ai [prompt]`                  | Open AI query assistant |
 | `:export csv\|json\|tsv <path>` | Export results      |
 | `:update [check\|status\|apply]` | Check/apply updates |
 | `:sbt` / `:sidebar-toggle`      | Toggle sidebar      |
@@ -209,6 +212,23 @@ mode = "auto"
 interval_hours = 24
 allow_apply_for_standalone = true
 github_repo = "fcoury/tsql"
+
+[ai]
+# Enable AI query assistant (`:ai`, `Ctrl+G`)
+enabled = false
+# provider:
+# - "open_ai"
+# - "open_ai_compatible"
+# - "ollama"
+# - "anthropic"
+# - "google"
+# - "openrouter"
+provider = "open_ai"
+model = "gpt-4o-mini"
+api_key_env = "OPENAI_API_KEY"
+# base_url = "http://localhost:1234/v1"
+# provider defaults when omitted:
+# ANTHROPIC_API_KEY / GEMINI_API_KEY / OPENROUTER_API_KEY
 
 [keymap]
 # Custom keymap overrides (see config.example.toml for options)

--- a/config.example.toml
+++ b/config.example.toml
@@ -121,6 +121,57 @@ allow_apply_for_standalone = true
 # GitHub repository used for release checks
 github_repo = "fcoury/tsql"
 
+# AI assistant settings
+[ai]
+# Enable `:ai` command and `Ctrl+G` shortcut in query editor
+enabled = false
+
+# Provider backend:
+# - "open_ai"            (OpenAI API)
+# - "open_ai_compatible" (OpenAI-compatible endpoints)
+# - "ollama"             (local Ollama)
+# - "anthropic"          (Anthropic Claude API)
+# - "google"             (Google Gemini API)
+# - "openrouter"         (OpenRouter API)
+provider = "open_ai"
+
+# Model name for selected provider
+model = "gpt-4o-mini"
+
+# Sampling temperature and max output tokens
+temperature = 0.1
+max_tokens = 1024
+
+# Request timeout in seconds
+request_timeout_secs = 30
+
+# Optional provider base URL override
+# - OpenAI-compatible example: "http://localhost:1234/v1"
+# - Ollama example: "http://localhost:11434"
+# - Anthropic example: "https://api.anthropic.com"
+# - Google Gemini example: "https://generativelanguage.googleapis.com"
+# - OpenRouter example: "https://openrouter.ai/api/v1"
+# base_url = "http://localhost:1234/v1"
+
+# API key environment variable name (ignored by ollama)
+# Common values:
+# - OPENAI_API_KEY      (open_ai / open_ai_compatible)
+# - ANTHROPIC_API_KEY   (anthropic)
+# - GEMINI_API_KEY      (google)
+# - OPENROUTER_API_KEY  (openrouter)
+# If left as OPENAI_API_KEY while using another provider, tsql
+# will automatically try that provider's default env var first.
+api_key_env = "OPENAI_API_KEY"
+
+# Prompt context controls
+include_schema_context = true
+max_schema_tables = 25
+max_columns_per_table = 20
+
+# Optional custom system prompts per engine
+# system_prompt_postgres = "Return only PostgreSQL SQL."
+# system_prompt_mongo = "Return only db.collection.op(...) or JSON command syntax."
+
 # Clipboard settings
 [clipboard]
 # Clipboard backend:
@@ -152,6 +203,12 @@ vim_mode = true
 # key = "ctrl+s"
 # action = "execute_query"
 # description = "Execute the current query"
+
+# Default: Ctrl+G opens AI query assistant
+# [[keymap.normal]]
+# key = "ctrl+g"
+# action = "open_ai_assistant"
+# description = "Open AI query assistant"
 
 # Custom keybindings for grid navigation
 # [[keymap.grid]]

--- a/crates/tsql/Cargo.toml
+++ b/crates/tsql/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow.workspace = true
+rig.workspace = true
 arboard.workspace = true
 crossterm.workspace = true
 dirs.workspace = true

--- a/crates/tsql/src/ai/mod.rs
+++ b/crates/tsql/src/ai/mod.rs
@@ -1,0 +1,598 @@
+use std::time::Duration;
+
+use rig::client::{CompletionClient, Nothing};
+use rig::completion::Prompt;
+use rig::providers::{anthropic, gemini, ollama, openai, openrouter};
+use serde::Deserialize;
+use tokio::time::timeout;
+
+use crate::config::{AiConfig, AiProvider, DbKind};
+use crate::ui::TableInfo;
+
+#[derive(Debug, Clone)]
+pub struct AiProposal {
+    pub query: String,
+    pub explanation: Option<String>,
+    pub raw_response: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AiTurn {
+    pub user_prompt: String,
+    pub assistant_query: String,
+}
+
+#[derive(Clone)]
+pub struct AiRequestContext {
+    pub db_kind: Option<DbKind>,
+    pub database_name: Option<String>,
+    pub schema_tables: Vec<TableInfo>,
+    pub conversation: Vec<AiTurn>,
+    pub user_prompt: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProposalPayload {
+    query: String,
+    explanation: Option<String>,
+}
+
+pub async fn generate_query(
+    config: &AiConfig,
+    context: &AiRequestContext,
+) -> std::result::Result<AiProposal, String> {
+    let system_prompt = build_system_prompt(config, context.db_kind);
+    let prompt = build_prompt(config, context);
+
+    let response = match config.provider {
+        AiProvider::OpenAi | AiProvider::OpenAiCompatible => {
+            run_openai_request(config, &system_prompt, &prompt).await
+        }
+        AiProvider::Ollama => run_ollama_request(config, &system_prompt, &prompt).await,
+        AiProvider::Anthropic => run_anthropic_request(config, &system_prompt, &prompt).await,
+        AiProvider::Google => run_google_request(config, &system_prompt, &prompt).await,
+        AiProvider::OpenRouter => run_openrouter_request(config, &system_prompt, &prompt).await,
+    }?;
+
+    let (query, explanation) = parse_proposal_response(&response)?;
+
+    Ok(AiProposal {
+        query,
+        explanation,
+        raw_response: response,
+    })
+}
+
+async fn run_openai_request(
+    config: &AiConfig,
+    system_prompt: &str,
+    prompt: &str,
+) -> std::result::Result<String, String> {
+    if config.provider == AiProvider::OpenAiCompatible
+        && config.base_url.as_deref().unwrap_or("").trim().is_empty()
+    {
+        return Err(
+            "AI config error: `ai.base_url` is required for `open_ai_compatible`".to_string(),
+        );
+    }
+
+    let api_key = resolve_api_key(config, config.provider == AiProvider::OpenAiCompatible)?;
+
+    let mut builder: openai::ClientBuilder = openai::Client::builder().api_key(&api_key);
+    if let Some(base_url) = config
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        builder = builder.base_url(base_url);
+    }
+
+    let client = builder
+        .build()
+        .map_err(|e| format!("Failed to initialize OpenAI client: {e}"))?;
+
+    let agent = client
+        .agent(config.model.as_str())
+        .preamble(system_prompt)
+        .temperature(config.temperature)
+        .max_tokens(config.max_tokens)
+        .build();
+
+    let response = timeout(
+        Duration::from_secs(config.request_timeout_secs),
+        agent.prompt(prompt),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "AI request timed out after {}s",
+            config.request_timeout_secs
+        )
+    })?
+    .map_err(|e| format!("AI provider error: {e}"))?;
+
+    Ok(response)
+}
+
+async fn run_anthropic_request(
+    config: &AiConfig,
+    system_prompt: &str,
+    prompt: &str,
+) -> std::result::Result<String, String> {
+    let api_key = resolve_api_key(config, false)?;
+
+    let mut builder: anthropic::ClientBuilder = anthropic::Client::builder().api_key(api_key);
+    if let Some(base_url) = config
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        builder = builder.base_url(base_url);
+    }
+
+    let client = builder
+        .build()
+        .map_err(|e| format!("Failed to initialize Anthropic client: {e}"))?;
+
+    let agent = client
+        .agent(config.model.as_str())
+        .preamble(system_prompt)
+        .temperature(config.temperature)
+        .max_tokens(config.max_tokens)
+        .build();
+
+    let response = timeout(
+        Duration::from_secs(config.request_timeout_secs),
+        agent.prompt(prompt),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "AI request timed out after {}s",
+            config.request_timeout_secs
+        )
+    })?
+    .map_err(|e| format!("AI provider error: {e}"))?;
+
+    Ok(response)
+}
+
+async fn run_google_request(
+    config: &AiConfig,
+    system_prompt: &str,
+    prompt: &str,
+) -> std::result::Result<String, String> {
+    let api_key = resolve_api_key(config, false)?;
+
+    let mut builder = gemini::Client::builder().api_key(api_key);
+    if let Some(base_url) = config
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        builder = builder.base_url(base_url);
+    }
+
+    let client = builder
+        .build()
+        .map_err(|e| format!("Failed to initialize Google Gemini client: {e}"))?;
+
+    let agent = client
+        .agent(config.model.as_str())
+        .preamble(system_prompt)
+        .temperature(config.temperature)
+        .max_tokens(config.max_tokens)
+        .build();
+
+    let response = timeout(
+        Duration::from_secs(config.request_timeout_secs),
+        agent.prompt(prompt),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "AI request timed out after {}s",
+            config.request_timeout_secs
+        )
+    })?
+    .map_err(|e| format!("AI provider error: {e}"))?;
+
+    Ok(response)
+}
+
+async fn run_openrouter_request(
+    config: &AiConfig,
+    system_prompt: &str,
+    prompt: &str,
+) -> std::result::Result<String, String> {
+    let api_key = resolve_api_key(config, false)?;
+
+    let mut builder: openrouter::ClientBuilder = openrouter::Client::builder().api_key(api_key);
+    if let Some(base_url) = config
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        builder = builder.base_url(base_url);
+    }
+
+    let client = builder
+        .build()
+        .map_err(|e| format!("Failed to initialize OpenRouter client: {e}"))?;
+
+    let agent = client
+        .agent(config.model.as_str())
+        .preamble(system_prompt)
+        .temperature(config.temperature)
+        .max_tokens(config.max_tokens)
+        .build();
+
+    let response = timeout(
+        Duration::from_secs(config.request_timeout_secs),
+        agent.prompt(prompt),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "AI request timed out after {}s",
+            config.request_timeout_secs
+        )
+    })?
+    .map_err(|e| format!("AI provider error: {e}"))?;
+
+    Ok(response)
+}
+
+async fn run_ollama_request(
+    config: &AiConfig,
+    system_prompt: &str,
+    prompt: &str,
+) -> std::result::Result<String, String> {
+    let mut builder: ollama::ClientBuilder = ollama::Client::builder().api_key(Nothing);
+    if let Some(base_url) = config
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        builder = builder.base_url(base_url);
+    }
+
+    let client = builder
+        .build()
+        .map_err(|e| format!("Failed to initialize Ollama client: {e}"))?;
+
+    let agent = client
+        .agent(config.model.as_str())
+        .preamble(system_prompt)
+        .temperature(config.temperature)
+        .max_tokens(config.max_tokens)
+        .build();
+
+    let response = timeout(
+        Duration::from_secs(config.request_timeout_secs),
+        agent.prompt(prompt),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "AI request timed out after {}s",
+            config.request_timeout_secs
+        )
+    })?
+    .map_err(|e| format!("AI provider error: {e}"))?;
+
+    Ok(response)
+}
+
+fn resolve_api_key(config: &AiConfig, allow_missing: bool) -> std::result::Result<String, String> {
+    let candidates = api_key_env_candidates(config);
+    for env_var in &candidates {
+        if let Ok(value) = std::env::var(env_var) {
+            if !value.trim().is_empty() {
+                return Ok(value);
+            }
+        }
+    }
+
+    if allow_missing {
+        return Ok("dummy".to_string());
+    }
+
+    if candidates.is_empty() {
+        return Err("AI config error: `ai.api_key_env` is empty".to_string());
+    }
+
+    let formatted = candidates
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(format!(
+        "AI config error: none of env vars [{formatted}] are set (or empty)"
+    ))
+}
+
+fn api_key_env_candidates(config: &AiConfig) -> Vec<String> {
+    let configured = config.api_key_env.trim();
+    let provider_default = default_api_key_env_for_provider(config.provider);
+
+    if configured.is_empty() {
+        return provider_default
+            .map(|name| vec![name.to_string()])
+            .unwrap_or_default();
+    }
+
+    if configured == "OPENAI_API_KEY" {
+        if let Some(default_env) = provider_default {
+            if default_env != "OPENAI_API_KEY" {
+                return vec![default_env.to_string(), configured.to_string()];
+            }
+        }
+    }
+
+    vec![configured.to_string()]
+}
+
+fn default_api_key_env_for_provider(provider: AiProvider) -> Option<&'static str> {
+    match provider {
+        AiProvider::OpenAi | AiProvider::OpenAiCompatible => Some("OPENAI_API_KEY"),
+        AiProvider::Anthropic => Some("ANTHROPIC_API_KEY"),
+        AiProvider::Google => Some("GEMINI_API_KEY"),
+        AiProvider::OpenRouter => Some("OPENROUTER_API_KEY"),
+        AiProvider::Ollama => None,
+    }
+}
+
+fn build_system_prompt(config: &AiConfig, db_kind: Option<DbKind>) -> String {
+    let (default_prompt, override_prompt) = match db_kind {
+        Some(DbKind::Mongo) => (
+            "You are a MongoDB query assistant for tsql.
+Return a query that tsql can execute:
+- Prefer `db.<collection>.<operation>(...)` syntax.
+- You may also use JSON command syntax: {\"op\":\"find\",...}.
+- Use only operations supported by tsql: find, findOne, aggregate, countDocuments, insertOne, insertMany, updateOne, updateMany, deleteOne, deleteMany.
+- Do not output markdown fences.
+- Keep response concise.",
+            config.system_prompt_mongo.as_deref(),
+        ),
+        _ => (
+            "You are a PostgreSQL query assistant for tsql.
+Return a single PostgreSQL query or statement block.
+- Do not output markdown fences.
+- Keep response concise.
+- If request is ambiguous, choose a safe query and explain assumptions briefly.",
+            config.system_prompt_postgres.as_deref(),
+        ),
+    };
+
+    override_prompt.unwrap_or(default_prompt).to_string()
+}
+
+fn build_prompt(config: &AiConfig, context: &AiRequestContext) -> String {
+    let mut sections = Vec::new();
+
+    let engine = match context.db_kind {
+        Some(DbKind::Mongo) => "mongo",
+        _ => "postgres",
+    };
+    sections.push(format!("engine: {engine}"));
+
+    if let Some(name) = context.database_name.as_deref().filter(|s| !s.is_empty()) {
+        sections.push(format!("database: {name}"));
+    }
+
+    if config.include_schema_context {
+        let schema_summary = summarize_schema(
+            &context.schema_tables,
+            config.max_schema_tables,
+            config.max_columns_per_table,
+        );
+        if !schema_summary.is_empty() {
+            sections.push(format!("schema:\n{schema_summary}"));
+        }
+    }
+
+    if !context.conversation.is_empty() {
+        let mut history = String::from("conversation:");
+        for (idx, turn) in context.conversation.iter().enumerate() {
+            history.push_str(&format!(
+                "\n{}. user: {}\n{}. assistant_query: {}",
+                idx + 1,
+                turn.user_prompt.trim(),
+                idx + 1,
+                turn.assistant_query.trim()
+            ));
+        }
+        sections.push(history);
+    }
+
+    sections.push(format!("request:\n{}", context.user_prompt.trim()));
+    sections.push(
+        "Return strictly JSON object with keys:\n{\"query\": \"...\", \"explanation\": \"...\"}\n`query` is required."
+            .to_string(),
+    );
+
+    sections.join("\n\n")
+}
+
+fn summarize_schema(tables: &[TableInfo], max_tables: usize, max_columns: usize) -> String {
+    if tables.is_empty() || max_tables == 0 || max_columns == 0 {
+        return String::new();
+    }
+
+    let mut lines = Vec::new();
+    for table in tables.iter().take(max_tables) {
+        let mut cols = Vec::new();
+        for col in table.columns.iter().take(max_columns) {
+            cols.push(col.name.clone());
+        }
+        if table.columns.len() > max_columns {
+            cols.push("...".to_string());
+        }
+        lines.push(format!(
+            "- {}.{}({})",
+            table.schema,
+            table.name,
+            cols.join(", ")
+        ));
+    }
+    if tables.len() > max_tables {
+        lines.push(format!("- ... {} more", tables.len() - max_tables));
+    }
+
+    lines.join("\n")
+}
+
+fn parse_proposal_response(raw: &str) -> std::result::Result<(String, Option<String>), String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("AI returned an empty response".to_string());
+    }
+
+    if let Ok(payload) = serde_json::from_str::<ProposalPayload>(trimmed) {
+        return validate_payload(payload);
+    }
+
+    if let Some(json_candidate) = extract_json_code_block(trimmed) {
+        if let Ok(payload) = serde_json::from_str::<ProposalPayload>(&json_candidate) {
+            return validate_payload(payload);
+        }
+    }
+
+    if let Some(braced) = extract_first_json_object(trimmed) {
+        if let Ok(payload) = serde_json::from_str::<ProposalPayload>(&braced) {
+            return validate_payload(payload);
+        }
+    }
+
+    let fallback_query = strip_markdown_fences(trimmed).trim().to_string();
+    if fallback_query.is_empty() {
+        return Err("AI response did not include a usable query".to_string());
+    }
+    Ok((fallback_query, None))
+}
+
+fn validate_payload(
+    payload: ProposalPayload,
+) -> std::result::Result<(String, Option<String>), String> {
+    let query = payload.query.trim().to_string();
+    if query.is_empty() {
+        return Err("AI response JSON contained an empty `query`".to_string());
+    }
+    Ok((query, payload.explanation.map(|s| s.trim().to_string())))
+}
+
+fn extract_json_code_block(input: &str) -> Option<String> {
+    let mut start = input.find("```")?;
+    loop {
+        let after_ticks = &input[start + 3..];
+        let end_rel = after_ticks.find("```")?;
+        let block = &after_ticks[..end_rel];
+        let normalized = block
+            .strip_prefix("json")
+            .or_else(|| block.strip_prefix("JSON"))
+            .map(str::trim_start)
+            .unwrap_or(block)
+            .trim();
+        if normalized.starts_with('{') {
+            return Some(normalized.to_string());
+        }
+        let next = &after_ticks[end_rel + 3..];
+        let offset = next.find("```")?;
+        start = input.len() - next.len() + offset;
+    }
+}
+
+fn extract_first_json_object(input: &str) -> Option<String> {
+    let start = input.find('{')?;
+    let end = input.rfind('}')?;
+    if end <= start {
+        return None;
+    }
+    Some(input[start..=end].to_string())
+}
+
+fn strip_markdown_fences(input: &str) -> String {
+    let mut out = input.trim().to_string();
+    if out.starts_with("```") {
+        out = out
+            .trim_start_matches("```json")
+            .trim_start_matches("```JSON")
+            .trim_start_matches("```")
+            .to_string();
+    }
+    if out.ends_with("```") {
+        out = out.trim_end_matches("```").to_string();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_payload_from_json() {
+        let raw = r#"{"query":"select 1","explanation":"test"}"#;
+        let (query, explanation) = parse_proposal_response(raw).unwrap();
+        assert_eq!(query, "select 1");
+        assert_eq!(explanation.as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn parse_payload_from_json_fence() {
+        let raw = "```json\n{\"query\":\"select * from users\"}\n```";
+        let (query, explanation) = parse_proposal_response(raw).unwrap();
+        assert_eq!(query, "select * from users");
+        assert!(explanation.is_none());
+    }
+
+    #[test]
+    fn parse_payload_fallback_plain_text() {
+        let raw = "db.users.find({\"active\": true})";
+        let (query, explanation) = parse_proposal_response(raw).unwrap();
+        assert_eq!(query, raw);
+        assert!(explanation.is_none());
+    }
+
+    #[test]
+    fn parse_payload_rejects_empty_query() {
+        let raw = "{\"query\":\"   \"}";
+        let err = parse_proposal_response(raw).unwrap_err();
+        assert!(err.contains("empty `query`"));
+    }
+
+    #[test]
+    fn api_key_env_candidates_fallback_to_provider_default_when_openai_default_is_implicit() {
+        let config = AiConfig {
+            provider: AiProvider::OpenRouter,
+            api_key_env: "OPENAI_API_KEY".to_string(),
+            ..AiConfig::default()
+        };
+        assert_eq!(
+            api_key_env_candidates(&config),
+            vec![
+                "OPENROUTER_API_KEY".to_string(),
+                "OPENAI_API_KEY".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn api_key_env_candidates_keep_explicit_custom_value() {
+        let config = AiConfig {
+            provider: AiProvider::OpenRouter,
+            api_key_env: "MY_OPENROUTER_TOKEN".to_string(),
+            ..AiConfig::default()
+        };
+        assert_eq!(
+            api_key_env_candidates(&config),
+            vec!["MY_OPENROUTER_TOKEN".to_string()]
+        );
+    }
+}

--- a/crates/tsql/src/ai/mod.rs
+++ b/crates/tsql/src/ai/mod.rs
@@ -1,3 +1,22 @@
+//! AI-assisted query generation.
+//!
+//! Translates natural-language prompts into database queries by sending
+//! schema-enriched requests to a configurable LLM provider (OpenAI, Anthropic,
+//! Google Gemini, OpenRouter, Ollama, or any OpenAI-compatible endpoint).
+//!
+//! All provider interaction goes through the [`rig`] crate. Each provider has
+//! a dedicated `run_*_request` function that builds a client, attaches a system
+//! prompt and sampling parameters, and applies a per-request timeout.
+//!
+//! Responses are expected as `{"query": "...", "explanation": "..."}` JSON.
+//! `parse_proposal_response` applies a four-layer fallback (raw JSON, fenced
+//! code block, brace extraction, plain text) so the module tolerates models
+//! that wrap output in markdown or omit the JSON envelope entirely.
+//!
+//! Multi-turn conversations are supported: the caller passes prior
+//! [`AiTurn`]s, which are formatted into the prompt so the model can refine
+//! a query across successive requests.
+
 use std::time::Duration;
 
 use rig::client::{CompletionClient, Nothing};
@@ -9,19 +28,27 @@ use tokio::time::timeout;
 use crate::config::{AiConfig, AiProvider, DbKind};
 use crate::ui::TableInfo;
 
+/// A successfully parsed AI response containing a proposed query and an
+/// optional natural-language explanation.
 #[derive(Debug, Clone)]
 pub struct AiProposal {
     pub query: String,
     pub explanation: Option<String>,
+    /// The raw text returned by the provider, kept for debugging.
     pub raw_response: String,
 }
 
+/// One user/assistant exchange in a multi-turn AI conversation.
 #[derive(Debug, Clone)]
 pub struct AiTurn {
     pub user_prompt: String,
     pub assistant_query: String,
 }
 
+/// Everything the AI module needs to build a prompt.
+///
+/// Constructed by `App::start_ai_generation` from the current application
+/// state and passed into [`generate_query`].
 #[derive(Clone)]
 pub struct AiRequestContext {
     pub db_kind: Option<DbKind>,
@@ -31,12 +58,24 @@ pub struct AiRequestContext {
     pub user_prompt: String,
 }
 
+/// Wire format expected from the LLM. Only `query` is required.
 #[derive(Debug, Deserialize)]
 struct ProposalPayload {
     query: String,
     explanation: Option<String>,
 }
 
+/// Send a natural-language prompt to the configured LLM and return a parsed
+/// query proposal.
+///
+/// Builds a system prompt (engine-aware, optionally user-overridden) and a
+/// user prompt containing schema context and conversation history, dispatches
+/// to the appropriate provider, and parses the response.
+///
+/// # Errors
+///
+/// Returns a human-readable `String` on client initialization failure,
+/// request timeout, provider HTTP error, or unparseable response.
 pub async fn generate_query(
     config: &AiConfig,
     context: &AiRequestContext,
@@ -289,6 +328,11 @@ async fn run_ollama_request(
     Ok(response)
 }
 
+/// Read the API key from the environment.
+///
+/// Tries each candidate env var in order (see [`api_key_env_candidates`]).
+/// When `allow_missing` is true (used for OpenAI-compatible endpoints that
+/// may not need auth), returns a dummy value instead of erroring.
 fn resolve_api_key(config: &AiConfig, allow_missing: bool) -> std::result::Result<String, String> {
     let candidates = api_key_env_candidates(config);
     for env_var in &candidates {
@@ -317,6 +361,12 @@ fn resolve_api_key(config: &AiConfig, allow_missing: bool) -> std::result::Resul
     ))
 }
 
+/// Determine which environment variable names to check for the API key.
+///
+/// If the user left the default `OPENAI_API_KEY` but selected a non-OpenAI
+/// provider, the provider's conventional env var is tried first so a user
+/// who only sets `ANTHROPIC_API_KEY` does not also need to override
+/// `api_key_env` in config. An explicitly customized value is used as-is.
 fn api_key_env_candidates(config: &AiConfig) -> Vec<String> {
     let configured = config.api_key_env.trim();
     let provider_default = default_api_key_env_for_provider(config.provider);
@@ -373,6 +423,9 @@ Return a single PostgreSQL query or statement block.
     override_prompt.unwrap_or(default_prompt).to_string()
 }
 
+/// Assemble the user-facing prompt from engine type, database name, schema
+/// summary, conversation history, and the current user request. Terminates
+/// with a JSON format instruction so the model returns a structured payload.
 fn build_prompt(config: &AiConfig, context: &AiRequestContext) -> String {
     let mut sections = Vec::new();
 
@@ -448,6 +501,15 @@ fn summarize_schema(tables: &[TableInfo], max_tables: usize, max_columns: usize)
     lines.join("\n")
 }
 
+/// Extract a `(query, explanation)` pair from a raw LLM response.
+///
+/// Applies four parsing strategies in order:
+/// 1. Direct JSON deserialization of the entire response.
+/// 2. Extract JSON from a markdown fenced code block (` ```json ... ``` `).
+/// 3. Extract the first `{...}` substring and try JSON deserialization.
+/// 4. Strip markdown fences and treat the remainder as a plain-text query.
+///
+/// Returns an error only if every strategy yields an empty or absent query.
 fn parse_proposal_response(raw: &str) -> std::result::Result<(String, Option<String>), String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -36,6 +36,7 @@ use tui_textarea::{CursorMove, Input};
 use webpki_roots::TLS_SERVER_ROOTS;
 
 use super::state::{DbStatus, Focus, Mode, PanelDirection, SearchTarget, SidebarSection};
+use crate::ai::{generate_query, AiProposal, AiRequestContext};
 use crate::config::{
     load_connections, save_connections, Action, ClipboardBackend, Config, ConnectionEntry,
     ConnectionsFile, DbKind, KeyBinding, Keymap, SslMode, UpdateMode,
@@ -44,15 +45,15 @@ use crate::history::{History, HistoryEntry};
 use crate::session::SessionState;
 use crate::ui::{
     create_sql_highlighter, determine_context, escape_sql_value, get_word_before_cursor, is_inside,
-    quote_identifier, ColumnInfo, CommandPrompt, CompletionKind, CompletionPopup, ConfirmContext,
-    ConfirmPrompt, ConfirmResult, ConnectionFormAction, ConnectionFormModal, ConnectionInfo,
-    ConnectionManagerAction, ConnectionManagerModal, CursorShape, DataGrid, FuzzyPicker,
-    GridKeyResult, GridModel, GridState, HelpAction, HelpPopup, HighlightedTextArea,
-    JsonEditorAction, JsonEditorModal, KeyHintPopup, KeySequenceAction, KeySequenceCompletion,
-    KeySequenceHandlerWithContext, KeySequenceResult, PasswordPrompt, PasswordPromptResult,
-    PendingKey, PickerAction, Priority, QueryEditor, ResizeAction, RowDetailAction, RowDetailModal,
-    SchemaCache, SearchPrompt, Sidebar, SidebarAction, StatusLineBuilder, StatusSegment, TableInfo,
-    YankFormat,
+    quote_identifier, AiQueryModal, AiQueryModalAction, ColumnInfo, CommandPrompt, CompletionKind,
+    CompletionPopup, ConfirmContext, ConfirmPrompt, ConfirmResult, ConnectionFormAction,
+    ConnectionFormModal, ConnectionInfo, ConnectionManagerAction, ConnectionManagerModal,
+    CursorShape, DataGrid, FuzzyPicker, GridKeyResult, GridModel, GridState, HelpAction, HelpPopup,
+    HighlightedTextArea, JsonEditorAction, JsonEditorModal, KeyHintPopup, KeySequenceAction,
+    KeySequenceCompletion, KeySequenceHandlerWithContext, KeySequenceResult, PasswordPrompt,
+    PasswordPromptResult, PendingKey, PickerAction, Priority, QueryEditor, ResizeAction,
+    RowDetailAction, RowDetailModal, SchemaCache, SearchPrompt, Sidebar, SidebarAction,
+    StatusLineBuilder, StatusSegment, TableInfo, YankFormat,
 };
 use crate::update::{
     apply_update, check_for_update, current_target_triple, detect_current_install_method,
@@ -1944,6 +1945,11 @@ pub enum DbEvent {
     UpdateApplyFinished {
         result: std::result::Result<ApplyResult, String>,
     },
+    /// AI query generation reply.
+    AiReply {
+        request_id: u64,
+        result: std::result::Result<AiProposal, String>,
+    },
 }
 
 pub struct DbSession {
@@ -2259,6 +2265,12 @@ pub struct App {
     pub connection_form: Option<ConnectionFormModal>,
     /// Password prompt modal (when connecting to entry that needs password).
     pub password_prompt: Option<PasswordPrompt>,
+    /// AI query assistant modal.
+    pub ai_modal: Option<AiQueryModal>,
+    /// Monotonic sequence for async AI requests.
+    ai_request_seq: u64,
+    /// Current in-flight AI request id (if any).
+    ai_pending_request_id: Option<u64>,
 
     /// Sidebar component state.
     pub sidebar: Sidebar,
@@ -2437,6 +2449,9 @@ impl App {
             connection_manager: None,
             connection_form: None,
             password_prompt: None,
+            ai_modal: None,
+            ai_request_seq: 0,
+            ai_pending_request_id: None,
 
             sidebar: Sidebar::new(),
             sidebar_visible: false,
@@ -3250,6 +3265,11 @@ impl App {
                     prompt.render(frame, size);
                 }
 
+                // Render AI assistant modal.
+                if let Some(ref mut modal) = self.ai_modal {
+                    modal.render(frame, size);
+                }
+
                 // Error popup (modal).
                 if let Some(ref err) = self.last_error {
                     let has_other_modal = self.help_popup.is_some()
@@ -3257,6 +3277,7 @@ impl App {
                         || self.command.active
                         || self.completion.active
                         || self.cell_editor.active
+                        || self.ai_modal.is_some()
                         || self.history_picker.is_some()
                         || self.connection_picker.is_some()
                         || self.json_editor.is_some()
@@ -3373,6 +3394,13 @@ impl App {
             }
         }
 
+        // Handle AI modal when active - it captures all input.
+        if let Some(modal) = self.ai_modal.as_mut() {
+            let action = modal.handle_key(key);
+            self.handle_ai_modal_action(action);
+            return false;
+        }
+
         // Handle password prompt when active
         if let Some(mut prompt) = self.password_prompt.take() {
             match prompt.handle_key(key) {
@@ -3404,15 +3432,15 @@ impl App {
         }
 
         // Handle connection form when active - it captures all input
-        if self.connection_form.is_some() {
-            let action = self.connection_form.as_mut().unwrap().handle_key(key);
+        if let Some(connection_form) = self.connection_form.as_mut() {
+            let action = connection_form.handle_key(key);
             self.handle_connection_form_action(action);
             return false;
         }
 
         // Handle connection manager when active - it captures all input
-        if self.connection_manager.is_some() {
-            let action = self.connection_manager.as_mut().unwrap().handle_key(key);
+        if let Some(connection_manager) = self.connection_manager.as_mut() {
+            let action = connection_manager.handle_key(key);
             self.handle_connection_manager_action(action);
             return false;
         }
@@ -3439,6 +3467,7 @@ impl App {
                 || self.command.active
                 || self.completion.active
                 || self.cell_editor.active
+                || self.ai_modal.is_some()
                 || self.history_picker.is_some()
                 || self.connection_picker.is_some()
                 || self.pending_key.is_some()
@@ -3455,6 +3484,8 @@ impl App {
                 self.command.close();
                 self.completion.close();
                 self.cell_editor.close();
+                self.ai_modal = None;
+                self.ai_pending_request_id = None;
                 self.history_picker = None;
                 self.history_picker_pinned_only = false;
                 self.connection_picker = None;
@@ -4116,6 +4147,11 @@ impl App {
             }
         }
 
+        // AI modal is keyboard-only and captures interaction when open.
+        if self.ai_modal.is_some() {
+            return false;
+        }
+
         // Error popup is modal: any click dismisses it.
         if self.last_error.is_some() {
             if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
@@ -4664,6 +4700,10 @@ impl App {
                 self.start_update_apply(info);
                 false
             }
+            ConfirmContext::OpenAiAssistant { prefill } => {
+                self.open_ai_modal(prefill);
+                false
+            }
         }
     }
 
@@ -4696,6 +4736,9 @@ impl App {
             }
             ConfirmContext::ApplyUpdate { .. } => {
                 self.last_status = Some("Update apply cancelled".to_string());
+            }
+            ConfirmContext::OpenAiAssistant { .. } => {
+                self.last_status = Some("AI assistant open cancelled".to_string());
             }
         }
     }
@@ -5404,14 +5447,12 @@ impl App {
                     } else {
                         self.execute_mongo_describe_collection(args);
                     }
+                } else if args.is_empty() {
+                    // \d without args is same as \dt
+                    self.execute_meta_query(META_QUERY_TABLES, None);
                 } else {
-                    if args.is_empty() {
-                        // \d without args is same as \dt
-                        self.execute_meta_query(META_QUERY_TABLES, None);
-                    } else {
-                        // \d <table> - describe table
-                        self.execute_meta_query(META_QUERY_DESCRIBE, Some(args));
-                    }
+                    // \d <table> - describe table
+                    self.execute_meta_query(META_QUERY_DESCRIBE, Some(args));
                 }
             }
             "\\di" | "di" => {
@@ -5463,6 +5504,14 @@ impl App {
             "history" => {
                 self.open_history_picker();
             }
+            "ai" => {
+                let prefill = if args.is_empty() {
+                    None
+                } else {
+                    Some(args.to_string())
+                };
+                self.request_open_ai_modal(prefill);
+            }
             "connections" | "conn" => {
                 self.open_connection_manager();
             }
@@ -5478,6 +5527,142 @@ impl App {
         }
 
         false
+    }
+
+    fn query_editor_has_content(&self) -> bool {
+        !self.editor.text().trim().is_empty()
+    }
+
+    fn active_database_name(&self) -> Option<String> {
+        if self.db.kind == Some(DbKind::Mongo) {
+            return self.db.mongo_database.clone();
+        }
+
+        if let Some(name) = self.current_connection_name.as_deref() {
+            if let Some(entry) = self.connections.find_by_name(name) {
+                if !entry.database.trim().is_empty() {
+                    return Some(entry.database.clone());
+                }
+            }
+        }
+
+        let conn_str = self.db.conn_str.as_deref()?;
+        if !conn_str.contains("://") {
+            return None;
+        }
+        let parsed = url::Url::parse(conn_str).ok()?;
+        let db = parsed.path().trim_matches('/').trim();
+        if db.is_empty() {
+            None
+        } else {
+            Some(db.to_string())
+        }
+    }
+
+    fn request_open_ai_modal(&mut self, prefill: Option<String>) {
+        if !self.config.ai.enabled {
+            self.last_error =
+                Some("AI assistant is disabled. Enable it under [ai] in config.toml".to_string());
+            return;
+        }
+
+        if let Some(modal) = self.ai_modal.as_mut() {
+            if let Some(text) = prefill {
+                modal.set_input_text(text);
+            }
+            self.last_status = Some("AI assistant already open".to_string());
+            return;
+        }
+
+        if self.query_editor_has_content() {
+            self.confirm_prompt = Some(ConfirmPrompt::new(
+                "Query editor has content. Open AI assistant anyway?",
+                ConfirmContext::OpenAiAssistant { prefill },
+            ));
+            return;
+        }
+
+        self.open_ai_modal(prefill);
+    }
+
+    fn open_ai_modal(&mut self, prefill: Option<String>) {
+        self.ai_modal = Some(AiQueryModal::new(prefill));
+        self.focus = Focus::Query;
+        self.mode = Mode::Insert;
+        self.last_status = Some("AI assistant opened".to_string());
+    }
+
+    fn start_ai_generation(&mut self, prompt: String) {
+        if !self.config.ai.enabled {
+            self.last_error =
+                Some("AI assistant is disabled. Enable it under [ai] in config.toml".to_string());
+            return;
+        }
+
+        let config = self.config.ai.clone();
+        let db_kind = self.db.kind;
+        let database_name = self.active_database_name();
+        let schema_tables = self.schema_cache.tables.clone();
+
+        let Some(modal) = self.ai_modal.as_mut() else {
+            return;
+        };
+
+        if modal.is_pending() {
+            self.last_status = Some("AI request already running".to_string());
+            return;
+        }
+
+        modal.begin_request(prompt.clone());
+
+        self.ai_request_seq = self.ai_request_seq.saturating_add(1);
+        let request_id = self.ai_request_seq;
+        self.ai_pending_request_id = Some(request_id);
+
+        let conversation = modal.conversation();
+        let tx = self.db_events_tx.clone();
+
+        self.rt.spawn(async move {
+            let context = AiRequestContext {
+                db_kind,
+                database_name,
+                schema_tables,
+                conversation,
+                user_prompt: prompt,
+            };
+            let result = generate_query(&config, &context).await;
+            let _ = tx.send(DbEvent::AiReply { request_id, result });
+        });
+    }
+
+    fn handle_ai_modal_action(&mut self, action: AiQueryModalAction) {
+        match action {
+            AiQueryModalAction::Continue => {}
+            AiQueryModalAction::Close => {
+                self.ai_modal = None;
+                self.ai_pending_request_id = None;
+                self.last_status = Some("AI assistant closed".to_string());
+            }
+            AiQueryModalAction::Send { prompt } => {
+                self.start_ai_generation(prompt);
+            }
+            AiQueryModalAction::Accept => {
+                let Some(modal) = self.ai_modal.as_ref() else {
+                    return;
+                };
+                let Some(query) = modal.latest_query() else {
+                    self.last_status = Some("No AI proposal to accept".to_string());
+                    return;
+                };
+
+                self.editor.set_text(query.to_string());
+                self.focus = Focus::Query;
+                self.mode = Mode::Insert;
+                self.ai_modal = None;
+                self.ai_pending_request_id = None;
+                self.last_status = Some("AI proposal accepted into query editor".to_string());
+            }
+        }
     }
 
     fn handle_update_command(&mut self, args: &str) {
@@ -6479,6 +6664,9 @@ impl App {
             Action::ShowHistory => {
                 self.open_history_picker();
             }
+            Action::OpenAiAssistant => {
+                self.request_open_ai_modal(None);
+            }
             Action::ToggleSidebar => {
                 self.toggle_sidebar();
             }
@@ -7078,6 +7266,10 @@ impl App {
                         }
                         Action::ToggleQueryHeight => {
                             self.toggle_query_height_mode();
+                            return;
+                        }
+                        Action::OpenAiAssistant => {
+                            self.request_open_ai_modal(None);
                             return;
                         }
                         _ => {}
@@ -9526,6 +9718,25 @@ impl App {
                     }
                 }
             }
+            DbEvent::AiReply { request_id, result } => {
+                if self.ai_pending_request_id != Some(request_id) {
+                    return;
+                }
+                self.ai_pending_request_id = None;
+
+                let Some(modal) = self.ai_modal.as_mut() else {
+                    return;
+                };
+
+                let ok = result.is_ok();
+                modal.apply_reply(result);
+                if ok {
+                    self.last_status = Some("AI proposal updated".to_string());
+                    self.last_error = None;
+                } else {
+                    self.last_status = Some("AI request failed".to_string());
+                }
+            }
         }
     }
 
@@ -10230,6 +10441,132 @@ mod tests {
             );
             assert!(app.confirm_prompt.is_none());
         }
+    }
+
+    #[test]
+    fn test_ai_command_opens_modal_when_editor_empty() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut config = Config::default();
+        config.ai.enabled = true;
+
+        let mut app = App::with_config(
+            GridModel::empty(),
+            rt.handle().clone(),
+            tx,
+            rx,
+            None,
+            config,
+        );
+
+        app.execute_command("ai");
+        assert!(app.ai_modal.is_some());
+        assert!(app.confirm_prompt.is_none());
+    }
+
+    #[test]
+    fn test_ai_command_with_existing_query_requires_confirmation() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut config = Config::default();
+        config.ai.enabled = true;
+
+        let mut app = App::with_config(
+            GridModel::empty(),
+            rt.handle().clone(),
+            tx,
+            rx,
+            None,
+            config,
+        );
+        app.editor.set_text("select 1".to_string());
+
+        app.execute_command("ai");
+        assert!(app.ai_modal.is_none());
+        assert!(matches!(
+            app.confirm_prompt.as_ref().map(|p| p.context()),
+            Some(ConfirmContext::OpenAiAssistant { .. })
+        ));
+    }
+
+    #[test]
+    fn test_ai_accept_replaces_query_editor_content() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut config = Config::default();
+        config.ai.enabled = true;
+
+        let mut app = App::with_config(
+            GridModel::empty(),
+            rt.handle().clone(),
+            tx,
+            rx,
+            None,
+            config,
+        );
+
+        app.open_ai_modal(None);
+        let modal = app.ai_modal.as_mut().unwrap();
+        modal.begin_request("list users".to_string());
+        modal.apply_reply(Ok(AiProposal {
+            query: "select * from users;".to_string(),
+            explanation: Some("basic listing".to_string()),
+            raw_response: "{\"query\":\"select * from users;\"}".to_string(),
+        }));
+
+        app.handle_ai_modal_action(AiQueryModalAction::Accept);
+
+        assert_eq!(app.editor.text(), "select * from users;");
+        assert!(app.ai_modal.is_none());
+    }
+
+    #[test]
+    fn test_stale_ai_reply_is_ignored() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut config = Config::default();
+        config.ai.enabled = true;
+
+        let mut app = App::with_config(
+            GridModel::empty(),
+            rt.handle().clone(),
+            tx,
+            rx,
+            None,
+            config,
+        );
+
+        app.open_ai_modal(None);
+        app.ai_pending_request_id = Some(2);
+
+        app.apply_db_event(DbEvent::AiReply {
+            request_id: 1,
+            result: Ok(AiProposal {
+                query: "select 1;".to_string(),
+                explanation: None,
+                raw_response: "{\"query\":\"select 1;\"}".to_string(),
+            }),
+        });
+
+        assert_eq!(app.ai_pending_request_id, Some(2));
+        assert!(app.ai_modal.is_some());
+        assert!(app.ai_modal.as_ref().unwrap().latest_query().is_none());
     }
 
     #[test]

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -7673,15 +7673,14 @@ impl App {
         let entries: Vec<ConnectionEntry> =
             self.connections.sorted().into_iter().cloned().collect();
 
-        let picker =
-            FuzzyPicker::with_display(entries, "Connect (gm or Ctrl+Shift+C: manage)", |entry| {
-                // Display: "[fav] name - user@host/db"
-                let fav = entry
-                    .favorite
-                    .map(|f| format!("[{}] ", f))
-                    .unwrap_or_default();
-                format!("{}{} - {}", fav, entry.name, entry.short_display())
-            });
+        let picker = FuzzyPicker::with_display(entries, "Connect (gm: manage)", |entry| {
+            // Display: "[fav] name - user@host/db"
+            let fav = entry
+                .favorite
+                .map(|f| format!("[{}] ", f))
+                .unwrap_or_default();
+            format!("{}{} - {}", fav, entry.name, entry.short_display())
+        });
 
         self.connection_picker = Some(picker);
     }
@@ -7979,6 +7978,22 @@ impl App {
         ));
     }
 
+    fn duplicate_connection_name(&self, base_name: &str) -> String {
+        let candidate = format!("{base_name}-copy");
+        if self.connections.find_by_name(&candidate).is_none() {
+            return candidate;
+        }
+
+        let mut suffix = 2;
+        loop {
+            let candidate = format!("{base_name}-copy-{suffix}");
+            if self.connections.find_by_name(&candidate).is_none() {
+                return candidate;
+            }
+            suffix += 1;
+        }
+    }
+
     /// Handle connection manager actions.
     fn handle_connection_manager_action(&mut self, action: ConnectionManagerAction) {
         match action {
@@ -8015,6 +8030,21 @@ impl App {
                     self.connection_form_keymap.clone(),
                     self.config.connection.enable_onepassword,
                 ));
+            }
+            ConnectionManagerAction::Duplicate { entry } => {
+                let password = entry
+                    .get_password_with_options(self.config.connection.enable_onepassword)
+                    .ok()
+                    .flatten();
+                let duplicate_name = self.duplicate_connection_name(&entry.name);
+                self.connection_form =
+                    Some(ConnectionFormModal::duplicate_with_keymap_and_onepassword(
+                        &entry,
+                        password,
+                        duplicate_name,
+                        self.connection_form_keymap.clone(),
+                        self.config.connection.enable_onepassword,
+                    ));
             }
             ConnectionManagerAction::Delete { name } => {
                 // Show confirmation for delete
@@ -12154,6 +12184,61 @@ mod tests {
             app.connections.find_by_name("editme2").is_some(),
             "Connection should be renamed to 'editme2'"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_duplicate_connection_opens_prefilled_new_form_and_saves() {
+        let _guard = ConfigDirGuard::new();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+
+        app.connection_picker = None;
+        app.connection_manager = None;
+
+        let entry = ConnectionEntry {
+            name: "editme".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            database: "testdb".to_string(),
+            user: "postgres".to_string(),
+            ..Default::default()
+        };
+        app.connections = ConnectionsFile::new();
+        app.connections.add(entry.clone()).unwrap();
+
+        app.connection_manager = Some(ConnectionManagerModal::new(
+            &app.connections,
+            app.current_connection_name.clone(),
+        ));
+
+        app.on_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        assert!(
+            app.connection_form.is_some(),
+            "Connection form should open after pressing 'y'"
+        );
+
+        app.on_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
+
+        assert!(
+            app.connection_form.is_none(),
+            "Connection form should close after saving duplicate. last_error={:?}, last_status={:?}",
+            app.last_error,
+            app.last_status
+        );
+        assert!(
+            app.connections.find_by_name("editme-copy").is_some(),
+            "Duplicated connection should be saved with a unique name"
+        );
+        let duplicate = app.connections.find_by_name("editme-copy").unwrap();
+        assert_eq!(duplicate.host, "localhost");
+        assert_eq!(duplicate.database, "testdb");
     }
 
     /// Issue 3: Esc in connection manager should close it in one press

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -2267,6 +2267,8 @@ pub struct App {
     pub password_prompt: Option<PasswordPrompt>,
     /// AI query assistant modal.
     pub ai_modal: Option<AiQueryModal>,
+    /// Editor mode active before the AI modal was opened.
+    ai_modal_previous_mode: Option<Mode>,
     /// Monotonic sequence for async AI requests.
     ai_request_seq: u64,
     /// Current in-flight AI request id (if any).
@@ -2450,6 +2452,7 @@ impl App {
             connection_form: None,
             password_prompt: None,
             ai_modal: None,
+            ai_modal_previous_mode: None,
             ai_request_seq: 0,
             ai_pending_request_id: None,
 
@@ -5586,6 +5589,7 @@ impl App {
     }
 
     fn open_ai_modal(&mut self, prefill: Option<String>) {
+        self.ai_modal_previous_mode = Some(self.mode);
         self.ai_modal = Some(AiQueryModal::new(prefill));
         self.focus = Focus::Query;
         self.mode = Mode::Insert;
@@ -5641,6 +5645,9 @@ impl App {
             AiQueryModalAction::Close => {
                 self.ai_modal = None;
                 self.ai_pending_request_id = None;
+                if let Some(mode) = self.ai_modal_previous_mode.take() {
+                    self.mode = mode;
+                }
                 self.last_status = Some("AI assistant closed".to_string());
             }
             AiQueryModalAction::Send { prompt } => {
@@ -5659,6 +5666,7 @@ impl App {
                 self.focus = Focus::Query;
                 self.mode = Mode::Insert;
                 self.ai_modal = None;
+                self.ai_modal_previous_mode = None;
                 self.ai_pending_request_id = None;
                 self.last_status = Some("AI proposal accepted into query editor".to_string());
             }
@@ -10559,6 +10567,34 @@ mod tests {
         app.handle_ai_modal_action(AiQueryModalAction::Accept);
 
         assert_eq!(app.editor.text(), "select * from users;");
+        assert!(app.ai_modal.is_none());
+    }
+
+    #[test]
+    fn test_ai_close_restores_previous_mode() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut config = Config::default();
+        config.ai.enabled = true;
+
+        let mut app = App::with_config(
+            GridModel::empty(),
+            rt.handle().clone(),
+            tx,
+            rx,
+            None,
+            config,
+        );
+        app.mode = Mode::Normal;
+
+        app.open_ai_modal(None);
+        app.handle_ai_modal_action(AiQueryModalAction::Close);
+
+        assert_eq!(app.mode, Mode::Normal);
         assert!(app.ai_modal.is_none());
     }
 

--- a/crates/tsql/src/config/keymap.rs
+++ b/crates/tsql/src/config/keymap.rs
@@ -84,6 +84,7 @@ pub enum Action {
     ForceQuit,
     Help,
     ShowHistory,
+    OpenAiAssistant,
     Refresh,
 
     // Connection
@@ -168,6 +169,7 @@ impl Action {
             Action::ForceQuit => "Force quit without saving",
             Action::Help => "Show help",
             Action::ShowHistory => "Show query history",
+            Action::OpenAiAssistant => "Open AI query assistant",
             Action::Refresh => "Refresh/re-run query",
             Action::Connect => "Connect to database",
             Action::Disconnect => "Disconnect from database",
@@ -269,6 +271,7 @@ impl FromStr for Action {
             "force_quit" => Ok(Action::ForceQuit),
             "help" => Ok(Action::Help),
             "show_history" => Ok(Action::ShowHistory),
+            "open_ai_assistant" => Ok(Action::OpenAiAssistant),
             "refresh" => Ok(Action::Refresh),
 
             // Connection
@@ -788,6 +791,11 @@ impl Keymap {
             KeyBinding::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
             Action::ShowHistory,
         );
+        // Open AI assistant
+        km.bind(
+            KeyBinding::new(KeyCode::Char('g'), KeyModifiers::CONTROL),
+            Action::OpenAiAssistant,
+        );
 
         // Sidebar
         km.bind(
@@ -870,6 +878,11 @@ impl Keymap {
         km.bind(
             KeyBinding::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
             Action::ShowHistory,
+        );
+        // Open AI assistant
+        km.bind(
+            KeyBinding::new(KeyCode::Char('g'), KeyModifiers::CONTROL),
+            Action::OpenAiAssistant,
         );
 
         // Sidebar
@@ -1017,6 +1030,9 @@ mod tests {
 
         let alt_m = KeyBinding::new(KeyCode::Char('m'), KeyModifiers::ALT);
         assert_eq!(km.get(&alt_m), Some(&Action::ToggleQueryHeight));
+
+        let ctrl_g = KeyBinding::new(KeyCode::Char('g'), KeyModifiers::CONTROL);
+        assert_eq!(km.get(&ctrl_g), Some(&Action::OpenAiAssistant));
     }
 
     #[test]
@@ -1025,6 +1041,9 @@ mod tests {
 
         let alt_m = KeyBinding::new(KeyCode::Char('m'), KeyModifiers::ALT);
         assert_eq!(km.get(&alt_m), Some(&Action::ToggleQueryHeight));
+
+        let ctrl_g = KeyBinding::new(KeyCode::Char('g'), KeyModifiers::CONTROL);
+        assert_eq!(km.get(&ctrl_g), Some(&Action::OpenAiAssistant));
     }
 
     #[test]
@@ -1066,6 +1085,10 @@ mod tests {
         assert_eq!(
             "toggle_query_height".parse::<Action>().unwrap(),
             Action::ToggleQueryHeight
+        );
+        assert_eq!(
+            "open_ai_assistant".parse::<Action>().unwrap(),
+            Action::OpenAiAssistant
         );
     }
 

--- a/crates/tsql/src/config/mod.rs
+++ b/crates/tsql/src/config/mod.rs
@@ -16,9 +16,9 @@ pub use connections::{
 };
 pub use keymap::{Action, KeyBinding, Keymap};
 pub use schema::{
-    ClipboardBackend, ClipboardConfig, Config, ConnectionConfig, CustomKeyBinding, DisplayConfig,
-    EditorConfig, IdentifierStyle, KeymapConfig, SqlConfig, UpdateChannel, UpdateMode,
-    UpdatesConfig,
+    AiConfig, AiProvider, ClipboardBackend, ClipboardConfig, Config, ConnectionConfig,
+    CustomKeyBinding, DisplayConfig, EditorConfig, IdentifierStyle, KeymapConfig, SqlConfig,
+    UpdateChannel, UpdateMode, UpdatesConfig,
 };
 
 use anyhow::{Context, Result};
@@ -237,7 +237,7 @@ pub fn config_dir() -> Option<PathBuf> {
 
     #[cfg(unix)]
     {
-        return unix_dot_tsql_config_dir();
+        unix_dot_tsql_config_dir()
     }
 
     #[cfg(not(unix))]

--- a/crates/tsql/src/config/schema.rs
+++ b/crates/tsql/src/config/schema.rs
@@ -266,7 +266,13 @@ pub enum UpdateMode {
     Off,
 }
 
-/// AI provider selection.
+/// LLM provider backend for the AI query assistant.
+///
+/// Each variant maps to a `run_*_request` function in [`crate::ai`] and
+/// determines the default API key environment variable via
+/// [`crate::ai`]'s `default_api_key_env_for_provider`. Serialized as
+/// `snake_case` with explicit aliases where the TOML name differs from the
+/// Rust variant name (e.g. `"google"` / `"gemini"`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AiProvider {
@@ -281,7 +287,12 @@ pub enum AiProvider {
     OpenRouter,
 }
 
-/// AI assistant settings.
+/// Configuration for the `[ai]` section of `config.toml`.
+///
+/// Defaults are chosen for zero-config failure: `enabled` is `false`, so the
+/// feature is inert unless the user opts in. When enabled, the default
+/// provider is OpenAI with `gpt-4o-mini`, a conservative temperature of 0.1,
+/// and a 30-second timeout.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AiConfig {

--- a/crates/tsql/src/config/schema.rs
+++ b/crates/tsql/src/config/schema.rs
@@ -21,6 +21,8 @@ pub struct Config {
     pub keymap: KeymapConfig,
     /// Update checking settings
     pub updates: UpdatesConfig,
+    /// AI assistant settings
+    pub ai: AiConfig,
 }
 
 /// Display-related settings
@@ -264,6 +266,73 @@ pub enum UpdateMode {
     Off,
 }
 
+/// AI provider selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AiProvider {
+    OpenAi,
+    OpenAiCompatible,
+    Ollama,
+    #[serde(rename = "anthropic")]
+    Anthropic,
+    #[serde(rename = "google", alias = "gemini")]
+    Google,
+    #[serde(rename = "openrouter", alias = "open_router")]
+    OpenRouter,
+}
+
+/// AI assistant settings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AiConfig {
+    /// Enable AI assistant features.
+    pub enabled: bool,
+    /// Provider backend used for query generation.
+    pub provider: AiProvider,
+    /// Model identifier for the selected provider.
+    pub model: String,
+    /// Sampling temperature.
+    pub temperature: f64,
+    /// Maximum output tokens.
+    pub max_tokens: u64,
+    /// Request timeout in seconds.
+    pub request_timeout_secs: u64,
+    /// Optional provider base URL override.
+    pub base_url: Option<String>,
+    /// Environment variable name containing API key/token.
+    pub api_key_env: String,
+    /// Include schema context in AI prompt.
+    pub include_schema_context: bool,
+    /// Maximum number of tables/collections to include in prompt context.
+    pub max_schema_tables: usize,
+    /// Maximum number of columns/fields per table/collection in prompt context.
+    pub max_columns_per_table: usize,
+    /// Optional custom system prompt for PostgreSQL generation.
+    pub system_prompt_postgres: Option<String>,
+    /// Optional custom system prompt for Mongo generation.
+    pub system_prompt_mongo: Option<String>,
+}
+
+impl Default for AiConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            provider: AiProvider::OpenAi,
+            model: "gpt-4o-mini".to_string(),
+            temperature: 0.1,
+            max_tokens: 1024,
+            request_timeout_secs: 30,
+            base_url: None,
+            api_key_env: "OPENAI_API_KEY".to_string(),
+            include_schema_context: true,
+            max_schema_tables: 25,
+            max_columns_per_table: 20,
+            system_prompt_postgres: None,
+            system_prompt_mongo: None,
+        }
+    }
+}
+
 /// SQL generation / templating settings
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
@@ -344,6 +413,21 @@ interval_hours = 12
 allow_apply_for_standalone = true
 github_repo = "fcoury/tsql"
 
+[ai]
+enabled = true
+provider = "open_ai"
+model = "gpt-4o-mini"
+temperature = 0.2
+max_tokens = 512
+request_timeout_secs = 20
+base_url = "https://api.openai.com/v1"
+api_key_env = "OPENAI_API_KEY"
+include_schema_context = true
+max_schema_tables = 10
+max_columns_per_table = 12
+system_prompt_postgres = "Only output PostgreSQL."
+system_prompt_mongo = "Only output Mongo syntax."
+
 [[keymap.normal]]
 key = "ctrl+s"
 action = "save_query"
@@ -398,6 +482,30 @@ description = "Export results as CSV"
         assert_eq!(config.updates.interval_hours, 12);
         assert!(config.updates.allow_apply_for_standalone);
         assert_eq!(config.updates.github_repo, "fcoury/tsql");
+
+        // AI
+        assert!(config.ai.enabled);
+        assert_eq!(config.ai.provider, AiProvider::OpenAi);
+        assert_eq!(config.ai.model, "gpt-4o-mini");
+        assert_eq!(config.ai.temperature, 0.2);
+        assert_eq!(config.ai.max_tokens, 512);
+        assert_eq!(config.ai.request_timeout_secs, 20);
+        assert_eq!(
+            config.ai.base_url,
+            Some("https://api.openai.com/v1".to_string())
+        );
+        assert_eq!(config.ai.api_key_env, "OPENAI_API_KEY");
+        assert!(config.ai.include_schema_context);
+        assert_eq!(config.ai.max_schema_tables, 10);
+        assert_eq!(config.ai.max_columns_per_table, 12);
+        assert_eq!(
+            config.ai.system_prompt_postgres,
+            Some("Only output PostgreSQL.".to_string())
+        );
+        assert_eq!(
+            config.ai.system_prompt_mongo,
+            Some("Only output Mongo syntax.".to_string())
+        );
     }
 
     #[test]
@@ -408,5 +516,6 @@ description = "Export results as CSV"
         assert!(toml_str.contains("[editor]"));
         assert!(toml_str.contains("[connection]"));
         assert!(toml_str.contains("[updates]"));
+        assert!(toml_str.contains("[ai]"));
     }
 }

--- a/crates/tsql/src/lib.rs
+++ b/crates/tsql/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ai;
 pub mod app;
 mod clipboard;
 pub mod config;

--- a/crates/tsql/src/ui/ai_query_modal.rs
+++ b/crates/tsql/src/ui/ai_query_modal.rs
@@ -1,3 +1,16 @@
+//! Full-screen modal for the AI query assistant.
+//!
+//! Owns the prompt input, conversation history, latest proposal, and pending
+//! request state. All keyboard input is captured while the modal is open;
+//! `App` delegates to [`AiQueryModal::handle_key`] and reacts to the returned
+//! [`AiQueryModalAction`].
+//!
+//! Key bindings inside the modal:
+//! - **Ctrl+E** -- send the current prompt to the AI backend.
+//! - **Ctrl+Y** -- accept the latest proposal into the query editor.
+//! - **Ctrl+U** -- clear the prompt input.
+//! - **Esc** -- close the modal without accepting.
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -8,19 +21,32 @@ use tui_textarea::{Input, TextArea};
 
 use crate::ai::{AiProposal, AiTurn};
 
+/// Result of handling a single key event inside the AI modal.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AiQueryModalAction {
+    /// Key was consumed; no state change needed in `App`.
     Continue,
+    /// User wants to close the modal.
     Close,
+    /// User wants to send the given prompt to the AI backend.
     Send { prompt: String },
+    /// User wants to accept the latest proposal into the query editor.
     Accept,
 }
 
+/// Modal state for the AI query assistant.
+///
+/// The modal tracks its own conversation and the latest AI proposal. `App`
+/// calls [`begin_request`](Self::begin_request) before spawning the async
+/// task and [`apply_reply`](Self::apply_reply) when the `DbEvent::AiReply`
+/// arrives.
 pub struct AiQueryModal {
     input: TextArea<'static>,
     conversation: Vec<AiTurn>,
     latest_proposal: Option<AiProposal>,
     pending: bool,
+    /// The prompt text that was sent with the in-flight request, used to
+    /// record the conversation turn when the reply arrives.
     pending_prompt: Option<String>,
     last_error: Option<String>,
 }
@@ -58,12 +84,18 @@ impl AiQueryModal {
         self.last_error = None;
     }
 
+    /// Mark the modal as "waiting for AI response" and stash the prompt so it
+    /// can be recorded into the conversation when the reply arrives.
     pub fn begin_request(&mut self, prompt: String) {
         self.pending = true;
         self.pending_prompt = Some(prompt);
         self.last_error = None;
     }
 
+    /// Consume an AI backend response. On success the proposal is stored and a
+    /// conversation turn is recorded. On failure the error is shown in the
+    /// status area. If no `pending_prompt` is set (shouldn't happen in
+    /// practice), the call is a no-op.
     pub fn apply_reply(&mut self, result: std::result::Result<AiProposal, String>) {
         let Some(prompt) = self.pending_prompt.take() else {
             self.pending = false;
@@ -136,10 +168,8 @@ impl AiQueryModal {
     }
 
     pub fn render(&mut self, frame: &mut Frame, area: Rect) {
-        let width =
-            (area.width.saturating_mul(90) / 100).clamp(70, area.width.saturating_sub(2).max(1));
-        let height =
-            (area.height.saturating_mul(80) / 100).clamp(18, area.height.saturating_sub(2).max(1));
+        let width = modal_dimension(area.width, 90, 70);
+        let height = modal_dimension(area.height, 80, 18);
 
         let popup = Rect {
             x: area.x + (area.width.saturating_sub(width)) / 2,
@@ -270,5 +300,43 @@ impl AiQueryModal {
             ))
         };
         frame.render_widget(Paragraph::new(status), chunks[3]);
+    }
+}
+
+fn modal_dimension(total: u16, percent: u16, preferred_min: u16) -> u16 {
+    let max = total.saturating_sub(2).max(1);
+    let desired = total.saturating_mul(percent) / 100;
+    desired.max(preferred_min).min(max)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    #[test]
+    fn test_render_does_not_panic_on_small_terminal() {
+        let backend = TestBackend::new(20, 8);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut modal = AiQueryModal::new(None);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            terminal
+                .draw(|frame| {
+                    let area = frame.area();
+                    modal.render(frame, area);
+                })
+                .unwrap();
+        }));
+
+        assert!(result.is_ok(), "render should not panic on a small terminal");
+    }
+
+    #[test]
+    fn test_modal_dimension_caps_to_available_space() {
+        assert_eq!(modal_dimension(20, 90, 70), 18);
+        assert_eq!(modal_dimension(8, 80, 18), 6);
+        assert_eq!(modal_dimension(120, 90, 70), 108);
     }
 }

--- a/crates/tsql/src/ui/ai_query_modal.rs
+++ b/crates/tsql/src/ui/ai_query_modal.rs
@@ -1,0 +1,274 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
+use ratatui::Frame;
+use tui_textarea::{Input, TextArea};
+
+use crate::ai::{AiProposal, AiTurn};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AiQueryModalAction {
+    Continue,
+    Close,
+    Send { prompt: String },
+    Accept,
+}
+
+pub struct AiQueryModal {
+    input: TextArea<'static>,
+    conversation: Vec<AiTurn>,
+    latest_proposal: Option<AiProposal>,
+    pending: bool,
+    pending_prompt: Option<String>,
+    last_error: Option<String>,
+}
+
+impl AiQueryModal {
+    pub fn new(prefill: Option<String>) -> Self {
+        let mut input = TextArea::new(vec![prefill.unwrap_or_default()]);
+        input.set_cursor_line_style(Style::default().add_modifier(Modifier::UNDERLINED));
+        Self {
+            input,
+            conversation: Vec::new(),
+            latest_proposal: None,
+            pending: false,
+            pending_prompt: None,
+            last_error: None,
+        }
+    }
+
+    pub fn is_pending(&self) -> bool {
+        self.pending
+    }
+
+    pub fn conversation(&self) -> Vec<AiTurn> {
+        self.conversation.clone()
+    }
+
+    pub fn latest_query(&self) -> Option<&str> {
+        self.latest_proposal.as_ref().map(|p| p.query.as_str())
+    }
+
+    pub fn set_input_text(&mut self, text: String) {
+        self.input = TextArea::new(vec![text]);
+        self.input
+            .set_cursor_line_style(Style::default().add_modifier(Modifier::UNDERLINED));
+        self.last_error = None;
+    }
+
+    pub fn begin_request(&mut self, prompt: String) {
+        self.pending = true;
+        self.pending_prompt = Some(prompt);
+        self.last_error = None;
+    }
+
+    pub fn apply_reply(&mut self, result: std::result::Result<AiProposal, String>) {
+        let Some(prompt) = self.pending_prompt.take() else {
+            self.pending = false;
+            return;
+        };
+
+        self.pending = false;
+        match result {
+            Ok(proposal) => {
+                self.last_error = None;
+                self.conversation.push(AiTurn {
+                    user_prompt: prompt,
+                    assistant_query: proposal.query.clone(),
+                });
+                self.latest_proposal = Some(proposal);
+            }
+            Err(error) => {
+                self.last_error = Some(error);
+            }
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> AiQueryModalAction {
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, KeyModifiers::NONE) => AiQueryModalAction::Close,
+            (KeyCode::Char('e'), KeyModifiers::CONTROL) => {
+                if self.pending {
+                    self.last_error = Some("AI request already running".to_string());
+                    return AiQueryModalAction::Continue;
+                }
+                let prompt = self.text().trim().to_string();
+                if prompt.is_empty() {
+                    self.last_error = Some("Prompt cannot be empty".to_string());
+                    return AiQueryModalAction::Continue;
+                }
+                self.input = TextArea::new(vec![String::new()]);
+                self.input
+                    .set_cursor_line_style(Style::default().add_modifier(Modifier::UNDERLINED));
+                AiQueryModalAction::Send { prompt }
+            }
+            (KeyCode::Char('y'), KeyModifiers::CONTROL) => {
+                if self.pending {
+                    self.last_error = Some("Wait for AI response before accepting".to_string());
+                    return AiQueryModalAction::Continue;
+                }
+                if self.latest_proposal.is_none() {
+                    self.last_error = Some("No AI proposal to accept yet".to_string());
+                    return AiQueryModalAction::Continue;
+                }
+                AiQueryModalAction::Accept
+            }
+            (KeyCode::Char('u'), KeyModifiers::CONTROL) => {
+                self.input = TextArea::new(vec![String::new()]);
+                self.input
+                    .set_cursor_line_style(Style::default().add_modifier(Modifier::UNDERLINED));
+                self.last_error = None;
+                AiQueryModalAction::Continue
+            }
+            _ => {
+                let input: Input = key.into();
+                self.input.input(input);
+                self.last_error = None;
+                AiQueryModalAction::Continue
+            }
+        }
+    }
+
+    fn text(&self) -> String {
+        self.input.lines().join("\n")
+    }
+
+    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+        let width =
+            (area.width.saturating_mul(90) / 100).clamp(70, area.width.saturating_sub(2).max(1));
+        let height =
+            (area.height.saturating_mul(80) / 100).clamp(18, area.height.saturating_sub(2).max(1));
+
+        let popup = Rect {
+            x: area.x + (area.width.saturating_sub(width)) / 2,
+            y: area.y + (area.height.saturating_sub(height)) / 2,
+            width,
+            height,
+        };
+
+        frame.render_widget(Clear, popup);
+        let block = Block::default()
+            .title(" AI Query Assistant ")
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Color::Cyan));
+        frame.render_widget(block, popup);
+
+        let inner = popup.inner(ratatui::layout::Margin {
+            horizontal: 1,
+            vertical: 1,
+        });
+        let chunks = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(5),
+            Constraint::Min(6),
+            Constraint::Length(2),
+        ])
+        .split(inner);
+
+        let header = Line::from(vec![
+            Span::raw("Ctrl+E send  "),
+            Span::raw("Ctrl+Y accept  "),
+            Span::raw("Esc close"),
+        ]);
+        frame.render_widget(
+            Paragraph::new(header).style(Style::default().fg(Color::Gray)),
+            chunks[0],
+        );
+
+        self.input.set_block(
+            Block::default()
+                .title(" Prompt / Follow-up ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Yellow)),
+        );
+        frame.render_widget(&self.input, chunks[1]);
+
+        let mut details = Vec::new();
+        if self.pending {
+            details.push(Line::from(Span::styled(
+                "Generating query...",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            if let Some(prompt) = self.pending_prompt.as_deref() {
+                details.push(Line::from(format!("Last request: {}", prompt.trim())));
+            }
+            details.push(Line::from(""));
+        }
+
+        if let Some(proposal) = self.latest_proposal.as_ref() {
+            details.push(Line::from(Span::styled(
+                "Proposed query:",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            for line in proposal.query.lines() {
+                details.push(Line::from(line.to_string()));
+            }
+            if let Some(explanation) = proposal.explanation.as_deref() {
+                details.push(Line::from(""));
+                details.push(Line::from(Span::styled(
+                    "Explanation:",
+                    Style::default().fg(Color::Gray),
+                )));
+                details.push(Line::from(explanation.to_string()));
+            }
+            details.push(Line::from(""));
+        } else {
+            details.push(Line::from(Span::styled(
+                "No proposal yet. Type a prompt and press Ctrl+E.",
+                Style::default().fg(Color::Gray),
+            )));
+            details.push(Line::from(""));
+        }
+
+        if !self.conversation.is_empty() {
+            details.push(Line::from(Span::styled(
+                "Recent turns:",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            for turn in self.conversation.iter().rev().take(3).rev() {
+                details.push(Line::from(format!("U: {}", turn.user_prompt.trim())));
+                details.push(Line::from(format!("A: {}", turn.assistant_query.trim())));
+                details.push(Line::from(""));
+            }
+        }
+
+        frame.render_widget(
+            Paragraph::new(details)
+                .block(
+                    Block::default()
+                        .title(" Proposal ")
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::Blue)),
+                )
+                .wrap(Wrap { trim: false }),
+            chunks[2],
+        );
+
+        let status = if let Some(err) = self.last_error.as_deref() {
+            Line::from(Span::styled(
+                err.to_string(),
+                Style::default().fg(Color::Red),
+            ))
+        } else if self.pending {
+            Line::from(Span::styled(
+                "Waiting for AI response...",
+                Style::default().fg(Color::Cyan),
+            ))
+        } else {
+            Line::from(Span::styled(
+                "Accept replaces the entire query editor content.",
+                Style::default().fg(Color::Gray),
+            ))
+        };
+        frame.render_widget(Paragraph::new(status), chunks[3]);
+    }
+}

--- a/crates/tsql/src/ui/ai_query_modal.rs
+++ b/crates/tsql/src/ui/ai_query_modal.rs
@@ -330,7 +330,10 @@ mod tests {
                 .unwrap();
         }));
 
-        assert!(result.is_ok(), "render should not panic on a small terminal");
+        assert!(
+            result.is_ok(),
+            "render should not panic on a small terminal"
+        );
     }
 
     #[test]

--- a/crates/tsql/src/ui/confirm_prompt.rs
+++ b/crates/tsql/src/ui/confirm_prompt.rs
@@ -50,6 +50,8 @@ pub enum ConfirmContext {
     SwitchConnection { entry: ConnectionEntry },
     /// Applying an in-app binary update.
     ApplyUpdate { info: UpdateInfo },
+    /// Opening the AI assistant when current query editor has content.
+    OpenAiAssistant { prefill: Option<String> },
 }
 
 /// A reusable confirmation dialog for unsaved changes.
@@ -117,7 +119,8 @@ impl ConfirmPrompt {
             | ConfirmContext::CloseCellEditor { .. }
             | ConfirmContext::QuitApp
             | ConfirmContext::CloseConnectionForm
-            | ConfirmContext::SwitchConnection { .. } => " Unsaved Changes ",
+            | ConfirmContext::SwitchConnection { .. }
+            | ConfirmContext::OpenAiAssistant { .. } => " Unsaved Changes ",
             ConfirmContext::QuitAppClean => " Confirm Quit ",
             ConfirmContext::DeleteConnection { .. } => " Delete Connection ",
             ConfirmContext::ApplyUpdate { .. } => " Apply Update ",

--- a/crates/tsql/src/ui/connection_form.rs
+++ b/crates/tsql/src/ui/connection_form.rs
@@ -317,6 +317,11 @@ impl ConnectionFormModal {
     }
 
     /// Create a new-connection form prefilled from an existing connection.
+    ///
+    /// The form opens in "new entry" mode (`original_name` is `None`), so
+    /// saving creates a fresh connection rather than overwriting the source.
+    /// `duplicate_name` should already be unique (see
+    /// `App::duplicate_connection_name`).
     pub fn duplicate_with_keymap_and_onepassword(
         entry: &ConnectionEntry,
         existing_password: Option<String>,

--- a/crates/tsql/src/ui/connection_form.rs
+++ b/crates/tsql/src/ui/connection_form.rs
@@ -316,6 +316,61 @@ impl ConnectionFormModal {
         }
     }
 
+    /// Create a new-connection form prefilled from an existing connection.
+    pub fn duplicate_with_keymap_and_onepassword(
+        entry: &ConnectionEntry,
+        existing_password: Option<String>,
+        duplicate_name: String,
+        keymap: Keymap,
+        onepassword_enabled: bool,
+    ) -> Self {
+        let password = existing_password.unwrap_or_default();
+        let op_ref = entry.password_onepassword.clone().unwrap_or_default();
+        let color_index = ConnectionColor::all_names()
+            .iter()
+            .position(|&c| c == entry.color.to_string())
+            .unwrap_or(0);
+
+        let ssl_mode = entry.ssl_mode.unwrap_or(SslMode::Disable);
+        let ssl_mode_index = ssl_mode.to_index();
+
+        Self {
+            name_cursor: duplicate_name.chars().count(),
+            host_cursor: entry.host.chars().count(),
+            port_cursor: entry.port.to_string().chars().count(),
+            database_cursor: entry.database.chars().count(),
+            user_cursor: entry.user.chars().count(),
+            password_cursor: password.chars().count(),
+            op_ref_cursor: op_ref.chars().count(),
+
+            name: duplicate_name,
+            kind: entry.kind,
+            mongo_uri: entry.uri.clone(),
+            host: entry.host.clone(),
+            port: entry.port.to_string(),
+            database: entry.database.clone(),
+            user: entry.user.clone(),
+            password,
+            op_ref,
+            save_password: entry.password_in_keychain,
+            ssl_mode,
+            color: entry.color,
+            url_paste: String::new(),
+            url_paste_cursor: 0,
+
+            focused: FormField::Name,
+            color_index,
+            ssl_mode_index,
+            editing: false,
+            original_name: None,
+            title: format!("Duplicate: {}", entry.name),
+            modified: false,
+            original_values: None,
+            keymap,
+            onepassword_enabled,
+        }
+    }
+
     /// Check if the form has unsaved changes.
     pub fn is_modified(&self) -> bool {
         if self.modified {
@@ -1484,6 +1539,36 @@ mod tests {
 
         let form = ConnectionFormModal::edit(&entry, None);
         assert_eq!(form.name_cursor, entry.name.chars().count());
+    }
+
+    #[test]
+    fn test_duplicate_form() {
+        let entry = ConnectionEntry {
+            name: "test".to_string(),
+            host: "db.example.com".to_string(),
+            port: 5433,
+            database: "mydb".to_string(),
+            user: "admin".to_string(),
+            color: ConnectionColor::Green,
+            favorite: Some(2),
+            ..Default::default()
+        };
+
+        let form = ConnectionFormModal::duplicate_with_keymap_and_onepassword(
+            &entry,
+            Some("secret".to_string()),
+            "test copy".to_string(),
+            Keymap::default_connection_form_keymap(),
+            true,
+        );
+
+        assert_eq!(form.name, "test copy");
+        assert_eq!(form.host, "db.example.com");
+        assert_eq!(form.port, "5433");
+        assert_eq!(form.password, "secret");
+        assert!(!form.editing);
+        assert!(form.original_name.is_none());
+        assert_eq!(form.title, "Duplicate: test");
     }
 
     #[test]

--- a/crates/tsql/src/ui/connection_manager.rs
+++ b/crates/tsql/src/ui/connection_manager.rs
@@ -3,7 +3,7 @@
 //! This modal provides:
 //! - List of saved connections with status indicators
 //! - Vim-like navigation (j/k, g/G, Ctrl+d/u)
-//! - Actions: connect, add, edit, delete, set favorite
+//! - Actions: connect, add, duplicate, edit, delete, set favorite
 //! - Visual indicators for connected state and favorites
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -36,6 +36,11 @@ pub enum ConnectionManagerAction {
     /// Open the edit form for the selected connection.
     Edit {
         /// The connection entry to edit
+        entry: ConnectionEntry,
+    },
+    /// Open a new form prefilled from the selected connection.
+    Duplicate {
+        /// The connection entry to duplicate
         entry: ConnectionEntry,
     },
     /// Delete the selected connection (requires confirmation).
@@ -163,6 +168,17 @@ impl ConnectionManagerModal {
             (KeyCode::Char('e'), KeyModifiers::NONE) => {
                 if let Some(entry) = self.selected_connection() {
                     ConnectionManagerAction::Edit {
+                        entry: entry.clone(),
+                    }
+                } else {
+                    ConnectionManagerAction::Continue
+                }
+            }
+
+            // Duplicate selected connection
+            (KeyCode::Char('y'), KeyModifiers::NONE) => {
+                if let Some(entry) = self.selected_connection() {
+                    ConnectionManagerAction::Duplicate {
                         entry: entry.clone(),
                     }
                 } else {
@@ -540,6 +556,8 @@ impl ConnectionManagerModal {
         let help_spans = vec![
             Span::styled("[a]", Style::default().fg(Color::Yellow)),
             Span::raw("dd "),
+            Span::styled("[y]", Style::default().fg(Color::Yellow)),
+            Span::raw(" duplicate "),
             Span::styled("[e]", Style::default().fg(Color::Yellow)),
             Span::raw("dit "),
             Span::styled("[d]", Style::default().fg(Color::Yellow)),
@@ -728,6 +746,21 @@ mod tests {
                 assert_eq!(entry.name, "local");
             }
             _ => panic!("Expected Edit action"),
+        }
+    }
+
+    #[test]
+    fn test_duplicate_action() {
+        let file = create_test_connections();
+        let mut manager = ConnectionManagerModal::new(&file, None);
+
+        let action = manager.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        match action {
+            ConnectionManagerAction::Duplicate { entry } => {
+                assert_eq!(entry.name, "local");
+            }
+            _ => panic!("Expected Duplicate action"),
         }
     }
 

--- a/crates/tsql/src/ui/editor.rs
+++ b/crates/tsql/src/ui/editor.rs
@@ -161,9 +161,10 @@ impl QueryEditor {
         if self.history_index.is_none() {
             self.history_draft = Some(self.text());
             self.history_index = Some(self.history.len().saturating_sub(1));
-        } else {
-            let i = self.history_index.unwrap();
+        } else if let Some(i) = self.history_index {
             self.history_index = Some(i.saturating_sub(1));
+        } else {
+            return;
         }
 
         if let Some(i) = self.history_index {
@@ -258,9 +259,7 @@ impl QueryEditor {
     fn classify_word_char(c: char, big_word: bool) -> u8 {
         if c.is_whitespace() {
             0
-        } else if big_word {
-            1
-        } else if c.is_ascii_alphanumeric() || c == '_' {
+        } else if big_word || c.is_ascii_alphanumeric() || c == '_' {
             1
         } else {
             2

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -82,6 +82,7 @@ const GLOBAL: HelpSection = HelpSection::new(
         KeyBinding::new("?", "Toggle this help  (/ to filter inside)"),
         KeyBinding::new("Ctrl+o", "Open connection picker"),
         KeyBinding::new("Ctrl+Shift+C", "Open connection manager"),
+        KeyBinding::new("Ctrl+g", "Open AI query assistant"),
         KeyBinding::new(":sbt / :sidebar-toggle", "Toggle sidebar"),
     ],
 );
@@ -253,6 +254,7 @@ const COMMANDS: HelpSection = HelpSection::new(
         KeyBinding::new(":export <fmt> <path>", "Export results (csv/json/tsv)"),
         KeyBinding::new(":gen <type>", "Generate SQL (update/delete/insert)"),
         KeyBinding::new(":history", "Open history picker"),
+        KeyBinding::new(":ai [prompt]", "Open AI query assistant"),
         KeyBinding::new(":update [check|status|apply]", "Check/apply updates"),
         KeyBinding::new(":sbt / :sidebar-toggle", "Toggle sidebar"),
         KeyBinding::new(":q / :quit", "Quit application"),

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -81,7 +81,10 @@ const GLOBAL: HelpSection = HelpSection::new(
         KeyBinding::new("q", "Quit application"),
         KeyBinding::new("?", "Toggle this help  (/ to filter inside)"),
         KeyBinding::new("Ctrl+o", "Open connection picker"),
-        KeyBinding::new("Ctrl+Shift+C", "Open connection manager"),
+        KeyBinding::new(
+            "Ctrl+Shift+C",
+            "Open connection manager (terminal-dependent)",
+        ),
         KeyBinding::new("Ctrl+g", "Open AI query assistant"),
         KeyBinding::new(":sbt / :sidebar-toggle", "Toggle sidebar"),
     ],

--- a/crates/tsql/src/ui/mod.rs
+++ b/crates/tsql/src/ui/mod.rs
@@ -1,3 +1,4 @@
+mod ai_query_modal;
 mod completion;
 mod confirm_prompt;
 mod connection_form;
@@ -17,6 +18,7 @@ mod row_detail;
 pub mod sidebar;
 mod status_line;
 
+pub use ai_query_modal::{AiQueryModal, AiQueryModalAction};
 pub use completion::{
     determine_context, get_word_before_cursor, ColumnInfo, CompletionContext, CompletionItem,
     CompletionKind, CompletionPopup, SchemaCache, TableInfo,

--- a/crates/tsql/src/update/state.rs
+++ b/crates/tsql/src/update/state.rs
@@ -4,23 +4,12 @@ use crate::config::{UpdateMode, UpdatesConfig};
 
 use super::types::{InstallMethod, UpdateCheckOutcome, UpdatePolicy};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct UpdateState {
     pub startup_check_started: bool,
     pub check_in_flight: bool,
     pub last_checked_at: Option<Instant>,
     pub last_outcome: Option<UpdateCheckOutcome>,
-}
-
-impl Default for UpdateState {
-    fn default() -> Self {
-        Self {
-            startup_check_started: false,
-            check_in_flight: false,
-            last_checked_at: None,
-            last_outcome: None,
-        }
-    }
 }
 
 impl UpdateState {


### PR DESCRIPTION
## Summary

This PR adds an AI query assistant with multi-provider support and extends
connection management with a duplicate workflow for saved connections.

## What Changed

- add the AI query assistant UI, app flow, configuration, and provider
  integration points
- document and expose the new AI configuration surface in `README.md` and
  `config.example.toml`
- add connection duplication from the manager, including a prefilled form,
  unique copied names, and updated help text
- add focused coverage for the duplicate-connection workflow

## Why

The AI assistant makes it easier to draft or refine SQL from within the TUI,
while the duplicate action removes repetitive manual editing when creating a
similar saved connection.

## Validation

- `cargo test -p tsql duplicate`
