### PR TITLE
fix(tui): defer startup reconnect and add manager actions

### DIFF
--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -7825,7 +7825,12 @@ impl App {
                 if entry.no_password_required {
                     self.start_connect(entry.to_url(None));
                 } else {
-                    self.begin_password_resolve(entry, PasswordResolveReason::Startup);
+                    let reason = if pending.automatic {
+                        PasswordResolveReason::Startup
+                    } else {
+                        PasswordResolveReason::UserPicked
+                    };
+                    self.begin_password_resolve(entry, reason);
                 }
             }
             None => {
@@ -13037,6 +13042,62 @@ mod tests {
 
         assert_eq!(app.db.status, DbStatus::Connecting);
         assert_eq!(app.current_connection_name.as_deref(), Some("saved"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_explicit_saved_connection_name_prompts_when_password_unavailable() {
+        let _guard = ConfigDirGuard::new();
+
+        let mut connections = ConnectionsFile::new();
+        connections
+            .add(ConnectionEntry {
+                name: "saved".to_string(),
+                host: "localhost".to_string(),
+                port: 5432,
+                database: "testdb".to_string(),
+                user: "postgres".to_string(),
+                password_in_keychain: true,
+                ..Default::default()
+            })
+            .unwrap();
+        save_connections(&connections).unwrap();
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(
+            GridModel::empty(),
+            rt.handle().clone(),
+            tx,
+            rx,
+            Some("saved".to_string()),
+        );
+
+        app.set_safe_mode(true);
+        app.dispatch_pending_startup_reconnect();
+
+        let generation = app
+            .password_resolve_in_flight
+            .get("saved")
+            .map(|pending| {
+                assert_eq!(pending.reason, PasswordResolveReason::UserPicked);
+                pending.generation
+            })
+            .expect("expected pending password resolve");
+        let entry = app.connections.find_by_name("saved").cloned().unwrap();
+
+        app.apply_db_event(DbEvent::PasswordResolved {
+            entry: Box::new(entry),
+            result: Ok(None),
+            password_resolve_generation: generation,
+        });
+
+        assert!(app.password_prompt.is_some());
+        assert!(app.connection_picker.is_none());
     }
 
     #[test]

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -215,6 +215,52 @@ fn resolve_ssl_mode(conn_str: &str) -> std::result::Result<SslMode, String> {
     Ok(default)
 }
 
+async fn probe_connection(url: &str, kind: DbKind) -> std::result::Result<(), String> {
+    if kind == DbKind::Mongo {
+        let client = mongodb::Client::with_uri_str(url)
+            .await
+            .map_err(|e| e.to_string())?;
+        client
+            .database("admin")
+            .run_command(doc! { "ping": 1 })
+            .await
+            .map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+
+    let ssl_mode = resolve_ssl_mode(url)?;
+    match ssl_mode {
+        SslMode::Disable => tokio_postgres::connect(url, NoTls)
+            .await
+            .map(|_| ())
+            .map_err(|e| format_pg_error(&e)),
+        SslMode::Require => {
+            let tls = make_rustls_connect_insecure();
+            tokio_postgres::connect(url, tls)
+                .await
+                .map(|_| ())
+                .map_err(|e| format_pg_error(&e))
+        }
+        SslMode::Prefer => {
+            let tls = make_rustls_connect_insecure();
+            match tokio_postgres::connect(url, tls).await {
+                Ok(_) => Ok(()),
+                Err(_) => tokio_postgres::connect(url, NoTls)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| format_pg_error(&e)),
+            }
+        }
+        SslMode::VerifyCa | SslMode::VerifyFull => {
+            let tls = make_rustls_connect_verified();
+            tokio_postgres::connect(url, tls)
+                .await
+                .map(|_| ())
+                .map_err(|e| format_pg_error(&e))
+        }
+    }
+}
+
 /// Normalize the max_rows config value.
 ///
 /// If the user sets max_rows to 0 in config (or leaves it unset), this returns
@@ -1889,16 +1935,20 @@ pub enum DbEvent {
         client: SharedClient,
         cancel_token: CancelToken,
         connected_with_tls: bool,
+        connect_generation: u64,
     },
     MongoConnected {
         client: SharedMongoClient,
         database: String,
+        connect_generation: u64,
     },
     ConnectError {
         error: String,
+        connect_generation: u64,
     },
     ConnectionLost {
         error: String,
+        connect_generation: u64,
     },
     QueryFinished {
         result: QueryResult,
@@ -1950,6 +2000,18 @@ pub enum DbEvent {
         request_id: u64,
         result: std::result::Result<AiProposal, String>,
     },
+    /// Result of a background password resolution for a saved connection.
+    PasswordResolved {
+        entry: Box<ConnectionEntry>,
+        result: std::result::Result<Option<String>, String>,
+        reason: PasswordResolveReason,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PasswordResolveReason {
+    Startup,
+    UserPicked,
 }
 
 pub struct DbSession {
@@ -2255,8 +2317,18 @@ pub struct App {
 
     /// Saved database connections.
     pub connections: ConnectionsFile,
-    /// Name of the currently connected connection (if from saved connections).
+    /// Name of the pending or currently connected saved connection.
     pub current_connection_name: Option<String>,
+    /// Name of the saved connection that is actually connected.
+    active_connection_name: Option<String>,
+    /// Saved connection name to reconnect after the first TUI frame.
+    pending_startup_reconnect: Option<String>,
+    /// Skip startup side effects that can block or touch the network.
+    safe_mode: bool,
+    /// Monotonic id used to ignore stale connect task completions.
+    connect_generation: u64,
+    /// Saved connection password resolves currently running off the UI thread.
+    password_resolve_in_flight: HashMap<String, PasswordResolveReason>,
     /// Connection picker (fuzzy picker for quick connection selection).
     pub connection_picker: Option<FuzzyPicker<ConnectionEntry>>,
     /// Connection manager modal (when open).
@@ -2447,6 +2519,11 @@ impl App {
 
             connections: ConnectionsFile::new(),
             current_connection_name: None,
+            active_connection_name: None,
+            pending_startup_reconnect: None,
+            safe_mode: false,
+            connect_generation: 0,
+            password_resolve_in_flight: HashMap::new(),
             connection_picker: None,
             connection_manager: None,
             connection_form: None,
@@ -2482,7 +2559,7 @@ impl App {
             if !url.contains("://") {
                 // Try to find a connection by name
                 if let Some(entry) = app.connections.find_by_name(&url) {
-                    app.connect_to_entry(entry.clone());
+                    app.pending_startup_reconnect = Some(entry.name.clone());
                 } else {
                     app.last_error = Some(format!("Unknown connection: {}", url));
                     // Open connection picker so user can select (falls back to manager if empty)
@@ -2502,7 +2579,11 @@ impl App {
     /// Capture current session state for persistence.
     pub fn capture_session_state(&self) -> SessionState {
         SessionState {
-            connection_name: self.current_connection_name.clone(),
+            connection_name: if self.db.status == DbStatus::Connected {
+                self.active_connection_name.clone()
+            } else {
+                None
+            },
             editor_content: self.editor.text(),
             schema_expanded: self.sidebar.get_expanded_nodes(),
             sidebar_visible: self.sidebar_visible,
@@ -2609,6 +2690,7 @@ impl App {
     }
 
     pub fn run(&mut self, terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+        let mut first_draw = true;
         loop {
             self.drain_db_events();
 
@@ -2617,7 +2699,9 @@ impl App {
                 self.query_ui.tick();
             }
 
-            self.maybe_start_scheduled_update_check();
+            if !self.safe_mode {
+                self.maybe_start_scheduled_update_check();
+            }
 
             // Pre-compute highlighted lines before the draw closure
             let query_text = self.editor.text();
@@ -3326,6 +3410,11 @@ impl App {
                 }
             })?;
 
+            if first_draw {
+                first_draw = false;
+                self.dispatch_pending_startup_reconnect();
+            }
+
             // Mark hint as shown after rendering (must be outside draw closure)
             if show_key_hint && !self.key_sequence.is_hint_shown() {
                 self.key_sequence.mark_hint_shown();
@@ -3413,6 +3502,7 @@ impl App {
                     return false;
                 }
                 PasswordPromptResult::Cancelled => {
+                    self.current_connection_name = self.active_connection_name.clone();
                     self.last_status = Some("Connection cancelled".to_string());
                     return false;
                 }
@@ -7432,6 +7522,8 @@ impl App {
         self.db.connected_with_tls = false;
 
         self.last_status = Some("Connecting...".to_string());
+        self.connect_generation = self.connect_generation.wrapping_add(1);
+        let connect_generation = self.connect_generation;
 
         let tx = self.db_events_tx.clone();
         let rt = self.rt.clone();
@@ -7446,17 +7538,20 @@ impl App {
                         if let Err(e) = ping_db.run_command(doc! { "ping": 1 }).await {
                             let _ = tx.send(DbEvent::ConnectError {
                                 error: format!("Mongo connection error: {e}"),
+                                connect_generation,
                             });
                             return;
                         }
                         let _ = tx.send(DbEvent::MongoConnected {
                             client: Arc::new(client),
                             database: db_name,
+                            connect_generation,
                         });
                     }
                     Err(e) => {
                         let _ = tx.send(DbEvent::ConnectError {
                             error: format!("Mongo connection error: {e}"),
+                            connect_generation,
                         });
                     }
                 }
@@ -7466,7 +7561,10 @@ impl App {
             let ssl_mode = match resolve_ssl_mode(&conn_str) {
                 Ok(m) => m,
                 Err(msg) => {
-                    let _ = tx.send(DbEvent::ConnectError { error: msg });
+                    let _ = tx.send(DbEvent::ConnectError {
+                        error: msg,
+                        connect_generation,
+                    });
                     return;
                 }
             };
@@ -7480,6 +7578,7 @@ impl App {
                                 if let Err(e) = connection.await {
                                     let _ = tx2.send(DbEvent::ConnectionLost {
                                         error: format_pg_error(&e),
+                                        connect_generation,
                                     });
                                 }
                             });
@@ -7490,11 +7589,13 @@ impl App {
                                 client: shared,
                                 cancel_token: token,
                                 connected_with_tls: false,
+                                connect_generation,
                             });
                         }
                         Err(e) => {
                             let _ = tx.send(DbEvent::ConnectError {
                                 error: format_pg_error(&e),
+                                connect_generation,
                             });
                         }
                     }
@@ -7509,6 +7610,7 @@ impl App {
                                 if let Err(e) = connection.await {
                                     let _ = tx2.send(DbEvent::ConnectionLost {
                                         error: format_pg_error(&e),
+                                        connect_generation,
                                     });
                                 }
                             });
@@ -7519,11 +7621,13 @@ impl App {
                                 client: shared,
                                 cancel_token: token,
                                 connected_with_tls: true,
+                                connect_generation,
                             });
                         }
                         Err(e) => {
                             let _ = tx.send(DbEvent::ConnectError {
                                 error: format_pg_error(&e),
+                                connect_generation,
                             });
                         }
                     }
@@ -7538,6 +7642,7 @@ impl App {
                                 if let Err(e) = connection.await {
                                     let _ = tx2.send(DbEvent::ConnectionLost {
                                         error: format_pg_error(&e),
+                                        connect_generation,
                                     });
                                 }
                             });
@@ -7548,6 +7653,7 @@ impl App {
                                 client: shared,
                                 cancel_token: token,
                                 connected_with_tls: true,
+                                connect_generation,
                             });
                         }
                         Err(e) => {
@@ -7559,6 +7665,7 @@ impl App {
                                         if let Err(e) = connection.await {
                                             let _ = tx2.send(DbEvent::ConnectionLost {
                                                 error: format_pg_error(&e),
+                                                connect_generation,
                                             });
                                         }
                                     });
@@ -7569,6 +7676,7 @@ impl App {
                                         client: shared,
                                         cancel_token: token,
                                         connected_with_tls: false,
+                                        connect_generation,
                                     });
                                 }
                                 Err(e) => {
@@ -7577,6 +7685,7 @@ impl App {
                                         error: format!(
                                             "{tls_error}\n\nTLS failed (sslmode=prefer), then plain connect failed:\n{plain_error}"
                                         ),
+                                        connect_generation,
                                     });
                                 }
                             }
@@ -7593,6 +7702,7 @@ impl App {
                                 if let Err(e) = connection.await {
                                     let _ = tx2.send(DbEvent::ConnectionLost {
                                         error: format_pg_error(&e),
+                                        connect_generation,
                                     });
                                 }
                             });
@@ -7603,11 +7713,13 @@ impl App {
                                 client: shared,
                                 cancel_token: token,
                                 connected_with_tls: true,
+                                connect_generation,
                             });
                         }
                         Err(e) => {
                             let _ = tx.send(DbEvent::ConnectError {
                                 error: format_pg_error(&e),
+                                connect_generation,
                             });
                         }
                     }
@@ -7618,41 +7730,116 @@ impl App {
 
     /// Connect to a saved connection entry.
     pub fn connect_to_entry(&mut self, entry: ConnectionEntry) {
-        // Try to get the password from keychain / env var / 1Password.
-        // Give 1Password more time since it shells out to `op`.
+        if entry.no_password_required {
+            let url = entry.to_url(None);
+            self.current_connection_name = Some(entry.name.clone());
+            self.start_connect(url);
+            return;
+        }
+
+        let op_configured =
+            self.config.connection.enable_onepassword && entry.password_onepassword.is_some();
+        let env_configured = entry.password_env.is_some();
+        if !entry.password_in_keychain && !op_configured && !env_configured {
+            self.last_error = None;
+            self.current_connection_name = Some(entry.name.clone());
+            self.password_prompt = Some(PasswordPrompt::new(entry));
+            return;
+        }
+
+        self.current_connection_name = Some(entry.name.clone());
+        self.last_status = Some(format!("Resolving credentials for {}...", entry.name));
+        self.begin_password_resolve(entry, PasswordResolveReason::UserPicked);
+    }
+
+    /// Queue a session auto-reconnect that will be dispatched after first draw.
+    pub fn set_pending_startup_reconnect(&mut self, name: Option<String>) {
+        self.pending_startup_reconnect = name;
+    }
+
+    /// Enable safe mode: skip startup reconnects and scheduled update checks.
+    pub fn set_safe_mode(&mut self, safe: bool) {
+        self.safe_mode = safe;
+    }
+
+    fn dispatch_pending_startup_reconnect(&mut self) {
+        if self.safe_mode {
+            self.pending_startup_reconnect = None;
+            return;
+        }
+
+        let Some(name) = self.pending_startup_reconnect.take() else {
+            return;
+        };
+
+        if let Ok(connections) = load_connections() {
+            self.connections = connections;
+        }
+
+        match self.connections.find_by_name(&name).cloned() {
+            Some(entry) => {
+                self.current_connection_name = Some(entry.name.clone());
+                self.last_status = Some(format!("Reconnecting to {}...", entry.name));
+                if entry.no_password_required {
+                    self.start_connect(entry.to_url(None));
+                } else {
+                    self.begin_password_resolve(entry, PasswordResolveReason::Startup);
+                }
+            }
+            None => {
+                self.last_status = Some(format!(
+                    "Previous connection '{}' no longer exists; pick a connection",
+                    name
+                ));
+                self.open_connection_picker();
+            }
+        }
+    }
+
+    pub fn begin_password_resolve(
+        &mut self,
+        entry: ConnectionEntry,
+        reason: PasswordResolveReason,
+    ) {
+        use std::collections::hash_map::Entry as MapEntry;
+
+        match self.password_resolve_in_flight.entry(entry.name.clone()) {
+            MapEntry::Occupied(mut slot) => {
+                if matches!(reason, PasswordResolveReason::UserPicked) {
+                    *slot.get_mut() = PasswordResolveReason::UserPicked;
+                }
+                return;
+            }
+            MapEntry::Vacant(slot) => {
+                slot.insert(reason);
+            }
+        }
+
+        let tx = self.db_events_tx.clone();
         let onepassword_enabled = self.config.connection.enable_onepassword;
         let timeout_ms = if onepassword_enabled && entry.password_onepassword.is_some() {
             5000
         } else {
             500
         };
-        let password =
-            match entry.get_password_with_timeout_and_options(timeout_ms, onepassword_enabled) {
-                Ok(Some(pwd)) => Some(pwd),
-                Ok(None) => None,
-                Err(e) => {
-                    self.last_error = None;
-                    self.last_status = Some(format!(
-                        "Password lookup failed ({}); enter password manually",
-                        e
-                    ));
-                    None
-                }
-            };
 
-        // Determine if we need to prompt for password:
-        // - If we have a password from keychain/env, use it
-        // - If no_password_required is true, connect without password
-        // - Otherwise, prompt for password
-        if password.is_some() || entry.no_password_required {
-            // We have a password or don't need one - connect directly
-            let url = entry.to_url(password.as_deref());
-            self.current_connection_name = Some(entry.name.clone());
-            self.start_connect(url);
+        self.rt.spawn_blocking(move || {
+            let result = entry
+                .get_password_with_timeout_and_options(timeout_ms, onepassword_enabled)
+                .map_err(|e| e.to_string());
+            let _ = tx.send(DbEvent::PasswordResolved {
+                entry: Box::new(entry),
+                result,
+                reason,
+            });
+        });
+    }
+
+    fn record_successful_connect(&mut self) {
+        if let Some(name) = self.current_connection_name.clone() {
+            self.active_connection_name = Some(name);
         } else {
-            // Need to prompt for password
-            self.last_error = None;
-            self.password_prompt = Some(PasswordPrompt::new(entry));
+            self.active_connection_name = None;
         }
     }
 
@@ -8054,6 +8241,18 @@ impl App {
                         self.config.connection.enable_onepassword,
                     ));
             }
+            ConnectionManagerAction::YankUrl { url } => {
+                self.copy_to_clipboard(&url);
+                self.last_status = Some("Connection URL copied (password stripped)".to_string());
+            }
+            ConnectionManagerAction::YankCli { command } => {
+                self.copy_to_clipboard(&command);
+                self.last_status = Some("tsql command copied".to_string());
+            }
+            ConnectionManagerAction::TestConnection { entry } => {
+                self.last_status = Some(format!("Testing connection to {}...", entry.name));
+                self.test_entry_in_background(entry);
+            }
             ConnectionManagerAction::Delete { name } => {
                 // Show confirmation for delete
                 self.confirm_prompt = Some(ConfirmPrompt::new(
@@ -8085,6 +8284,61 @@ impl App {
                 self.last_status = Some(msg);
             }
         }
+    }
+
+    fn test_entry_in_background(&mut self, entry: ConnectionEntry) {
+        if entry.no_password_required {
+            self.handle_connection_form_action(ConnectionFormAction::TestConnection {
+                entry,
+                password: None,
+            });
+            return;
+        }
+
+        let tx = self.db_events_tx.clone();
+        let onepassword_enabled = self.config.connection.enable_onepassword;
+        let timeout_ms = if onepassword_enabled && entry.password_onepassword.is_some() {
+            5000
+        } else {
+            500
+        };
+
+        self.rt.spawn_blocking(move || {
+            let password = entry
+                .get_password_with_timeout_and_options(timeout_ms, onepassword_enabled)
+                .ok()
+                .flatten();
+            let url = entry.to_url(password.as_deref());
+
+            let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            else {
+                let _ = tx.send(DbEvent::TestConnectionResult {
+                    success: false,
+                    message: format!(
+                        "Connection failed: could not start test runtime for {}",
+                        entry.name
+                    ),
+                });
+                return;
+            };
+
+            rt.block_on(async move {
+                let result = probe_connection(&url, entry.kind).await;
+                let event = match result {
+                    Ok(()) => DbEvent::TestConnectionResult {
+                        success: true,
+                        message: format!("Test OK: {} is reachable", entry.name),
+                    },
+                    Err(error) => DbEvent::TestConnectionResult {
+                        success: false,
+                        message: format!("Test failed for {}: {}", entry.name, error),
+                    },
+                };
+                let _ = tx.send(event);
+            });
+        });
     }
 
     /// Handle sidebar actions (from mouse clicks or keyboard).
@@ -9511,7 +9765,11 @@ impl App {
                 client,
                 cancel_token,
                 connected_with_tls,
+                connect_generation,
             } => {
+                if connect_generation != self.connect_generation {
+                    return;
+                }
                 self.db.status = DbStatus::Connected;
                 self.db.kind = Some(DbKind::Postgres);
                 self.db.client = Some(client);
@@ -9522,10 +9780,18 @@ impl App {
                 self.db.connected_with_tls = connected_with_tls;
                 self.query_ui.clear();
                 self.last_status = Some("Connected, loading schema...".to_string());
+                self.record_successful_connect();
                 // Load schema for completion
                 self.load_schema();
             }
-            DbEvent::MongoConnected { client, database } => {
+            DbEvent::MongoConnected {
+                client,
+                database,
+                connect_generation,
+            } => {
+                if connect_generation != self.connect_generation {
+                    return;
+                }
                 self.db.status = DbStatus::Connected;
                 self.db.kind = Some(DbKind::Mongo);
                 self.db.client = None;
@@ -9539,9 +9805,16 @@ impl App {
                 self.last_status = Some(format!(
                     "Connected to Mongo ({database}), loading schema..."
                 ));
+                self.record_successful_connect();
                 self.load_schema();
             }
-            DbEvent::ConnectError { error } => {
+            DbEvent::ConnectError {
+                error,
+                connect_generation,
+            } => {
+                if connect_generation != self.connect_generation {
+                    return;
+                }
                 self.db.status = DbStatus::Error;
                 self.db.kind = None;
                 self.db.client = None;
@@ -9550,10 +9823,17 @@ impl App {
                 self.db.running = false;
                 self.query_ui.clear();
                 self.current_connection_name = None;
+                self.active_connection_name = None;
                 self.last_status = Some("Connect failed (see error)".to_string());
                 self.last_error = Some(format!("Connection error: {}", error));
             }
-            DbEvent::ConnectionLost { error } => {
+            DbEvent::ConnectionLost {
+                error,
+                connect_generation,
+            } => {
+                if connect_generation != self.connect_generation {
+                    return;
+                }
                 self.db.status = DbStatus::Error;
                 self.db.kind = None;
                 self.db.client = None;
@@ -9562,6 +9842,7 @@ impl App {
                 self.db.running = false;
                 self.query_ui.clear();
                 self.current_connection_name = None;
+                self.active_connection_name = None;
                 self.last_status = Some("Connection lost (see error)".to_string());
                 self.last_error = Some(format!("Connection lost: {}", error));
             }
@@ -9753,6 +10034,59 @@ impl App {
                     Err(error) => {
                         self.last_error = Some(error);
                         self.last_status = Some("Update apply failed (see error)".to_string());
+                    }
+                }
+            }
+            DbEvent::PasswordResolved {
+                entry,
+                result,
+                reason,
+            } => {
+                let entry = *entry;
+                let reason = self
+                    .password_resolve_in_flight
+                    .remove(&entry.name)
+                    .unwrap_or(reason);
+
+                if self.current_connection_name.as_deref() != Some(entry.name.as_str()) {
+                    return;
+                }
+
+                match result {
+                    Ok(Some(password)) => {
+                        self.last_error = None;
+                        self.last_status = Some(format!("Connecting to {}...", entry.name));
+                        self.start_connect(entry.to_url(Some(&password)));
+                    }
+                    Ok(None) => {
+                        self.current_connection_name = self.active_connection_name.clone();
+                        match reason {
+                            PasswordResolveReason::UserPicked => {
+                                self.last_error = None;
+                                self.last_status = None;
+                                self.password_prompt = Some(PasswordPrompt::new(entry));
+                            }
+                            PasswordResolveReason::Startup => {
+                                self.last_status = Some(format!(
+                                    "Saved credentials for '{}' unavailable; pick a connection",
+                                    entry.name
+                                ));
+                                self.open_connection_picker();
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        self.current_connection_name = self.active_connection_name.clone();
+                        self.last_error = None;
+                        self.last_status = Some(format!("Password lookup failed: {}", error));
+                        match reason {
+                            PasswordResolveReason::UserPicked => {
+                                self.password_prompt = Some(PasswordPrompt::new(entry));
+                            }
+                            PasswordResolveReason::Startup => {
+                                self.open_connection_picker();
+                            }
+                        }
                     }
                 }
             }
@@ -12253,11 +12587,11 @@ mod tests {
             app.current_connection_name.clone(),
         ));
 
-        app.on_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        app.on_key(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::NONE));
 
         assert!(
             app.connection_form.is_some(),
-            "Connection form should open after pressing 'y'"
+            "Connection form should open after pressing 'D'"
         );
 
         app.on_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -10108,14 +10108,11 @@ impl App {
                 self.password_resolve_in_flight.remove(&entry.name);
                 let reason = pending.reason;
 
-                if self.current_connection_name.as_deref() != Some(entry.name.as_str()) {
-                    return;
-                }
-
                 match result {
                     Ok(Some(password)) => {
                         self.last_error = None;
                         self.last_status = Some(format!("Connecting to {}...", entry.name));
+                        self.current_connection_name = Some(entry.name.clone());
                         self.start_connect(entry.to_url(Some(&password)));
                     }
                     Ok(None) => {
@@ -12982,6 +12979,69 @@ mod tests {
                 .map(|pending| pending.generation),
             Some(fresh_generation)
         );
+    }
+
+    #[test]
+    fn test_password_resolve_survives_old_connection_lost() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+        app.db.status = DbStatus::Connected;
+        app.current_connection_name = Some("old".to_string());
+        app.active_connection_name = Some("old".to_string());
+        app.connect_generation = 7;
+
+        let entry = ConnectionEntry {
+            name: "new".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            database: "testdb".to_string(),
+            user: "postgres".to_string(),
+            password_in_keychain: true,
+            ..Default::default()
+        };
+
+        app.current_connection_name = Some(entry.name.clone());
+        app.password_resolve_generation = app.password_resolve_generation.wrapping_add(1);
+        let password_generation = app.password_resolve_generation;
+        app.password_resolve_in_flight.insert(
+            entry.name.clone(),
+            PendingPasswordResolve {
+                reason: PasswordResolveReason::UserPicked,
+                generation: password_generation,
+            },
+        );
+
+        app.apply_db_event(DbEvent::ConnectionLost {
+            error: "old connection dropped".to_string(),
+            connect_generation: 7,
+        });
+
+        assert_eq!(app.current_connection_name, None);
+        assert_eq!(
+            app.password_resolve_in_flight
+                .get(&entry.name)
+                .map(|pending| pending.generation),
+            Some(password_generation)
+        );
+
+        app.apply_db_event(DbEvent::PasswordResolved {
+            entry: Box::new(entry),
+            result: Ok(Some("secret".to_string())),
+            password_resolve_generation: password_generation,
+        });
+
+        assert_eq!(app.db.status, DbStatus::Connecting);
+        assert_eq!(app.current_connection_name.as_deref(), Some("new"));
+        assert!(app
+            .db
+            .conn_str
+            .as_deref()
+            .is_some_and(|url| url.contains("postgres:secret@localhost")));
     }
 
     #[test]

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -2339,6 +2339,8 @@ pub struct App {
     safe_mode: bool,
     /// Monotonic id used to ignore stale connect task completions.
     connect_generation: u64,
+    /// Saved connection name associated with the current connect generation.
+    connect_generation_name: Option<String>,
     /// Monotonic id used to ignore stale saved-connection password resolves.
     password_resolve_generation: u64,
     /// Saved connection password resolves currently running off the UI thread.
@@ -2538,6 +2540,7 @@ impl App {
             pending_startup_reconnect: None,
             safe_mode: false,
             connect_generation: 0,
+            connect_generation_name: None,
             password_resolve_generation: 0,
             password_resolve_in_flight: HashMap::new(),
             connection_picker: None,
@@ -5496,6 +5499,7 @@ impl App {
                 self.query_ui.clear();
                 self.current_connection_name = None;
                 self.active_connection_name = None;
+                self.connect_generation_name = None;
                 self.last_status = Some("Disconnected".to_string());
             }
             "help" | "h" => {
@@ -7556,6 +7560,7 @@ impl App {
         self.last_status = Some("Connecting...".to_string());
         self.connect_generation = self.connect_generation.wrapping_add(1);
         let connect_generation = self.connect_generation;
+        self.connect_generation_name = self.current_connection_name.clone();
 
         let tx = self.db_events_tx.clone();
         let rt = self.rt.clone();
@@ -7887,12 +7892,8 @@ impl App {
         });
     }
 
-    fn record_successful_connect(&mut self) {
-        if let Some(name) = self.current_connection_name.clone() {
-            self.active_connection_name = Some(name);
-        } else {
-            self.active_connection_name = None;
-        }
+    fn record_successful_connect(&mut self, connection_name: Option<String>) {
+        self.active_connection_name = connection_name;
     }
 
     /// Connect to an entry with the provided password (called after password prompt).
@@ -9835,7 +9836,7 @@ impl App {
                 self.db.connected_with_tls = connected_with_tls;
                 self.query_ui.clear();
                 self.last_status = Some("Connected, loading schema...".to_string());
-                self.record_successful_connect();
+                self.record_successful_connect(self.connect_generation_name.clone());
                 // Load schema for completion
                 self.load_schema();
             }
@@ -9860,7 +9861,7 @@ impl App {
                 self.last_status = Some(format!(
                     "Connected to Mongo ({database}), loading schema..."
                 ));
-                self.record_successful_connect();
+                self.record_successful_connect(self.connect_generation_name.clone());
                 self.load_schema();
             }
             DbEvent::ConnectError {
@@ -9879,6 +9880,7 @@ impl App {
                 self.query_ui.clear();
                 self.current_connection_name = None;
                 self.active_connection_name = None;
+                self.connect_generation_name = None;
                 self.last_status = Some("Connect failed (see error)".to_string());
                 self.last_error = Some(format!("Connection error: {}", error));
             }
@@ -9898,6 +9900,7 @@ impl App {
                 self.query_ui.clear();
                 self.current_connection_name = None;
                 self.active_connection_name = None;
+                self.connect_generation_name = None;
                 self.last_status = Some("Connection lost (see error)".to_string());
                 self.last_error = Some(format!("Connection lost: {}", error));
             }
@@ -13042,6 +13045,24 @@ mod tests {
             .conn_str
             .as_deref()
             .is_some_and(|url| url.contains("postgres:secret@localhost")));
+    }
+
+    #[test]
+    fn test_successful_connect_records_attempt_connection_name() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+        app.current_connection_name = Some("attempt-a".to_string());
+        app.start_connect("postgres://postgres@localhost/db".to_string());
+
+        app.current_connection_name = Some("pending-b".to_string());
+        app.record_successful_connect(app.connect_generation_name.clone());
+
+        assert_eq!(app.active_connection_name.as_deref(), Some("attempt-a"));
     }
 
     #[test]

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -2020,6 +2020,12 @@ struct PendingPasswordResolve {
     generation: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingStartupReconnect {
+    name: String,
+    automatic: bool,
+}
+
 pub struct DbSession {
     pub status: DbStatus,
     pub kind: Option<DbKind>,
@@ -2327,8 +2333,8 @@ pub struct App {
     pub current_connection_name: Option<String>,
     /// Name of the saved connection that is actually connected.
     active_connection_name: Option<String>,
-    /// Saved connection name to reconnect after the first TUI frame.
-    pending_startup_reconnect: Option<String>,
+    /// Saved connection to connect after the first TUI frame.
+    pending_startup_reconnect: Option<PendingStartupReconnect>,
     /// Skip startup side effects that can block or touch the network.
     safe_mode: bool,
     /// Monotonic id used to ignore stale connect task completions.
@@ -2462,7 +2468,8 @@ impl App {
             History::new_empty(config.editor.max_history)
         });
 
-        // Determine connection string: CLI arg > config > env var
+        // Determine connection string: CLI arg > config.
+        let explicit_conn_str = conn_str.is_some();
         let effective_conn_str = conn_str.or_else(|| config.connection.default_url.clone());
 
         // Build keymaps from defaults + config overrides
@@ -2568,7 +2575,10 @@ impl App {
             if !url.contains("://") {
                 // Try to find a connection by name
                 if let Some(entry) = app.connections.find_by_name(&url) {
-                    app.pending_startup_reconnect = Some(entry.name.clone());
+                    app.pending_startup_reconnect = Some(PendingStartupReconnect {
+                        name: entry.name.clone(),
+                        automatic: !explicit_conn_str,
+                    });
                 } else {
                     app.last_error = Some(format!("Unknown connection: {}", url));
                     // Open connection picker so user can select (falls back to manager if empty)
@@ -4561,18 +4571,18 @@ impl App {
         }
     }
 
-    fn copy_to_clipboard(&mut self, text: &str) {
+    fn copy_to_clipboard(&mut self, text: &str) -> bool {
         if self.config.clipboard.backend == ClipboardBackend::Disabled {
             self.last_error = None;
             self.last_status = Some("Clipboard disabled".to_string());
-            return;
+            return false;
         }
 
         let choice = match crate::clipboard::choose_backend(&self.config.clipboard) {
             Ok(choice) => choice,
             Err(e) => {
                 self.last_error = Some(e.to_string());
-                return;
+                return false;
             }
         };
 
@@ -4582,18 +4592,22 @@ impl App {
             crate::clipboard::ClipboardBackendChoice::Disabled => {
                 self.last_error = None;
                 self.last_status = Some("Clipboard disabled".to_string());
+                false
             }
             crate::clipboard::ClipboardBackendChoice::Arboard => {
                 if let Err(e) = self.copy_to_clipboard_with_arboard(text) {
                     self.last_error = Some(format!("Failed to copy: {}", e));
+                    false
                 } else {
                     self.set_copied_status(text);
+                    true
                 }
             }
             crate::clipboard::ClipboardBackendChoice::WlCopy { cmd } => {
                 match crate::clipboard::copy_with_wl_copy(text, &self.config.clipboard, &cmd) {
                     Ok(()) => {
                         self.set_copied_status(text);
+                        true
                     }
                     Err(e) => {
                         if self.config.clipboard.backend == ClipboardBackend::Auto {
@@ -4603,11 +4617,14 @@ impl App {
                                     "wl-copy failed: {}; arboard failed: {}",
                                     e, arboard_err
                                 ));
+                                false
                             } else {
                                 self.set_copied_status(text);
+                                true
                             }
                         } else {
                             self.last_error = Some(format!("Failed to copy: {}", e));
+                            false
                         }
                     }
                 }
@@ -7771,7 +7788,10 @@ impl App {
 
     /// Queue a session auto-reconnect that will be dispatched after first draw.
     pub fn set_pending_startup_reconnect(&mut self, name: Option<String>) {
-        self.pending_startup_reconnect = name;
+        self.pending_startup_reconnect = name.map(|name| PendingStartupReconnect {
+            name,
+            automatic: true,
+        });
     }
 
     /// Enable safe mode: skip startup reconnects and scheduled update checks.
@@ -7785,14 +7805,13 @@ impl App {
     }
 
     fn dispatch_pending_startup_reconnect(&mut self) {
-        if self.safe_mode {
-            self.pending_startup_reconnect = None;
-            return;
-        }
-
-        let Some(name) = self.pending_startup_reconnect.take() else {
+        let Some(pending) = self.pending_startup_reconnect.take() else {
             return;
         };
+        if self.safe_mode && pending.automatic {
+            return;
+        }
+        let name = pending.name;
 
         if let Ok(connections) = load_connections() {
             self.connections = connections;
@@ -8270,12 +8289,15 @@ impl App {
                     ));
             }
             ConnectionManagerAction::YankUrl { url } => {
-                self.copy_to_clipboard(&url);
-                self.last_status = Some("Connection URL copied (password stripped)".to_string());
+                if self.copy_to_clipboard(&url) {
+                    self.last_status =
+                        Some("Connection URL copied (password stripped)".to_string());
+                }
             }
             ConnectionManagerAction::YankCli { command } => {
-                self.copy_to_clipboard(&command);
-                self.last_status = Some("tsql command copied".to_string());
+                if self.copy_to_clipboard(&command) {
+                    self.last_status = Some("tsql command copied".to_string());
+                }
             }
             ConnectionManagerAction::TestConnection { entry } => {
                 self.last_status = Some(format!("Testing connection to {}...", entry.name));
@@ -12955,6 +12977,97 @@ mod tests {
                 .map(|pending| pending.generation),
             Some(fresh_generation)
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_safe_mode_suppresses_automatic_pending_reconnect() {
+        let _guard = ConfigDirGuard::new();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+
+        app.set_pending_startup_reconnect(Some("saved".to_string()));
+        app.set_safe_mode(true);
+        app.dispatch_pending_startup_reconnect();
+
+        assert_eq!(app.db.status, DbStatus::Disconnected);
+        assert_eq!(app.current_connection_name, None);
+    }
+
+    #[test]
+    #[serial]
+    fn test_safe_mode_honors_explicit_saved_connection_name() {
+        let _guard = ConfigDirGuard::new();
+
+        let mut connections = ConnectionsFile::new();
+        connections
+            .add(ConnectionEntry {
+                name: "saved".to_string(),
+                host: "localhost".to_string(),
+                port: 5432,
+                database: "testdb".to_string(),
+                user: "postgres".to_string(),
+                no_password_required: true,
+                ..Default::default()
+            })
+            .unwrap();
+        save_connections(&connections).unwrap();
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(
+            GridModel::empty(),
+            rt.handle().clone(),
+            tx,
+            rx,
+            Some("saved".to_string()),
+        );
+
+        app.set_safe_mode(true);
+        app.dispatch_pending_startup_reconnect();
+
+        assert_eq!(app.db.status, DbStatus::Connecting);
+        assert_eq!(app.current_connection_name.as_deref(), Some("saved"));
+    }
+
+    #[test]
+    fn test_connection_manager_copy_status_preserves_clipboard_failure() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut config = Config::default();
+        config.clipboard.backend = ClipboardBackend::Disabled;
+
+        let mut app = App::with_config(
+            GridModel::empty(),
+            rt.handle().clone(),
+            tx,
+            rx,
+            None,
+            config,
+        );
+
+        app.handle_connection_manager_action(ConnectionManagerAction::YankUrl {
+            url: "postgres://postgres@localhost/testdb".to_string(),
+        });
+        assert_eq!(app.last_status.as_deref(), Some("Clipboard disabled"));
+
+        app.handle_connection_manager_action(ConnectionManagerAction::YankCli {
+            command: "tsql saved".to_string(),
+        });
+        assert_eq!(app.last_status.as_deref(), Some("Clipboard disabled"));
     }
 
     /// Test the full workflow: Esc on unmodified form closes immediately

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -2004,7 +2004,7 @@ pub enum DbEvent {
     PasswordResolved {
         entry: Box<ConnectionEntry>,
         result: std::result::Result<Option<String>, String>,
-        reason: PasswordResolveReason,
+        password_resolve_generation: u64,
     },
 }
 
@@ -2012,6 +2012,12 @@ pub enum DbEvent {
 pub enum PasswordResolveReason {
     Startup,
     UserPicked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PendingPasswordResolve {
+    reason: PasswordResolveReason,
+    generation: u64,
 }
 
 pub struct DbSession {
@@ -2327,8 +2333,10 @@ pub struct App {
     safe_mode: bool,
     /// Monotonic id used to ignore stale connect task completions.
     connect_generation: u64,
+    /// Monotonic id used to ignore stale saved-connection password resolves.
+    password_resolve_generation: u64,
     /// Saved connection password resolves currently running off the UI thread.
-    password_resolve_in_flight: HashMap<String, PasswordResolveReason>,
+    password_resolve_in_flight: HashMap<String, PendingPasswordResolve>,
     /// Connection picker (fuzzy picker for quick connection selection).
     pub connection_picker: Option<FuzzyPicker<ConnectionEntry>>,
     /// Connection manager modal (when open).
@@ -2523,6 +2531,7 @@ impl App {
             pending_startup_reconnect: None,
             safe_mode: false,
             connect_generation: 0,
+            password_resolve_generation: 0,
             password_resolve_in_flight: HashMap::new(),
             connection_picker: None,
             connection_manager: None,
@@ -5453,10 +5462,13 @@ impl App {
                 if args.is_empty() {
                     self.last_status = Some("Usage: :connect <connection_url>".to_string());
                 } else {
+                    self.current_connection_name = None;
                     self.start_connect(args.to_string());
                 }
             }
             "disconnect" | "dc" => {
+                self.invalidate_password_resolves();
+                self.connect_generation = self.connect_generation.wrapping_add(1);
                 self.db.client = None;
                 self.db.mongo_client = None;
                 self.db.mongo_database = None;
@@ -5465,6 +5477,8 @@ impl App {
                 self.db.status = DbStatus::Disconnected;
                 self.db.running = false;
                 self.query_ui.clear();
+                self.current_connection_name = None;
+                self.active_connection_name = None;
                 self.last_status = Some("Disconnected".to_string());
             }
             "help" | "h" => {
@@ -7511,6 +7525,7 @@ impl App {
     }
 
     pub fn start_connect(&mut self, conn_str: String) {
+        self.invalidate_password_resolves();
         self.db.status = DbStatus::Connecting;
         self.db.kind = None;
         self.db.conn_str = Some(conn_str.clone());
@@ -7730,6 +7745,8 @@ impl App {
 
     /// Connect to a saved connection entry.
     pub fn connect_to_entry(&mut self, entry: ConnectionEntry) {
+        self.invalidate_password_resolves();
+
         if entry.no_password_required {
             let url = entry.to_url(None);
             self.current_connection_name = Some(entry.name.clone());
@@ -7762,6 +7779,11 @@ impl App {
         self.safe_mode = safe;
     }
 
+    fn invalidate_password_resolves(&mut self) {
+        self.password_resolve_generation = self.password_resolve_generation.wrapping_add(1);
+        self.password_resolve_in_flight.clear();
+    }
+
     fn dispatch_pending_startup_reconnect(&mut self) {
         if self.safe_mode {
             self.pending_startup_reconnect = None;
@@ -7778,6 +7800,7 @@ impl App {
 
         match self.connections.find_by_name(&name).cloned() {
             Some(entry) => {
+                self.invalidate_password_resolves();
                 self.current_connection_name = Some(entry.name.clone());
                 self.last_status = Some(format!("Reconnecting to {}...", entry.name));
                 if entry.no_password_required {
@@ -7806,16 +7829,21 @@ impl App {
         match self.password_resolve_in_flight.entry(entry.name.clone()) {
             MapEntry::Occupied(mut slot) => {
                 if matches!(reason, PasswordResolveReason::UserPicked) {
-                    *slot.get_mut() = PasswordResolveReason::UserPicked;
+                    slot.get_mut().reason = PasswordResolveReason::UserPicked;
                 }
                 return;
             }
             MapEntry::Vacant(slot) => {
-                slot.insert(reason);
+                self.password_resolve_generation = self.password_resolve_generation.wrapping_add(1);
+                slot.insert(PendingPasswordResolve {
+                    reason,
+                    generation: self.password_resolve_generation,
+                });
             }
         }
 
         let tx = self.db_events_tx.clone();
+        let password_resolve_generation = self.password_resolve_generation;
         let onepassword_enabled = self.config.connection.enable_onepassword;
         let timeout_ms = if onepassword_enabled && entry.password_onepassword.is_some() {
             5000
@@ -7830,7 +7858,7 @@ impl App {
             let _ = tx.send(DbEvent::PasswordResolved {
                 entry: Box::new(entry),
                 result,
-                reason,
+                password_resolve_generation,
             });
         });
     }
@@ -10040,13 +10068,18 @@ impl App {
             DbEvent::PasswordResolved {
                 entry,
                 result,
-                reason,
+                password_resolve_generation,
             } => {
                 let entry = *entry;
-                let reason = self
-                    .password_resolve_in_flight
-                    .remove(&entry.name)
-                    .unwrap_or(reason);
+                let Some(pending) = self.password_resolve_in_flight.get(&entry.name).copied()
+                else {
+                    return;
+                };
+                if pending.generation != password_resolve_generation {
+                    return;
+                }
+                self.password_resolve_in_flight.remove(&entry.name);
+                let reason = pending.reason;
 
                 if self.current_connection_name.as_deref() != Some(entry.name.as_str()) {
                     return;
@@ -12864,6 +12897,63 @@ mod tests {
         assert!(
             app.connection_manager.is_some(),
             "Connection manager should open on gm from picker"
+        );
+    }
+
+    #[test]
+    fn test_stale_password_resolve_does_not_override_new_same_name_resolve() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mut app = App::new(GridModel::empty(), rt.handle().clone(), tx, rx, None);
+        let entry = ConnectionEntry {
+            name: "saved".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            database: "testdb".to_string(),
+            user: "postgres".to_string(),
+            ..Default::default()
+        };
+
+        app.current_connection_name = Some(entry.name.clone());
+        app.password_resolve_generation = 1;
+        app.password_resolve_in_flight.insert(
+            entry.name.clone(),
+            PendingPasswordResolve {
+                reason: PasswordResolveReason::UserPicked,
+                generation: 1,
+            },
+        );
+
+        app.execute_command("disconnect");
+
+        app.current_connection_name = Some(entry.name.clone());
+        app.password_resolve_generation = app.password_resolve_generation.wrapping_add(1);
+        let fresh_generation = app.password_resolve_generation;
+        app.password_resolve_in_flight.insert(
+            entry.name.clone(),
+            PendingPasswordResolve {
+                reason: PasswordResolveReason::UserPicked,
+                generation: fresh_generation,
+            },
+        );
+
+        app.apply_db_event(DbEvent::PasswordResolved {
+            entry: Box::new(entry.clone()),
+            result: Ok(Some("old-password".to_string())),
+            password_resolve_generation: 1,
+        });
+
+        assert_eq!(app.db.status, DbStatus::Disconnected);
+        assert_eq!(app.current_connection_name, Some(entry.name.clone()));
+        assert_eq!(
+            app.password_resolve_in_flight
+                .get(&entry.name)
+                .map(|pending| pending.generation),
+            Some(fresh_generation)
         );
     }
 

--- a/crates/tsql/src/config/connections.rs
+++ b/crates/tsql/src/config/connections.rs
@@ -344,10 +344,9 @@ impl ConnectionEntry {
 
     /// Build a shell-pasteable command for launching this connection.
     pub fn to_cli_command(&self) -> String {
-        let url = self.sanitized_url();
-        match shlex::try_quote(&url) {
+        match shlex::try_quote(&self.name) {
             Ok(quoted) => format!("tsql {}", quoted),
-            Err(_) => format!("tsql {}", url),
+            Err(_) => format!("tsql {}", self.name),
         }
     }
 
@@ -1280,9 +1279,9 @@ mod tests {
     }
 
     #[test]
-    fn test_cli_command_quotes_sanitized_url() {
+    fn test_cli_command_quotes_connection_name() {
         let entry = ConnectionEntry {
-            name: "quoted".to_string(),
+            name: "local;dev".to_string(),
             host: "localhost".to_string(),
             port: 5432,
             database: "my db".to_string(),
@@ -1290,10 +1289,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(
-            entry.to_cli_command(),
-            "tsql 'postgres://postgres@localhost/my db'"
-        );
+        assert_eq!(entry.to_cli_command(), "tsql 'local;dev'");
     }
 
     #[test]

--- a/crates/tsql/src/config/connections.rs
+++ b/crates/tsql/src/config/connections.rs
@@ -344,9 +344,14 @@ impl ConnectionEntry {
 
     /// Build a shell-pasteable command for launching this connection.
     pub fn to_cli_command(&self) -> String {
+        let separator = if self.name.starts_with('-') {
+            "-- "
+        } else {
+            ""
+        };
         match shlex::try_quote(&self.name) {
-            Ok(quoted) => format!("tsql {}", quoted),
-            Err(_) => format!("tsql {}", self.name),
+            Ok(quoted) => format!("tsql {}{}", separator, quoted),
+            Err(_) => format!("tsql {}{}", separator, self.name),
         }
     }
 
@@ -1290,6 +1295,20 @@ mod tests {
         };
 
         assert_eq!(entry.to_cli_command(), "tsql 'local;dev'");
+    }
+
+    #[test]
+    fn test_cli_command_uses_double_dash_for_option_like_name() {
+        let entry = ConnectionEntry {
+            name: "-prod".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            database: "mydb".to_string(),
+            user: "postgres".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(entry.to_cli_command(), "tsql -- -prod");
     }
 
     #[test]

--- a/crates/tsql/src/config/connections.rs
+++ b/crates/tsql/src/config/connections.rs
@@ -217,6 +217,39 @@ pub struct ConnectionEntry {
     pub ssl_mode: Option<SslMode>,
 }
 
+fn sanitize_connection_url(raw: &str) -> String {
+    if let Ok(mut parsed) = Url::parse(raw) {
+        if parsed.password().is_some() {
+            let _ = parsed.set_password(None);
+            return parsed.to_string();
+        }
+        return raw.to_string();
+    }
+
+    let Some(scheme_end) = raw.find("://") else {
+        return raw.to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let tail = &raw[authority_start..];
+    let authority_len = tail.find(['/', '?']).unwrap_or(tail.len());
+    let authority = &tail[..authority_len];
+    let Some(at) = authority.rfind('@') else {
+        return raw.to_string();
+    };
+    let userinfo = &authority[..at];
+    let Some((username, _)) = userinfo.split_once(':') else {
+        return raw.to_string();
+    };
+
+    let mut sanitized = String::with_capacity(raw.len());
+    sanitized.push_str(&raw[..authority_start]);
+    sanitized.push_str(username);
+    sanitized.push('@');
+    sanitized.push_str(&authority[at + 1..]);
+    sanitized.push_str(&tail[authority_len..]);
+    sanitized
+}
+
 fn default_port() -> u16 {
     // Postgres default. Mongo defaults come from the parsed URI.
     5432
@@ -302,6 +335,20 @@ impl ConnectionEntry {
         }
 
         url
+    }
+
+    /// Build a display/copy-safe URL that never includes an embedded password.
+    pub fn sanitized_url(&self) -> String {
+        sanitize_connection_url(&self.to_url(None))
+    }
+
+    /// Build a shell-pasteable command for launching this connection.
+    pub fn to_cli_command(&self) -> String {
+        let url = self.sanitized_url();
+        match shlex::try_quote(&url) {
+            Ok(quoted) => format!("tsql {}", quoted),
+            Err(_) => format!("tsql {}", url),
+        }
     }
 
     /// Parse a URL and create a ConnectionEntry.
@@ -1192,6 +1239,61 @@ mod tests {
         };
         let url = entry.to_url(Some("secret"));
         assert_eq!(url, "mongodb://admin:secret@mongo.example.com:27018/sample");
+    }
+
+    #[test]
+    fn test_sanitized_url_strips_postgres_password() {
+        let entry = ConnectionEntry {
+            name: "pg".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            database: "mydb".to_string(),
+            user: "postgres".to_string(),
+            ..Default::default()
+        };
+
+        let runtime_url = entry.to_url(Some("secret"));
+        assert_eq!(sanitize_connection_url(&runtime_url), entry.sanitized_url());
+        assert_eq!(entry.sanitized_url(), "postgres://postgres@localhost/mydb");
+    }
+
+    #[test]
+    fn test_sanitized_url_strips_mongo_password() {
+        let entry = ConnectionEntry {
+            kind: DbKind::Mongo,
+            name: "mongo".to_string(),
+            uri: Some(
+                "mongodb://admin:secret@mongo.example.com:27018/sample?authSource=admin"
+                    .to_string(),
+            ),
+            host: "mongo.example.com".to_string(),
+            port: 27018,
+            database: "sample".to_string(),
+            user: "admin".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            entry.sanitized_url(),
+            "mongodb://admin@mongo.example.com:27018/sample?authSource=admin"
+        );
+    }
+
+    #[test]
+    fn test_cli_command_quotes_sanitized_url() {
+        let entry = ConnectionEntry {
+            name: "quoted".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            database: "my db".to_string(),
+            user: "postgres".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            entry.to_cli_command(),
+            "tsql 'postgres://postgres@localhost/my db'"
+        );
     }
 
     #[test]

--- a/crates/tsql/src/main.rs
+++ b/crates/tsql/src/main.rs
@@ -212,6 +212,26 @@ fn config_for_startup(mut cfg: config::Config, safe_mode: bool) -> config::Confi
     cfg
 }
 
+fn startup_connection_target(
+    positional_arg: Option<&str>,
+    safe_mode: bool,
+) -> (Option<String>, Option<String>) {
+    if let Some(url) = positional_arg {
+        return (Some(url.to_string()), None);
+    }
+
+    if safe_mode {
+        return (None, None);
+    }
+
+    if let Ok(url) = env::var("DATABASE_URL") {
+        return (Some(url), None);
+    }
+
+    let result = build_url_from_libpq_env();
+    (result.url, result.warning)
+}
+
 fn onepassword_cli_available() -> bool {
     std::process::Command::new("op")
         .arg("--version")
@@ -312,16 +332,7 @@ fn main() -> Result<()> {
 
     // Connection string priority: CLI arg > DATABASE_URL env var > libpq env vars > config file
     let positional_url = first_positional_arg(&args);
-    let (conn_str, libpq_warning) = if let Some(url) = positional_url {
-        (Some(url.to_string()), None)
-    } else if let Ok(url) = env::var("DATABASE_URL") {
-        // Fall back to DATABASE_URL environment variable
-        (Some(url), None)
-    } else {
-        // Then try libpq-compatible env vars (PGHOST, PGPORT, PGDATABASE, etc.)
-        let result = build_url_from_libpq_env();
-        (result.url, result.warning)
-    };
+    let (conn_str, libpq_warning) = startup_connection_target(positional_url, safe_mode);
 
     let rt = Runtime::new().context("failed to initialize tokio runtime")?;
     let (db_events_tx, db_events_rx) = mpsc::unbounded_channel();
@@ -533,6 +544,7 @@ mod tests {
     /// Helper to clear all libpq env vars before each test
     fn clear_libpq_env_vars() {
         for var in [
+            "DATABASE_URL",
             "PGHOST",
             "PGPORT",
             "PGDATABASE",
@@ -565,6 +577,42 @@ mod tests {
         let cfg = config_for_startup(cfg, true);
 
         assert_eq!(cfg.connection.default_url, None);
+    }
+
+    #[test]
+    #[serial]
+    fn test_safe_mode_skips_database_url_fallback() {
+        clear_libpq_env_vars();
+        env::set_var("DATABASE_URL", "postgres://localhost/prod");
+
+        let (conn_str, warning) = startup_connection_target(None, true);
+
+        assert_eq!(conn_str, None);
+        assert_eq!(warning, None);
+    }
+
+    #[test]
+    #[serial]
+    fn test_safe_mode_skips_libpq_env_fallback() {
+        clear_libpq_env_vars();
+        env::set_var("PGHOST", "db.example.com");
+
+        let (conn_str, warning) = startup_connection_target(None, true);
+
+        assert_eq!(conn_str, None);
+        assert_eq!(warning, None);
+    }
+
+    #[test]
+    #[serial]
+    fn test_safe_mode_honors_explicit_positional_connection() {
+        clear_libpq_env_vars();
+        env::set_var("DATABASE_URL", "postgres://localhost/prod");
+
+        let (conn_str, warning) = startup_connection_target(Some("my-conn"), true);
+
+        assert_eq!(conn_str.as_deref(), Some("my-conn"));
+        assert_eq!(warning, None);
     }
 
     #[test]

--- a/crates/tsql/src/main.rs
+++ b/crates/tsql/src/main.rs
@@ -14,7 +14,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 
 use tsql::app::App;
-use tsql::config::{self, load_connections};
+use tsql::config;
 use tsql::session::load_session;
 use tsql::ui::GridModel;
 
@@ -153,6 +153,9 @@ fn print_usage() {
     eprintln!("  -V, --version     Print version information");
     eprintln!("      --debug-keys  Print detected key/mouse events (for troubleshooting)");
     eprintln!("      --mouse       (with --debug-keys) Also print mouse events");
+    eprintln!("      --safe-mode   Skip session reconnect and startup side effects");
+    eprintln!("      --no-auto-connect");
+    eprintln!("                    Alias for --safe-mode");
     eprintln!();
     eprintln!("Environment Variables:");
     eprintln!("  DATABASE_URL      Default connection URL if not provided as argument");
@@ -189,7 +192,7 @@ fn onepassword_cli_available() -> bool {
         .unwrap_or(false)
 }
 
-fn onepassword_startup_warning(onepassword_enabled: bool) -> Option<String> {
+fn onepassword_startup_warning_nonblocking(onepassword_enabled: bool) -> Option<String> {
     if !onepassword_enabled {
         return None;
     }
@@ -202,14 +205,26 @@ fn onepassword_startup_warning(onepassword_enabled: bool) -> Option<String> {
         );
     }
 
-    if !onepassword_cli_available() {
-        return Some(
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(onepassword_cli_available());
+    });
+
+    match rx.recv_timeout(Duration::from_millis(750)) {
+        Ok(true) => None,
+        Ok(false) => Some(
             "1Password support is enabled, but `op` was not found on PATH. Install/sign in via \
              1Password CLI or disable `connection.enable_onepassword`."
                 .to_string(),
-        );
+        ),
+        Err(_) => Some(
+            "1Password CLI probe timed out; use `tsql --safe-mode` to bypass startup side effects."
+                .to_string(),
+        ),
     }
-    None
 }
 
 fn main() -> Result<()> {
@@ -240,16 +255,21 @@ fn main() -> Result<()> {
         return run_debug_keys(debug_mouse);
     }
 
+    let safe_mode = args
+        .iter()
+        .any(|a| a == "--safe-mode" || a == "--no-auto-connect");
+    let mut startup_warnings: Vec<String> = Vec::new();
+
     if let Err(err) = config::migrate_legacy_config_dir_on_startup() {
-        eprintln!(
-            "Warning: Failed to migrate legacy config directory to ~/.tsql: {}",
+        startup_warnings.push(format!(
+            "Failed to migrate legacy config directory to ~/.tsql: {}",
             err
-        );
+        ));
     }
 
     // Load configuration from ~/.tsql/config.toml
     let cfg = config::load_config().unwrap_or_else(|e| {
-        eprintln!("Warning: Failed to load config: {}", e);
+        startup_warnings.push(format!("Failed to load config: {}", e));
         config::Config::default()
     });
     let onepassword_enabled = cfg.connection.enable_onepassword;
@@ -257,7 +277,7 @@ fn main() -> Result<()> {
     // Load session state if persistence is enabled
     let session = if cfg.editor.persist_session {
         load_session().unwrap_or_else(|e| {
-            eprintln!("Warning: Failed to load session: {}", e);
+            startup_warnings.push(format!("Failed to load session: {}", e));
             Default::default()
         })
     } else {
@@ -265,9 +285,9 @@ fn main() -> Result<()> {
     };
 
     // Connection string priority: CLI arg > DATABASE_URL env var > libpq env vars > config file
-    let (conn_str, libpq_warning) = if args.len() > 1 && !args[1].starts_with('-') {
-        // First argument is the connection string
-        (Some(args[1].clone()), None)
+    let positional_url = args.iter().skip(1).find(|a| !a.starts_with('-'));
+    let (conn_str, libpq_warning) = if let Some(url) = positional_url {
+        (Some(url.clone()), None)
     } else if let Ok(url) = env::var("DATABASE_URL") {
         // Fall back to DATABASE_URL environment variable
         (Some(url), None)
@@ -291,54 +311,40 @@ fn main() -> Result<()> {
         conn_str.clone(),
         cfg,
     );
+    app.set_safe_mode(safe_mode);
 
     // Display startup warnings.
     if let Some(warning) = libpq_warning {
-        app.last_status = Some(warning);
+        startup_warnings.push(warning);
     }
-    if let Some(warning) = onepassword_startup_warning(onepassword_enabled) {
-        app.last_status = Some(match app.last_status.take() {
-            Some(existing) => format!("{} | {}", existing, warning),
-            None => warning,
-        });
+    if !safe_mode {
+        if let Some(warning) = onepassword_startup_warning_nonblocking(onepassword_enabled) {
+            startup_warnings.push(warning);
+        }
+    } else {
+        startup_warnings.push(
+            "Running in safe mode: session reconnect and startup update checks disabled"
+                .to_string(),
+        );
+    }
+    if !startup_warnings.is_empty() {
+        app.last_status = Some(startup_warnings.join(" | "));
     }
 
     // Apply session state (editor content, sidebar visibility, pending schema expanded)
     let session_connection = app.apply_session_state(session);
 
-    // Auto-connect from session if no CLI/env connection was specified
-    let mut session_reconnected = false;
-    if conn_str.is_none() {
+    // Auto-connect from session if no CLI/env connection was specified. Queue
+    // it for after the first draw so keychain/1Password cannot black-screen
+    // the terminal before the user sees the UI.
+    if conn_str.is_none() && !safe_mode {
         if let Some(conn_name) = session_connection {
-            // Verify connection still exists
-            let connections = load_connections().unwrap_or_default();
-            if let Some(entry) = connections.find_by_name(&conn_name) {
-                // Check if password is available (not requiring prompt)
-                let timeout_ms = if onepassword_enabled && entry.password_onepassword.is_some() {
-                    5000
-                } else {
-                    500
-                };
-                match entry.get_password_with_timeout_and_options(timeout_ms, onepassword_enabled) {
-                    Ok(Some(_)) | Ok(None) => {
-                        // Password available or not needed - auto-connect
-                        app.connect_to_entry(entry.clone());
-                        session_reconnected = true;
-                    }
-                    Err(_) => {
-                        // Password retrieval failed - skip auto-connect
-                        // User can manually connect
-                    }
-                }
-            }
-            // If connection doesn't exist, silently skip auto-connect
-        }
-
-        // Only open connection picker if no connection was established
-        // (no CLI/env URL and no session reconnection)
-        if !session_reconnected {
+            app.set_pending_startup_reconnect(Some(conn_name));
+        } else {
             app.open_connection_picker();
         }
+    } else if conn_str.is_none() && safe_mode {
+        app.open_connection_picker();
     }
 
     let res = app.run(&mut terminal);

--- a/crates/tsql/src/main.rs
+++ b/crates/tsql/src/main.rs
@@ -141,10 +141,11 @@ fn build_url_from_libpq_env() -> LibpqEnvResult {
 fn print_usage() {
     eprintln!("tsql - A modern SQL and MongoDB CLI");
     eprintln!();
-    eprintln!("Usage: tsql [OPTIONS] [CONNECTION_URL]");
+    eprintln!("Usage: tsql [OPTIONS] [CONNECTION_URL|CONNECTION_NAME]");
     eprintln!();
     eprintln!("Arguments:");
-    eprintln!("  [CONNECTION_URL]  Connection URL");
+    eprintln!("  [CONNECTION_URL|CONNECTION_NAME]");
+    eprintln!("                    Connection URL or saved connection name");
     eprintln!("                    (e.g., postgres://user:pass@host:5432/dbname)");
     eprintln!("                    (or mongodb://user:pass@host:27017/dbname)");
     eprintln!();
@@ -176,9 +177,39 @@ fn print_usage() {
     eprintln!("Examples:");
     eprintln!("  tsql postgres://localhost/mydb");
     eprintln!("  tsql mongodb://localhost:27017/mydb");
+    eprintln!("  tsql -- -prod");
     eprintln!("  DATABASE_URL=postgres://localhost/mydb tsql");
     eprintln!("  tsql --debug-keys");
     eprintln!("  tsql --debug-keys --mouse");
+}
+
+fn has_any_startup_option(args: &[String], options: &[&str]) -> bool {
+    args.iter()
+        .skip(1)
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| options.iter().any(|option| arg == option))
+}
+
+fn first_positional_arg(args: &[String]) -> Option<&str> {
+    let mut iter = args.iter().skip(1);
+
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            return iter.next().map(String::as_str);
+        }
+        if !arg.starts_with('-') {
+            return Some(arg);
+        }
+    }
+
+    None
+}
+
+fn config_for_startup(mut cfg: config::Config, safe_mode: bool) -> config::Config {
+    if safe_mode {
+        cfg.connection.default_url = None;
+    }
+    cfg
 }
 
 fn onepassword_cli_available() -> bool {
@@ -232,32 +263,26 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     // Check for help flag
-    if args.iter().any(|a| a == "-h" || a == "--help") {
+    if has_any_startup_option(&args, &["-h", "--help"]) {
         print_usage();
         return Ok(());
     }
 
     // Check for version flag
-    if args.iter().any(|a| a == "-V" || a == "--version") {
+    if has_any_startup_option(&args, &["-V", "--version"]) {
         print_version();
         return Ok(());
     }
 
     // Key debug mode (helps identify what the terminal actually sends)
-    let debug_keys_mode = args
-        .iter()
-        .any(|a| a == "--debug-keys" || a == "--debug-keys-mouse")
+    let debug_keys_mode = has_any_startup_option(&args, &["--debug-keys", "--debug-keys-mouse"])
         || args.get(1).is_some_and(|a| a == "debug-keys");
     if debug_keys_mode {
-        let debug_mouse = args
-            .iter()
-            .any(|a| a == "--debug-keys-mouse" || a == "--mouse");
+        let debug_mouse = has_any_startup_option(&args, &["--debug-keys-mouse", "--mouse"]);
         return run_debug_keys(debug_mouse);
     }
 
-    let safe_mode = args
-        .iter()
-        .any(|a| a == "--safe-mode" || a == "--no-auto-connect");
+    let safe_mode = has_any_startup_option(&args, &["--safe-mode", "--no-auto-connect"]);
     let mut startup_warnings: Vec<String> = Vec::new();
 
     if let Err(err) = config::migrate_legacy_config_dir_on_startup() {
@@ -272,6 +297,7 @@ fn main() -> Result<()> {
         startup_warnings.push(format!("Failed to load config: {}", e));
         config::Config::default()
     });
+    let cfg = config_for_startup(cfg, safe_mode);
     let onepassword_enabled = cfg.connection.enable_onepassword;
 
     // Load session state if persistence is enabled
@@ -285,9 +311,9 @@ fn main() -> Result<()> {
     };
 
     // Connection string priority: CLI arg > DATABASE_URL env var > libpq env vars > config file
-    let positional_url = args.iter().skip(1).find(|a| !a.starts_with('-'));
+    let positional_url = first_positional_arg(&args);
     let (conn_str, libpq_warning) = if let Some(url) = positional_url {
-        (Some(url.clone()), None)
+        (Some(url.to_string()), None)
     } else if let Ok(url) = env::var("DATABASE_URL") {
         // Fall back to DATABASE_URL environment variable
         (Some(url), None)
@@ -500,6 +526,10 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
     /// Helper to clear all libpq env vars before each test
     fn clear_libpq_env_vars() {
         for var in [
@@ -512,6 +542,29 @@ mod tests {
         ] {
             env::remove_var(var);
         }
+    }
+
+    #[test]
+    fn test_first_positional_arg_uses_value_after_double_dash() {
+        let args = args(&["tsql", "--safe-mode", "--", "-prod"]);
+        assert_eq!(first_positional_arg(&args), Some("-prod"));
+    }
+
+    #[test]
+    fn test_options_after_double_dash_are_positional() {
+        let args = args(&["tsql", "--", "--help"]);
+        assert!(!has_any_startup_option(&args, &["--help"]));
+        assert_eq!(first_positional_arg(&args), Some("--help"));
+    }
+
+    #[test]
+    fn test_safe_mode_suppresses_config_default_url() {
+        let mut cfg = config::Config::default();
+        cfg.connection.default_url = Some("postgres://localhost/prod".to_string());
+
+        let cfg = config_for_startup(cfg, true);
+
+        assert_eq!(cfg.connection.default_url, None);
     }
 
     #[test]

--- a/crates/tsql/src/ui/connection_manager.rs
+++ b/crates/tsql/src/ui/connection_manager.rs
@@ -49,7 +49,7 @@ pub enum ConnectionManagerAction {
         /// URL to copy.
         url: String,
     },
-    /// Copy a shell-pasteable `tsql <url>` command.
+    /// Copy a shell-pasteable `tsql <connection-name>` command.
     YankCli {
         /// Command to copy.
         command: String,
@@ -870,10 +870,10 @@ mod tests {
     }
 
     #[test]
-    fn test_yank_cli_action_quotes_sanitized_url() {
+    fn test_yank_cli_action_quotes_connection_name() {
         let mut file = ConnectionsFile::new();
         file.add(ConnectionEntry {
-            name: "quoted".to_string(),
+            name: "local;dev".to_string(),
             host: "localhost".to_string(),
             port: 5432,
             database: "my db".to_string(),
@@ -887,7 +887,7 @@ mod tests {
 
         match action {
             ConnectionManagerAction::YankCli { command } => {
-                assert_eq!(command, "tsql 'postgres://postgres@localhost/my db'");
+                assert_eq!(command, "tsql 'local;dev'");
             }
             _ => panic!("Expected YankCli action"),
         }

--- a/crates/tsql/src/ui/connection_manager.rs
+++ b/crates/tsql/src/ui/connection_manager.rs
@@ -894,6 +894,30 @@ mod tests {
     }
 
     #[test]
+    fn test_yank_cli_action_uses_double_dash_for_option_like_name() {
+        let mut file = ConnectionsFile::new();
+        file.add(ConnectionEntry {
+            name: "-prod".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            database: "mydb".to_string(),
+            user: "postgres".to_string(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let mut manager = ConnectionManagerModal::new(&file, None);
+        let action = manager.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE));
+
+        match action {
+            ConnectionManagerAction::YankCli { command } => {
+                assert_eq!(command, "tsql -- -prod");
+            }
+            _ => panic!("Expected YankCli action"),
+        }
+    }
+
+    #[test]
     fn test_connection_test_action() {
         let file = create_test_connections();
         let mut manager = ConnectionManagerModal::new(&file, None);

--- a/crates/tsql/src/ui/connection_manager.rs
+++ b/crates/tsql/src/ui/connection_manager.rs
@@ -44,6 +44,21 @@ pub enum ConnectionManagerAction {
         /// The connection entry to duplicate
         entry: ConnectionEntry,
     },
+    /// Copy the selected connection URL without a password.
+    YankUrl {
+        /// URL to copy.
+        url: String,
+    },
+    /// Copy a shell-pasteable `tsql <url>` command.
+    YankCli {
+        /// Command to copy.
+        command: String,
+    },
+    /// Test the selected connection in the background.
+    TestConnection {
+        /// The connection entry to test.
+        entry: ConnectionEntry,
+    },
     /// Delete the selected connection (requires confirmation).
     Delete {
         /// The connection name to delete
@@ -177,9 +192,43 @@ impl ConnectionManagerModal {
             }
 
             // Duplicate selected connection
-            (KeyCode::Char('y'), KeyModifiers::NONE) => {
+            (KeyCode::Char('D'), KeyModifiers::NONE)
+            | (KeyCode::Char('D'), KeyModifiers::SHIFT) => {
                 if let Some(entry) = self.selected_connection() {
                     ConnectionManagerAction::Duplicate {
+                        entry: entry.clone(),
+                    }
+                } else {
+                    ConnectionManagerAction::Continue
+                }
+            }
+
+            // Yank sanitized URL
+            (KeyCode::Char('y'), KeyModifiers::NONE) => {
+                if let Some(entry) = self.selected_connection() {
+                    ConnectionManagerAction::YankUrl {
+                        url: entry.sanitized_url(),
+                    }
+                } else {
+                    ConnectionManagerAction::Continue
+                }
+            }
+
+            // Copy CLI command
+            (KeyCode::Char('c'), KeyModifiers::NONE) => {
+                if let Some(entry) = self.selected_connection() {
+                    ConnectionManagerAction::YankCli {
+                        command: entry.to_cli_command(),
+                    }
+                } else {
+                    ConnectionManagerAction::Continue
+                }
+            }
+
+            // Test connection
+            (KeyCode::Char('t'), KeyModifiers::NONE) => {
+                if let Some(entry) = self.selected_connection() {
+                    ConnectionManagerAction::TestConnection {
                         entry: entry.clone(),
                     }
                 } else {
@@ -564,8 +613,14 @@ impl ConnectionManagerModal {
         let help_spans = vec![
             Span::styled("[a]", Style::default().fg(Color::Yellow)),
             Span::raw("dd "),
-            Span::styled("[y]", Style::default().fg(Color::Yellow)),
+            Span::styled("[D]", Style::default().fg(Color::Yellow)),
             Span::raw(" duplicate "),
+            Span::styled("[y]", Style::default().fg(Color::Yellow)),
+            Span::raw(" url "),
+            Span::styled("[c]", Style::default().fg(Color::Yellow)),
+            Span::raw(" cli "),
+            Span::styled("[t]", Style::default().fg(Color::Yellow)),
+            Span::raw(" test "),
             Span::styled("[e]", Style::default().fg(Color::Yellow)),
             Span::raw("dit "),
             Span::styled("[d]", Style::default().fg(Color::Yellow)),
@@ -779,13 +834,77 @@ mod tests {
         let file = create_test_connections();
         let mut manager = ConnectionManagerModal::new(&file, None);
 
-        let action = manager.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        let action = manager.handle_key(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::NONE));
 
         match action {
             ConnectionManagerAction::Duplicate { entry } => {
                 assert_eq!(entry.name, "local");
             }
             _ => panic!("Expected Duplicate action"),
+        }
+    }
+
+    #[test]
+    fn test_yank_url_action_uses_sanitized_url() {
+        let mut file = ConnectionsFile::new();
+        file.add(ConnectionEntry {
+            name: "secret".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            database: "mydb".to_string(),
+            user: "postgres".to_string(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let mut manager = ConnectionManagerModal::new(&file, None);
+        let action = manager.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        match action {
+            ConnectionManagerAction::YankUrl { url } => {
+                assert_eq!(url, "postgres://postgres@localhost/mydb");
+                assert!(!url.contains(":secret@"));
+            }
+            _ => panic!("Expected YankUrl action"),
+        }
+    }
+
+    #[test]
+    fn test_yank_cli_action_quotes_sanitized_url() {
+        let mut file = ConnectionsFile::new();
+        file.add(ConnectionEntry {
+            name: "quoted".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            database: "my db".to_string(),
+            user: "postgres".to_string(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let mut manager = ConnectionManagerModal::new(&file, None);
+        let action = manager.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE));
+
+        match action {
+            ConnectionManagerAction::YankCli { command } => {
+                assert_eq!(command, "tsql 'postgres://postgres@localhost/my db'");
+            }
+            _ => panic!("Expected YankCli action"),
+        }
+    }
+
+    #[test]
+    fn test_connection_test_action() {
+        let file = create_test_connections();
+        let mut manager = ConnectionManagerModal::new(&file, None);
+
+        let action = manager.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE));
+
+        match action {
+            ConnectionManagerAction::TestConnection { entry } => {
+                assert_eq!(entry.name, "local");
+            }
+            _ => panic!("Expected TestConnection action"),
         }
     }
 

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -111,6 +111,22 @@ const SIDEBAR_CONNECTIONS: HelpSection = HelpSection::new(
     ],
 );
 
+const CONNECTION_MANAGER: HelpSection = HelpSection::new(
+    "Connection Manager",
+    &[
+        KeyBinding::new("j/k or arrows", "Navigate connections"),
+        KeyBinding::new("Enter", "Connect to selected"),
+        KeyBinding::new("a / e", "Add/edit connection"),
+        KeyBinding::new("D", "Duplicate connection"),
+        KeyBinding::new("y", "Copy URL without password"),
+        KeyBinding::new("c", "Copy `tsql` command"),
+        KeyBinding::new("t", "Test connection"),
+        KeyBinding::new("d", "Delete connection"),
+        KeyBinding::new("f", "Set favorite"),
+        KeyBinding::new("q / Esc", "Close connection manager"),
+    ],
+);
+
 const SIDEBAR_SCHEMA: HelpSection = HelpSection::new(
     "Sidebar - Schema",
     &[
@@ -288,6 +304,7 @@ const ALL_SECTIONS: &[HelpSection] = &[
     GLOBAL,
     GOTO,
     SIDEBAR_CONNECTIONS,
+    CONNECTION_MANAGER,
     SIDEBAR_SCHEMA,
     QUERY_NAVIGATION,
     QUERY_EDITING,

--- a/crates/tsql/tests/startup_nonblocking.rs
+++ b/crates/tsql/tests/startup_nonblocking.rs
@@ -1,0 +1,31 @@
+//! Static regression coverage for startup paths that must not block first draw.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn main_does_not_resolve_saved_connection_passwords() {
+    let main_rs = fs::read_to_string(crate_root().join("src/main.rs")).unwrap();
+
+    assert!(
+        !main_rs.contains("get_password_with_timeout"),
+        "startup password lookup belongs in App after the first draw"
+    );
+    assert!(main_rs.contains("--safe-mode"));
+    assert!(main_rs.contains("set_safe_mode"));
+    assert!(main_rs.contains("set_pending_startup_reconnect"));
+}
+
+#[test]
+fn app_resolves_startup_passwords_via_background_event() {
+    let app_rs = fs::read_to_string(crate_root().join("src/app/app.rs")).unwrap();
+
+    assert!(app_rs.contains("PasswordResolveReason::Startup"));
+    assert!(app_rs.contains("DbEvent::PasswordResolved"));
+    assert!(app_rs.contains("dispatch_pending_startup_reconnect"));
+    assert!(app_rs.contains("spawn_blocking"));
+}


### PR DESCRIPTION
## Summary

This is a scoped recovery of the mergeable pieces from #37.

- defer saved-connection password resolution until after the first TUI frame
- add `--safe-mode` / `--no-auto-connect` to skip startup reconnect and startup update checks
- keep stale connection task completions from overwriting newer connection state
- add connection-manager actions for copying sanitized URLs, copying `tsql` commands, and testing saved connections
- move duplicate from `y` to `D` so `y` can yank the safe URL

Intentionally left out the broader #37 changes around search/sort/import/export, metadata schema changes, and repository renames.

## Verification

- `cargo fmt --all`
- `cargo test --lib --bins`
- `cargo test -p tsql --test startup_nonblocking`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p tsql --test integration_tests`
