### PR TITLE
Fix for SSL connections: select aws_lc_rs as the default Rustls provider

### DIFF
--- a/crates/tsql/src/main.rs
+++ b/crates/tsql/src/main.rs
@@ -311,6 +311,10 @@ fn main() -> Result<()> {
             err
         ));
     }
+    // Install the aws_lc_rs Rustls provider
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
 
     // Load configuration from ~/.tsql/config.toml
     let cfg = config::load_config().unwrap_or_else(|e| {


### PR DESCRIPTION
Hi!
I tried to connect to a postgresql DB that requires SSL connections, the connection failed with this error message:
```
no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point
```
The [rustls docs](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html) state:

```
applications should call CryptoProvider::install_default() early in their fn main(). 
```

So I added that in `main`, installing `aws_lc_rs` which seemed like a good choice. The SSL connection then worked.
I run formats and tests.
I am human.
Thank you!

/Avner