### PR TITLE
feat(notebook): add an interactive notebook and result workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3609,6 +3609,8 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls-improved",
  "toml",
+ "tree-sitter",
+ "tree-sitter-sequel",
  "tui-syntax",
  "tui-textarea",
  "tui-tree-widget",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,6 +3546,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-javascript"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-json"
 version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +3642,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-highlight",
  "tree-sitter-html",
+ "tree-sitter-javascript",
  "tree-sitter-json",
  "tree-sitter-sequel",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rig = { package = "rig-core", version = "0.31.0" }
 arboard = "3"
 crossterm = "0.28"
 ratatui = "0.29"
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "fs", "io-util"] }
 tokio-postgres = "0.7"
 tokio-postgres-rustls-improved = "0.16"
 rustls = "0.23.35"
@@ -31,6 +31,7 @@ tree-sitter-highlight = "0.24"
 tree-sitter-sequel = "0.3"
 tree-sitter-json = "0.24"
 tree-sitter-html = "0.23"
+tree-sitter-javascript = "0.23"
 
 # Theme/config parsing
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If you like this crate show some support by [following fcoury (me) on X](https:/
 ## Features
 
 - **Full-screen TUI** - Split-pane interface with query editor and results grid
+- **Notebook workspace** - Build an ordered SQL narrative with durable inline outputs and PostgreSQL session-snapshot refinement
 - **Vim-style keybindings** - Navigate and edit with familiar modal commands
 - **Syntax highlighting** - SQL and JSON highlighting powered by tree-sitter
 - **Smart completion** - Schema-aware autocomplete for tables, columns, and keywords
@@ -71,6 +72,9 @@ Once connected:
 2. Press `Enter` to execute
 3. Use `Tab` / `Shift-Tab` to cycle panes, or `Ctrl-h/j/k/l` to move spatially
 4. Press `?` for help with all keybindings (type `/` inside the help popup to filter)
+
+Switch to the opt-in notebook workspace with `:notebook` or `:mode notebook`.
+Use `:mode classic` to return without discarding either workspace.
 
 ## Keybindings
 
@@ -158,6 +162,53 @@ editor. When it already contains a query, tsql asks for confirmation first.
 
 Yank commands operate on all selected rows when a selection is active, or the cursor row otherwise.
 
+### Notebook Workspace
+
+Notebook mode keeps one selected cell with Cell, Editor, and Result focus. PostgreSQL
+`SELECT`, `WITH`, `VALUES`, and `TABLE` results that fit the configured retention
+limits are captured once as session-local TEMP snapshots. Pressing `r` creates a
+dependent cell bound to that immutable result version; it does not rerun the source.
+MongoDB cells execute normally, but refinement is unavailable.
+
+Cell numbers are stable identities used by `@result_N`, so inserting or deleting
+cells can leave them out of visual sequence. `@result` uses the most recently
+completed refinable result, while `@result_N` uses the latest available result from
+cell `N` when a restored or loaded cell has no live binding. The chosen snapshot is
+pinned for that execution; existing live `@result_N` dependencies remain immutable.
+After restarting, rerun the source cell before running its dependent cell.
+
+| Key | Cell-focus action |
+| --- | --- |
+| `j` / `k` | Next / previous cell |
+| `Enter` / `e` | Enter the selected editor |
+| `Ctrl-e` | Execute in place |
+| `o` | Inspect the result |
+| `n` | Select or create the trailing draft |
+| `r` | Refine a complete retained PostgreSQL result |
+| `h` / `l` | Collapse / expand the selected result |
+| `z` | Collapse or expand output |
+| `x` | Clear the selected cell and dependent executions |
+| `Esc` | Return from Editor/Result to Cell focus |
+
+Mouse input is also supported: click a composer to focus its editor, click the right-edge
+`▾` / `▸` chevron to expand or collapse its result, click an inline result to select its row
+and column, and use the wheel to move within the focused region.
+Clearing an execution preserves the SQL in every affected cell so the chain can be
+rerun; a confirmation prompt lists how many dependent results will be cleared.
+
+Result focus uses the same navigable table as the Classic results grid. Use `h/j/k/l` or
+the arrow keys to move between cells, `gg/G` and `0/$` to jump between rows and columns,
+`/` and `n/N` to search, `Space` to select rows, the yank commands to copy, `+/-` or `=`
+to size a column, and `o` to open row detail. The active result expands to fill the
+workspace while other cells compact into one-line summaries. Notebook results are
+read-only; press `Esc` to restore the notebook flow and return to Cell focus.
+
+Snapshots last only for the current database session. Reconnects keep displayed
+output but disable refinement. Transaction/statement poolers are not compatible
+with cross-cell TEMP snapshots; set `snapshot_mode = "off"` for those connections.
+Metadata commands such as `:\\dt` open their results in the Classic grid; use
+`:notebook` to return to the preserved notebook workspace.
+
 ### Row Detail (`o` to open)
 
 | Key           | Action                             |
@@ -205,6 +256,11 @@ tsql --debug-keys --mouse
 | `:export csv\|json\|tsv <path>` | Export results      |
 | `:update [check\|status\|apply]` | Check/apply updates |
 | `:refresh`                      | Refresh focused schema or last query |
+| `:notebook` / `:mode notebook` | Switch to Notebook workspace |
+| `:mode classic`                | Switch to Classic workspace |
+| `:rebase`                      | Rebind a dependent cell to its source's latest snapshot |
+| `:rebind`                      | Allow the selected cell to run on the active connection |
+| `:run-without-snapshot`        | Explicitly retry a cell without retaining its result |
 | `:sbt` / `:sidebar-toggle`      | Toggle sidebar      |
 | `:q` / `:quit`                  | Quit                |
 | `:\dt`                          | List tables         |
@@ -236,6 +292,14 @@ theme = "one_dark"
 default_url = "postgres://localhost/mydb"
 # Enable 1Password CLI support for `password_onepassword` refs
 enable_onepassword = false
+
+[notebook]
+startup = false
+snapshot_mode = "auto" # use "off" with transaction/statement poolers
+snapshot_max_rows = 2000
+snapshot_max_bytes = 67108864
+snapshot_total_bytes = 134217728
+max_retained_snapshots = 8
 
 [updates]
 # Update checks + optional in-app apply for standalone installs

--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ tsql looks for configuration at `~/.tsql/config.toml` by default.
 On Linux/macOS startup, legacy config folders are auto-migrated to `~/.tsql`.
 
 ```toml
+[display]
+# Built-ins: "one_dark" and "github_light". "default" maps to One Dark.
+theme = "one_dark"
+
 [connection]
 # Default connection URL (can be overridden by CLI arg or DATABASE_URL)
 default_url = "postgres://localhost/mydb"
@@ -265,6 +269,45 @@ api_key_env = "OPENAI_API_KEY"
 ```
 
 See [config.example.toml](config.example.toml) for all available options.
+
+### Custom themes
+
+Custom themes use the same Helix-style TOML format as syntax highlighting and
+can also define tsql's UI chrome. Place `<name>.toml` in
+`~/.tsql/themes/`, then set `display.theme = "<name>"`. When
+`TSQL_CONFIG_DIR` is set, tsql uses `$TSQL_CONFIG_DIR/themes/` instead.
+
+Scope names containing dots must be quoted. A minimal theme can override only
+the values it needs; missing UI fields inherit the One Dark fallback:
+
+```toml
+[palette]
+foreground = "#d8dee9"
+background = "#242933"
+accent = "#88c0d0"
+
+["ui.background"]
+fg = "foreground"
+bg = "background"
+
+["ui.background.panel"]
+bg = "#20242c"
+
+["ui.background.elevated"]
+bg = "#2e3440"
+
+["ui.accent"]
+fg = "accent"
+
+[keyword]
+fg = "accent"
+```
+
+Supported UI scope families are `ui.background`, `ui.text`, `ui.label`,
+`ui.accent`, `ui.selection`, `ui.cursor`, `ui.search.match`, `ui.statusline`,
+`ui.success`, `ui.warning`, `ui.error`, `ui.scrollbar`, and
+`ui.grid.header`. A missing, unreadable, or malformed custom theme falls back
+to One Dark and reports a nonfatal startup warning.
 
 ### 1Password integration
 

--- a/README.md
+++ b/README.md
@@ -305,9 +305,10 @@ fg = "accent"
 
 Supported UI scope families are `ui.background`, `ui.text`, `ui.label`,
 `ui.accent`, `ui.selection`, `ui.cursor`, `ui.search.match`, `ui.statusline`,
-`ui.success`, `ui.warning`, `ui.error`, `ui.scrollbar`, and
-`ui.grid.header`. A missing, unreadable, or malformed custom theme falls back
-to One Dark and reports a nonfatal startup warning.
+`ui.success`, `ui.warning`, `ui.error`, `ui.transaction`, `ui.overlay`
+(modal surfaces, with `ui.overlay.border` and `ui.overlay.title`),
+`ui.scrollbar`, and `ui.grid.header`. A missing, unreadable, or malformed
+custom theme falls back to One Dark and reports a nonfatal startup warning.
 
 ### 1Password integration
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you like this crate show some support by [following fcoury (me) on X](https:/
 - **Vim-style keybindings** - Navigate and edit with familiar modal commands
 - **Syntax highlighting** - SQL and JSON highlighting powered by tree-sitter
 - **Smart completion** - Schema-aware autocomplete for tables, columns, and keywords
-- **Results grid** - Scrollable, searchable data grid with column resizing, multi-row selection, and flexible yank (TSV/CSV/JSON/Markdown)
+- **Results grid** - Scrollable, searchable data grid with column resizing, multi-row selection, flexible yank (TSV/CSV/JSON/Markdown), and server-backed Classic/PostgreSQL result transformations
 - **Inline editing** - Edit cells directly in the grid with automatic SQL generation
 - **JSON support** - Detect, format, and edit JSON/JSONB columns with syntax highlighting
 - **Postgres + MongoDB** - Connect with `postgres://...` or `mongodb://...` URLs
@@ -163,11 +163,18 @@ editor. When it already contains a query, tsql asks for confirmation first.
 
 Yank commands operate on all selected rows when a selection is active, or the cursor row otherwise.
 
+### Classic result transformations
+
+With a PostgreSQL result cell focused, open the Actions palette with `Ctrl+Shift+P`, `Cmd+K`, or `:actions` to sort or add a secondary sort, filter or exclude the current value, filter NULL/non-NULL or text contents, enter a custom comparison, choose columns, or group and count the current column. These transformations run on the server against the original read-only query, not just the rows loaded in the grid. Applying one reruns the source query, respects an existing `LIMIT`, and is unavailable during an active transaction; volatile functions and other session-level effects can still run again.
+
+The same operations are available as commands: `:sort asc|desc|add-asc|add-desc|toggle [#column|name]`, `:filter [#column|name] eq|ne|<|<=|>|>=|contains|not-contains|null|not-null [value]`, `:columns`, and `:group-count`. Use `:clear-filters`, `:clear-sort`, or `:reset-result` to remove transformations, and `:result-sql copy|open` to copy the generated SQL or open it in the editor.
+
 ### Notebook Workspace
 
 Notebook mode keeps one selected cell with Cell, Editor, and Result focus. PostgreSQL
-`SELECT`, `WITH`, `VALUES`, and `TABLE` results that fit the configured retention
-limits are captured once as session-local TEMP snapshots. Pressing `r` creates a
+read-only `SELECT`, `WITH`, `VALUES`, and `TABLE` results that fit the configured
+retention limits are captured once as session-local TEMP snapshots. Data-changing
+CTEs, `SELECT ... INTO`, and locking statements execute without retention. Pressing `r` creates a
 dependent cell bound to that immutable result version; it does not rerun the source.
 MongoDB cells execute normally, but refinement is unavailable.
 
@@ -177,6 +184,13 @@ completed refinable result, while `@result_N` uses the latest available result f
 cell `N` when a restored or loaded cell has no live binding. The chosen snapshot is
 pinned for that execution; existing live `@result_N` dependencies remain immutable.
 After restarting, rerun the source cell before running its dependent cell.
+Cells can join multiple sources naturally, including aliases, for example
+`SELECT a.id FROM @result_1 AS a JOIN @result_2 b USING (id)`. Name a reusable
+source with `:name recent_users` and reference it as `@result_recent_users`;
+names are stable across saves, case-insensitive, and must be unique.
+While editing a PostgreSQL cell, press `Tab` after `@res...` to complete the
+latest, numbered, or named live result reference with its source/run/row-count
+metadata.
 
 | Key | Cell-focus action |
 | --- | --- |
@@ -202,7 +216,40 @@ the arrow keys to move between cells, `gg/G` and `0/$` to jump between rows and 
 `/` and `n/N` to search, `Space` to select rows, the yank commands to copy, `+/-` or `=`
 to size a column, and `o` to open row detail. The active result expands to fill the
 workspace while other cells compact into one-line summaries. Notebook results are
-read-only; press `Esc` to restore the notebook flow and return to Cell focus.
+read-only; complete retained results fetch more rows as the cursor approaches the
+end, and `G` loads through to the final retained row. Press `Esc` to restore the
+notebook flow and return to Cell focus. Search clearly reports when a retained
+result is only partially loaded. Full-result export streams all retained rows
+directly to disk without expanding the display-memory budget; selecting loaded
+rows with `Space` exports only those rows. CSV, JSON, TSV, and SQL INSERT
+exports are supported (`:export sql:archive.users ./users.sql` overrides the
+inferred/default destination table). Notebook previews enforce both row and
+display-byte limits.
+
+Use `:run-all`, `:run-above`, `:run-below`, or `:run-dependents` to replay cells in
+dependency order. Execution is serial and stops at the first failed cell. Save a
+source-and-lineage-only document with `:save-notebook <path>` and reopen it with
+`:open-notebook <path>`; runtime outputs and TEMP handles are intentionally not
+stored in portable notebook files. Recent run status, timing, row counts, SQL,
+and compact output/error previews are kept in the local session only; use
+`:cell-history` to browse and restore a previous source or `:cell-run <id>` to
+restore a specific execution.
+For larger documents, `:insert-above`, `:insert-below`, `:duplicate-cell`, and
+`:move-cell-up` / `:move-cell-down` preserve stable identities while composing or
+reordering a workflow. `:outline` lists runnable cells and names; use
+`:cell <id-or-name>` to jump directly to one. `:collapse-source`,
+`:expand-source`, and `:toggle-source` compact or reveal long composers.
+Use `:error` to inspect a failed cell's full database diagnostic and `y` to copy
+it from the error popup, or `:copy-error` to copy the selected cell error directly.
+PostgreSQL positions are mapped through result-reference expansion and preview
+wrappers; `:error-jump` expands the source and moves the cursor to the reported
+line/column. Cells that finish or fail off-screen leave a status indicator;
+`:activity` jumps to the latest update.
+`:explain-cell` creates and runs a non-materialized PostgreSQL `EXPLAIN` cell below
+the selection while preserving any result dependencies.
+Set `TSQL_ASCII=1` (or use `TERM=dumb`) when a terminal cannot render the
+notebook disclosure and rail glyphs; expanded results use `v`, collapsed results
+use `>`, and cell rails use `|`.
 
 Snapshots last only for the current database session. Reconnects keep displayed
 output but disable refinement. Transaction/statement poolers are not compatible
@@ -233,6 +280,19 @@ Metadata commands such as `:\\dt` open their results in the Classic grid; use
 | `Ctrl-t` | Toggle between full history and pinned-only view                                |
 | `Esc`    | Close picker                                                                    |
 
+### Actions and saved snippets
+
+Press `Ctrl+Shift+P`, `Cmd+K` (where the terminal reports it), or run
+`:actions` to open the contextual Actions palette. It exposes operations
+relevant to the active Classic/Notebook editor, result, selection, or error,
+including execution, exports, SQL generation, cell workflows, history, and
+activity navigation.
+
+Save a reusable query with `:snippet-save <name>`, browse/filter snippets with
+`:snippets`, load one directly with `:snippet <name>`, and remove one with
+`:snippet-delete <name>` (or `Ctrl-d` inside the picker). Snippets are stored in
+the local query-history file and keep a sanitized connection hint.
+
 ### Troubleshooting keybindings
 
 If a key combo isn't working in your terminal, you can inspect what `tsql` is actually receiving:
@@ -254,14 +314,37 @@ tsql --debug-keys --mouse
 | `:connect <url>`                | Connect to database |
 | `:disconnect`                   | Disconnect          |
 | `:ai [prompt]`                  | Open AI query assistant |
-| `:export csv\|json\|tsv <path>` | Export results      |
+| `:export csv\|json\|tsv\|sql[:table] <path>` | Export selected rows or stream a full retained result |
+| `:actions` / `:palette`        | Open contextual Actions palette |
+| `:sort asc\|desc\|add-asc\|add-desc\|toggle` | Sort the focused Classic/PostgreSQL result |
+| `:filter [#column\|name] eq\|ne\|<\|<=\|>\|>=\|contains\|not-contains\|null\|not-null [value]` | Filter the focused Classic/PostgreSQL result |
+| `:columns` / `:group-count` | Choose result columns or group and count the current column |
+| `:clear-filters` / `:clear-sort` / `:reset-result` | Clear or reset Classic result transformations |
+| `:result-sql copy\|open` | Copy transformed SQL or open it in the editor |
+| `:snippets` / `:snippet-save <name>` | Browse or save reusable query snippets |
+| `:snippet <name>` / `:snippet-delete <name>` | Load or delete a saved snippet |
 | `:update [check\|status\|apply]` | Check/apply updates |
 | `:refresh`                      | Refresh focused schema or last query |
 | `:notebook` / `:mode notebook` | Switch to Notebook workspace |
 | `:mode classic`                | Switch to Classic workspace |
 | `:rebase`                      | Rebind a dependent cell to its source's latest snapshot |
 | `:rebind`                      | Allow the selected cell to run on the active connection |
+| `:detach`                      | Remove the selected cell's previous result binding |
 | `:run-without-snapshot`        | Explicitly retry a cell without retaining its result |
+| `:run-all` / `:run-above` / `:run-below` | Run notebook cells in dependency order |
+| `:run-dependents`              | Rerun the selected cell and its dependents |
+| `:save-notebook <path>`        | Save a portable notebook document |
+| `:open-notebook <path>`        | Open a portable notebook document |
+| `:insert-above` / `:insert-below` / `:duplicate-cell` | Insert or duplicate a notebook cell |
+| `:move-cell-up` / `:move-cell-down` | Reorder the selected notebook cell |
+| `:name <identifier>` / `:name clear` | Set or clear a stable result name |
+| `:outline` / `:cell <id-or-name>` | List notebook cells or jump to one |
+| `:error` / `:copy-error`       | Inspect or copy the selected cell error |
+| `:error-jump`                  | Move the editor cursor to a mapped PostgreSQL error |
+| `:activity`                    | Jump to the latest off-screen cell update |
+| `:cell-history` / `:cell-run <id>` | Browse cell runs or restore a previous source |
+| `:explain-cell`                | Explain the selected PostgreSQL notebook cell |
+| `:collapse-source` / `:expand-source` / `:toggle-source` | Compact or reveal the selected cell source |
 | `:sbt` / `:sidebar-toggle`      | Toggle sidebar      |
 | `:q` / `:quit`                  | Quit                |
 | `:\dt`                          | List tables         |

--- a/config.example.toml
+++ b/config.example.toml
@@ -24,10 +24,8 @@ show_null_indicator = true
 # Text to display for NULL values
 null_indicator = "NULL"
 
-# Show borders around grid cells
-show_borders = true
-
-# Theme name (reserved for future use)
+# Theme name: "one_dark", "github_light", or a custom file name from
+# ~/.tsql/themes/<name>.toml (or $TSQL_CONFIG_DIR/themes/<name>.toml)
 theme = "default"
 
 # SQL generation settings (used by Schema panel templates, etc.)

--- a/config.example.toml
+++ b/config.example.toml
@@ -170,6 +170,19 @@ max_columns_per_table = 20
 # system_prompt_postgres = "Return only PostgreSQL SQL."
 # system_prompt_mongo = "Return only db.collection.op(...) or JSON command syntax."
 
+# Notebook workspace and PostgreSQL session-snapshot settings
+[notebook]
+# Start in Notebook mode. Classic remains the default when false.
+startup = false
+# "auto" retains eligible complete PostgreSQL SELECT results; "off" only renders output.
+snapshot_mode = "auto"
+snapshot_max_rows = 2000
+snapshot_max_bytes = 67108864
+snapshot_total_bytes = 134217728
+max_retained_snapshots = 8
+composer_max_rows = 10
+output_preview_rows = 12
+
 # Clipboard settings
 [clipboard]
 # Clipboard backend:
@@ -213,6 +226,15 @@ vim_mode = true
 # key = "ctrl+x"
 # action = "export_csv"
 # description = "Export results to CSV"
+
+# Custom keybindings for Notebook Cell focus
+# [[keymap.notebook]]
+# key = "ctrl+n"
+# action = "new_notebook_cell"
+# description = "Create a notebook draft"
+#
+# Notebook output actions: collapse_cell_output (h), expand_cell_output (l),
+# toggle_cell_output (z), and clear_notebook_cell_execution (x).
 
 # Custom keybindings for sidebar navigation
 # [[keymap.sidebar]]

--- a/crates/tsql/Cargo.toml
+++ b/crates/tsql/Cargo.toml
@@ -65,6 +65,7 @@ tui_confirm_dialog_with_mouse.workspace = true
 
 # Atomic file writes
 tempfile.workspace = true
+uuid.workspace = true
 
 # Internal crate
 tui-syntax = { path = "../tui-syntax", version = "0.6.0" }
@@ -73,5 +74,4 @@ tree-sitter-sequel.workspace = true
 
 [dev-dependencies]
 dotenvy.workspace = true
-uuid.workspace = true
 serial_test = "3"

--- a/crates/tsql/Cargo.toml
+++ b/crates/tsql/Cargo.toml
@@ -68,6 +68,8 @@ tempfile.workspace = true
 
 # Internal crate
 tui-syntax = { path = "../tui-syntax", version = "0.6.0" }
+tree-sitter.workspace = true
+tree-sitter-sequel.workspace = true
 
 [dev-dependencies]
 dotenvy.workspace = true

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -8318,7 +8318,14 @@ impl App {
         if notebook && !exporting_selection {
             if let Some(retained) = retained {
                 let loaded = grid.rows.len();
-                if loaded < retained.rows {
+                if loaded < retained.rows
+                    || self
+                        .notebook
+                        .selected_cell()
+                        .output
+                        .as_ref()
+                        .is_some_and(|output| output.truncated)
+                {
                     if self.notebook_export_loading.is_some() {
                         self.last_status = Some("A notebook export is already running".to_string());
                         return;
@@ -19216,6 +19223,30 @@ mod tests {
             .last_status
             .as_deref()
             .is_some_and(|status| status.contains("Exported 1 selected row")));
+    }
+
+    #[test]
+    fn notebook_export_requires_live_snapshot_when_loaded_output_is_truncated() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        let _version = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let output = app.notebook.cells[0].output.as_mut().unwrap();
+        output.grid.rows[0][0] = "partial…".to_string();
+        output.truncated = true;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("truncated.csv");
+        app.handle_export_command(&format!("csv {}", path.display()));
+
+        assert!(app
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("Not connected; cannot export snapshot")));
+        assert!(!path.exists());
     }
 
     #[test]

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -14102,6 +14102,7 @@ impl App {
             }
             let before = notebook_grid_bytes(output);
             output.grid.rows.truncate(preview_rows);
+            output.grid.null_cells.truncate(preview_rows);
             output.grid_state.clamp_to_bounds(&output.grid);
             output.truncated = true;
             cell.output_collapsed = true;
@@ -19640,6 +19641,12 @@ mod tests {
             vec!["old-row-one-xxxxxxxx".to_string()],
             vec!["old-row-two-xxxxxxxx".to_string()],
         ];
+        app.notebook.cells[0]
+            .output
+            .as_mut()
+            .unwrap()
+            .grid
+            .null_cells = vec![vec![false], vec![true]];
         app.notebook.select_or_create_draft();
         app.notebook
             .selected_cell_mut()
@@ -19664,6 +19671,21 @@ mod tests {
         );
         assert!(app.notebook.cells[0].output_collapsed);
         assert!(app.notebook.cells[0].output.as_ref().unwrap().truncated);
+        let older_grid = &mut app.notebook.cells[0].output.as_mut().unwrap().grid;
+        assert_eq!(older_grid.null_cells, vec![vec![false]]);
+        older_grid.append_rows_with_nulls(
+            vec![vec!["NULL".to_string()], vec!["NULL".to_string()]],
+            vec![vec![false], vec![true]],
+        );
+        assert!(!older_grid.cell_is_null(1, 0));
+        assert!(older_grid.cell_is_null(2, 0));
+        assert_eq!(
+            older_grid.rows_as_sql_inserts(&[1, 2], "result"),
+            concat!(
+                "INSERT INTO result (value) VALUES ('NULL');\n",
+                "INSERT INTO result (value) VALUES (NULL);"
+            )
+        );
         assert_eq!(
             app.notebook.cells[1]
                 .output

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{self, Stdout};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -19,7 +19,9 @@ use ratatui::layout::Alignment;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState};
+use ratatui::widgets::{
+    Block, Clear, Padding, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+};
 use ratatui::Terminal;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
@@ -33,14 +35,30 @@ use tokio_postgres_rustls_improved::MakeRustlsConnect;
 use tui_textarea::{CursorMove, Input};
 use webpki_roots::TLS_SERVER_ROOTS;
 
-use super::state::{DbStatus, Focus, Mode, PanelDirection, SearchTarget, SidebarSection};
+use super::execution::{
+    classify_transaction_control, ActiveExecution, CellId, ExecutionContext, ExecutionId,
+    ExecutionTarget, QueryExecutionKind, TransactionControl, TransactionState,
+};
+use super::notebook::{
+    CellExecutionState, NotebookCell, NotebookFocus, NotebookOutput, NotebookState,
+};
+use super::pg_snapshot::{self, PgSnapshotRequest, PgTempSnapshot};
+use super::refinement::{
+    compile_logical_reference, logical_result_reference, LogicalResultReference,
+    RefinementAvailability, RefinementUnavailableReason, ResultVersion, RetainedResultHandle,
+};
+use super::state::{
+    DbStatus, Focus, Mode, PanelDirection, SearchTarget, SidebarSection, WorkspaceMode,
+};
 use crate::ai::{generate_query, AiProposal, AiRequestContext};
 use crate::config::{
     load_connections, save_connections, Action, ClipboardBackend, Config, ConnectionEntry,
-    ConnectionsFile, DbKind, KeyBinding, Keymap, SslMode, UpdateMode,
+    ConnectionsFile, DbKind, KeyBinding, Keymap, SnapshotMode, SslMode, UpdateMode,
 };
 use crate::history::{History, HistoryEntry};
-use crate::session::SessionState;
+use crate::session::{
+    NotebookCellSession, NotebookDependencySession, NotebookSession, SessionState,
+};
 use crate::ui::{
     create_sql_highlighter, determine_context, escape_sql_value, get_word_before_cursor, is_inside,
     load_theme, overlay_block, quote_identifier, zone_block, zone_inner, zone_label,
@@ -48,11 +66,12 @@ use crate::ui::{
     CompletionKind, CompletionPopup, ConfirmContext, ConfirmPrompt, ConfirmResult,
     ConnectionFormAction, ConnectionFormModal, ConnectionInfo, ConnectionManagerAction,
     ConnectionManagerModal, CursorShape, DataGrid, FuzzyPicker, GridKeyResult, GridModel,
-    GridState, HelpAction, HelpPopup, HighlightedTextArea, JsonEditorAction, JsonEditorModal,
-    KeyHintPopup, KeySequenceAction, KeySequenceCompletion, KeySequenceHandlerWithContext,
-    KeySequenceResult, PasswordPrompt, PasswordPromptResult, PendingKey, PickerAction, Priority,
-    QueryEditor, ResizeAction, RowDetailAction, RowDetailModal, SchemaCache, SearchPrompt, Sidebar,
-    SidebarAction, StatusLineBuilder, StatusSegment, TableInfo, UiTheme, YankFormat,
+    GridState, GridViewport, HelpAction, HelpPopup, HighlightedTextArea, JsonEditorAction,
+    JsonEditorModal, KeyHintPopup, KeySequenceAction, KeySequenceCompletion,
+    KeySequenceHandlerWithContext, KeySequenceResult, PasswordPrompt, PasswordPromptResult,
+    PendingKey, PickerAction, Priority, QueryEditor, ResizeAction, RowDetailAction, RowDetailModal,
+    SchemaCache, SearchPrompt, Sidebar, SidebarAction, StatusLineBuilder, StatusSegment, TableInfo,
+    UiTheme, YankFormat,
 };
 use crate::update::{
     apply_update, check_for_update, current_target_triple, detect_current_install_method,
@@ -542,6 +561,8 @@ SELECT
     tableowner AS owner
 FROM pg_catalog.pg_tables
 WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+  AND schemaname NOT LIKE 'pg_temp_%'
+  AND schemaname NOT LIKE 'pg_toast_temp_%'
 ORDER BY schemaname, tablename
 "#;
 
@@ -587,6 +608,8 @@ SELECT
     indexdef AS definition
 FROM pg_catalog.pg_indexes
 WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+  AND schemaname NOT LIKE 'pg_temp_%'
+  AND schemaname NOT LIKE 'pg_toast_temp_%'
 ORDER BY schemaname, tablename, indexname
 "#;
 
@@ -622,6 +645,8 @@ SELECT
     viewowner AS owner
 FROM pg_catalog.pg_views
 WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+  AND schemaname NOT LIKE 'pg_temp_%'
+  AND schemaname NOT LIKE 'pg_toast_temp_%'
 ORDER BY schemaname, viewname
 "#;
 
@@ -635,6 +660,8 @@ SELECT
 FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
 WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+  AND n.nspname NOT LIKE 'pg_temp_%'
+  AND n.nspname NOT LIKE 'pg_toast_temp_%'
 ORDER BY n.nspname, p.proname
 "#;
 
@@ -2130,7 +2157,17 @@ pub enum DbEvent {
     QueryFinished {
         result: QueryResult,
     },
+    NotebookQueryFinished {
+        context: ExecutionContext,
+        result: QueryResult,
+        retained: Option<super::refinement::RetainedResult>,
+        snapshot: Option<PgTempSnapshot>,
+    },
     QueryError {
+        error: String,
+    },
+    NotebookQueryError {
+        context: ExecutionContext,
         error: String,
     },
     QueryCancelled,
@@ -2218,8 +2255,8 @@ pub struct DbSession {
     pub last_command_tag: Option<String>,
     pub last_elapsed: Option<Duration>,
     pub running: bool,
-    /// Whether we're currently in a transaction (after BEGIN, before COMMIT/ROLLBACK)
-    pub in_transaction: bool,
+    /// Conservatively inferred state of the current PostgreSQL user transaction.
+    pub transaction_state: TransactionState,
     /// Whether the current connection was established using TLS.
     pub connected_with_tls: bool,
 }
@@ -2237,7 +2274,7 @@ impl DbSession {
             last_command_tag: None,
             last_elapsed: None,
             running: false,
-            in_transaction: false,
+            transaction_state: TransactionState::Unknown,
             connected_with_tls: false,
         }
     }
@@ -2431,6 +2468,8 @@ impl CellEditor {
 pub struct App {
     pub focus: Focus,
     pub mode: Mode,
+    pub workspace_mode: WorkspaceMode,
+    pub notebook: NotebookState,
 
     /// Application configuration
     pub config: Config,
@@ -2446,6 +2485,8 @@ pub struct App {
 
     /// Keymap for grid navigation
     pub grid_keymap: Keymap,
+    /// Keymap for Notebook Cell focus.
+    pub notebook_keymap: Keymap,
     /// Keymap for editor in normal mode
     pub editor_normal_keymap: Keymap,
     /// Keymap for editor in insert mode
@@ -2483,6 +2524,12 @@ pub struct App {
     last_executed_query: Option<String>,
     /// How the active editor query was started, used when applying its result.
     active_query_kind: Option<QueryExecutionKind>,
+    active_execution: Option<ActiveExecution>,
+    next_execution_id: u64,
+    next_retained_handle: u64,
+    pg_snapshots: HashMap<RetainedResultHandle, PgTempSnapshot>,
+    retained_versions: HashMap<super::refinement::ResultVersion, RetainedResultHandle>,
+    pg_snapshot_order: VecDeque<RetainedResultHandle>,
 
     pub grid: GridModel,
     pub grid_state: GridState,
@@ -2522,6 +2569,8 @@ pub struct App {
     render_query_area: Option<Rect>,
     /// Last rendered area for results grid (for mouse click handling).
     render_grid_area: Option<Rect>,
+    /// Last rendered Notebook composer/output areas (for mouse hit testing).
+    render_notebook_cells: Vec<NotebookCellRenderArea>,
     /// Last rendered area for sidebar (for mouse click handling).
     render_sidebar_area: Option<Rect>,
 
@@ -2598,6 +2647,16 @@ struct GridCellClick {
     col: usize,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct NotebookCellRenderArea {
+    cell_id: CellId,
+    composer: Rect,
+    output_toggle: Option<Rect>,
+    output: Option<Rect>,
+    grid: Option<Rect>,
+    compact: bool,
+}
+
 /// Local enum to track cursor style changes (SetCursorStyle doesn't implement PartialEq).
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum CachedCursorStyle {
@@ -2609,12 +2668,6 @@ enum CachedCursorStyle {
 enum QueryHeightMode {
     Minimized,
     Maximized,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum QueryExecutionKind {
-    New,
-    Refresh,
 }
 
 /// Groups spinner and timing state for query execution UI.
@@ -2686,6 +2739,7 @@ impl App {
 
         // Build keymaps from defaults + config overrides
         let grid_keymap = Self::build_grid_keymap(&config);
+        let notebook_keymap = Self::build_notebook_keymap(&config);
         let editor_normal_keymap = Self::build_editor_normal_keymap(&config);
         let editor_insert_keymap = Self::build_editor_insert_keymap(&config);
         let editor_visual_keymap = Self::build_editor_visual_keymap(&config);
@@ -2696,12 +2750,15 @@ impl App {
         let mut app = Self {
             focus: Focus::Query,
             mode: Mode::Normal,
+            workspace_mode: WorkspaceMode::Classic,
+            notebook: NotebookState::new(),
 
             config,
             ui_theme,
             startup_warnings: theme_warning.into_iter().collect(),
 
             grid_keymap,
+            notebook_keymap,
             editor_normal_keymap,
             editor_insert_keymap,
             editor_visual_keymap,
@@ -2728,6 +2785,12 @@ impl App {
             paged_query: None,
             last_executed_query: None,
             active_query_kind: None,
+            active_execution: None,
+            next_execution_id: 1,
+            next_retained_handle: 1,
+            pg_snapshots: HashMap::new(),
+            retained_versions: HashMap::new(),
+            pg_snapshot_order: VecDeque::new(),
 
             grid,
             grid_state: GridState::default(),
@@ -2751,6 +2814,7 @@ impl App {
 
             render_query_area: None,
             render_grid_area: None,
+            render_notebook_cells: Vec::new(),
             render_sidebar_area: None,
 
             connections: ConnectionsFile::new(),
@@ -2816,6 +2880,11 @@ impl App {
         // Note: connection picker is NOT opened here when no URL specified.
         // This allows main.rs to first check session state for auto-reconnect.
 
+        if app.config.notebook.startup {
+            app.workspace_mode = WorkspaceMode::Notebook;
+            app.focus = Focus::Notebook;
+        }
+
         app
     }
 
@@ -2835,6 +2904,29 @@ impl App {
             editor_content: self.editor.text(),
             schema_expanded: self.sidebar.get_expanded_nodes(),
             sidebar_visible: self.sidebar_visible,
+            workspace: match self.workspace_mode {
+                WorkspaceMode::Classic => "classic",
+                WorkspaceMode::Notebook => "notebook",
+            }
+            .to_string(),
+            notebook: NotebookSession {
+                cells: self
+                    .notebook
+                    .cells
+                    .iter()
+                    .map(|cell| NotebookCellSession {
+                        cell_id: Some(cell.id.0),
+                        source: cell.source(),
+                        output_collapsed: cell.output_collapsed,
+                        dependency: cell.dependency.map(|version| NotebookDependencySession {
+                            source_cell_id: version.source_cell.0,
+                            source_execution_id: version.source_execution.0,
+                            source_revision: version.source_revision,
+                        }),
+                    })
+                    .collect(),
+                selected_index: self.notebook.selected_index(),
+            },
         }
     }
 
@@ -2847,12 +2939,40 @@ impl App {
     /// Apply restored session state.
     /// Returns the connection name to auto-connect to, if any.
     pub fn apply_session_state(&mut self, state: SessionState) -> Option<String> {
+        let connection_name = state.connection_name;
         // Restore editor content (apply exactly, even if empty)
         self.editor.set_text(state.editor_content);
         self.editor.mark_saved();
 
         // Restore sidebar visibility
         self.sidebar_visible = state.sidebar_visible;
+        self.notebook = NotebookState::from_sources_with_ids(
+            state
+                .notebook
+                .cells
+                .into_iter()
+                .map(|cell| {
+                    (
+                        cell.cell_id.map(super::execution::CellId),
+                        cell.source,
+                        cell.output_collapsed,
+                        cell.dependency
+                            .map(|dependency| super::refinement::ResultVersion {
+                                source_cell: super::execution::CellId(dependency.source_cell_id),
+                                source_execution: super::execution::ExecutionId(
+                                    dependency.source_execution_id,
+                                ),
+                                source_revision: dependency.source_revision,
+                            }),
+                    )
+                })
+                .collect(),
+            state.notebook.selected_index,
+        );
+        if state.workspace == "notebook" {
+            self.workspace_mode = WorkspaceMode::Notebook;
+            self.focus = Focus::Notebook;
+        }
 
         // Store pending schema expanded for later application when schema loads
         // Always set (even to None) to clear any prior pending paths
@@ -2863,7 +2983,7 @@ impl App {
         };
 
         // Return connection name for auto-connect handling
-        state.connection_name
+        connection_name
     }
 
     /// Apply pending schema expanded state after schema loads.
@@ -2886,6 +3006,18 @@ impl App {
             }
         }
 
+        keymap
+    }
+
+    fn build_notebook_keymap(config: &Config) -> Keymap {
+        let mut keymap = Keymap::default_notebook_keymap();
+        for binding in &config.keymap.notebook {
+            if let Some(key) = KeyBinding::parse(&binding.key) {
+                if let Ok(action) = binding.action.parse::<Action>() {
+                    keymap.bind(key, action);
+                }
+            }
+        }
         keymap
     }
 
@@ -3002,6 +3134,9 @@ impl App {
             // Set terminal cursor style based on vim mode (only when changed)
             let cached_style = match (self.focus, self.mode) {
                 (Focus::Query, Mode::Insert) => CachedCursorStyle::BlinkingBar,
+                (Focus::Notebook, Mode::Insert) if self.notebook.focus == NotebookFocus::Editor => {
+                    CachedCursorStyle::BlinkingBar
+                }
                 _ => CachedCursorStyle::SteadyBlock,
             };
             if self.last_cursor_style != Some(cached_style) {
@@ -3105,7 +3240,7 @@ impl App {
                         self.ui_theme.label_focused.fg(query_accent),
                     ));
                 }
-                if self.editor.is_modified() {
+                if self.workspace_has_unsaved_changes() {
                     query_details.push(Span::styled(" [+]", self.ui_theme.warning));
                 }
                 let query_block = zone_block(
@@ -3304,6 +3439,10 @@ impl App {
                             .alignment(Alignment::Center);
                         frame.render_widget(elapsed_widget, chunks[1]);
                     }
+                }
+
+                if self.workspace_mode == WorkspaceMode::Notebook {
+                    self.render_notebook_workspace(frame, main_area);
                 }
 
                 // Status.
@@ -3732,7 +3871,7 @@ impl App {
 
             if self.pending_external_edit {
                 self.pending_external_edit = false;
-                if let Err(e) = self.open_in_external_editor(terminal) {
+                if let Err(e) = self.open_active_external_editor(terminal) {
                     self.last_error = Some(format!("External editor failed: {e}"));
                 }
             }
@@ -3830,6 +3969,40 @@ impl App {
 
         // Esc: cancel running query, close popups, or quit if nothing is open.
         if key.code == KeyCode::Esc && key.modifiers == KeyModifiers::NONE {
+            if self.workspace_mode == WorkspaceMode::Notebook
+                && matches!(self.focus, Focus::Sidebar(_))
+                && !self.search.active
+                && !self.command.active
+                && !self.completion.active
+                && self.last_error.is_none()
+            {
+                self.set_focus(Focus::Notebook);
+                self.notebook.focus = NotebookFocus::Cell;
+                self.mode = Mode::Normal;
+                return false;
+            }
+            let notebook_can_handle_escape = self.focus == Focus::Notebook
+                && !self.search.active
+                && !self.command.active
+                && !self.completion.active
+                && self.last_error.is_none();
+            if notebook_can_handle_escape {
+                match self.notebook.focus {
+                    NotebookFocus::Editor if self.mode == Mode::Normal => {
+                        self.notebook.focus = NotebookFocus::Cell;
+                        return false;
+                    }
+                    NotebookFocus::Editor => {
+                        self.handle_notebook_key(key);
+                        return false;
+                    }
+                    NotebookFocus::Result => {
+                        self.notebook.focus = NotebookFocus::Cell;
+                        return false;
+                    }
+                    NotebookFocus::Cell => {}
+                }
+            }
             if self.db.running {
                 self.cancel_query();
                 return false;
@@ -3877,7 +4050,7 @@ impl App {
                 self.grid_state.selected_rows.clear();
             } else {
                 // Nothing open - behave like 'q' and show quit confirmation
-                if self.editor.is_modified() {
+                if self.workspace_has_unsaved_changes() {
                     self.confirm_prompt = Some(ConfirmPrompt::new(
                         "You have unsaved changes. Quit anyway?",
                         ConfirmContext::QuitApp,
@@ -3916,7 +4089,11 @@ impl App {
 
         // Global Ctrl+E to execute query (works regardless of mode/focus)
         if key.code == KeyCode::Char('e') && key.modifiers == KeyModifiers::CONTROL {
-            self.execute_query();
+            if self.workspace_mode == WorkspaceMode::Notebook {
+                self.execute_notebook_cell();
+            } else {
+                self.execute_query();
+            }
             return false;
         }
 
@@ -3947,6 +4124,9 @@ impl App {
 
         // Handle completion popup when active
         if self.completion.active {
+            if self.workspace_mode == WorkspaceMode::Notebook {
+                return self.handle_notebook_completion_key(key);
+            }
             match (key.code, key.modifiers) {
                 // Enter accepts the completion
                 (KeyCode::Enter, KeyModifiers::NONE) => {
@@ -4038,7 +4218,9 @@ impl App {
         }
 
         // Handle key sequences (e.g., gg, gc, gt, ge, gr) in Normal mode
-        if self.mode == Mode::Normal {
+        if self.mode == Mode::Normal
+            && !(self.focus == Focus::Notebook && self.notebook.focus == NotebookFocus::Editor)
+        {
             // Start a new key sequence for 'g' key (only when no sequence is pending)
             if !self.key_sequence.is_waiting() {
                 if let KeyCode::Char('g') = key.code {
@@ -4080,7 +4262,7 @@ impl App {
                 }
                 (KeyCode::Char('q'), KeyModifiers::NONE) => {
                     // Always show confirmation prompt, with different message based on unsaved changes
-                    if self.editor.is_modified() {
+                    if self.workspace_has_unsaved_changes() {
                         self.confirm_prompt = Some(ConfirmPrompt::new(
                             "You have unsaved changes. Quit anyway?",
                             ConfirmContext::QuitApp,
@@ -4260,6 +4442,7 @@ impl App {
             Focus::Query => {
                 self.handle_editor_key(key);
             }
+            Focus::Notebook => self.handle_notebook_key(key),
             Focus::Sidebar(section) => {
                 self.handle_sidebar_key(key, section);
             }
@@ -4276,6 +4459,15 @@ impl App {
                 Mode::Visual => self.editor_visual_keymap.get_action(key),
             },
             Focus::Grid => self.grid_keymap.get_action(key),
+            Focus::Notebook => match self.notebook.focus {
+                NotebookFocus::Cell => self.notebook_keymap.get_action(key),
+                NotebookFocus::Editor => match self.mode {
+                    Mode::Normal => self.editor_normal_keymap.get_action(key),
+                    Mode::Insert => self.editor_insert_keymap.get_action(key),
+                    Mode::Visual => self.editor_visual_keymap.get_action(key),
+                },
+                NotebookFocus::Result => self.grid_keymap.get_action(key),
+            },
             Focus::Sidebar(_) => self.sidebar_keymap.get_action(key),
         }?;
 
@@ -4325,7 +4517,7 @@ impl App {
                 self.sidebar_focus = SidebarSection::Schema;
                 self.select_first_schema_if_empty();
             }
-            Focus::Query | Focus::Grid => {}
+            Focus::Query | Focus::Grid | Focus::Notebook => {}
         }
 
         self.focus = focus;
@@ -4348,6 +4540,23 @@ impl App {
     }
 
     fn focus_next(&mut self) {
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            let next = if self.sidebar_visible {
+                match self.focus {
+                    Focus::Notebook => Focus::Sidebar(SidebarSection::Schema),
+                    Focus::Sidebar(SidebarSection::Schema) => {
+                        Focus::Sidebar(SidebarSection::Connections)
+                    }
+                    Focus::Sidebar(SidebarSection::Connections) => Focus::Notebook,
+                    Focus::Query | Focus::Grid => Focus::Notebook,
+                }
+            } else {
+                Focus::Notebook
+            };
+            self.set_focus(next);
+            return;
+        }
+
         let next = if self.sidebar_visible {
             match self.focus {
                 Focus::Query => Focus::Grid,
@@ -4356,17 +4565,36 @@ impl App {
                     Focus::Sidebar(SidebarSection::Connections)
                 }
                 Focus::Sidebar(SidebarSection::Connections) => Focus::Query,
+                Focus::Notebook => Focus::Sidebar(SidebarSection::Schema),
             }
         } else {
             match self.focus {
                 Focus::Query | Focus::Sidebar(SidebarSection::Schema) => Focus::Grid,
                 Focus::Grid | Focus::Sidebar(SidebarSection::Connections) => Focus::Query,
+                Focus::Notebook => Focus::Notebook,
             }
         };
         self.set_focus(next);
     }
 
     fn focus_previous(&mut self) {
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            let previous = if self.sidebar_visible {
+                match self.focus {
+                    Focus::Notebook => Focus::Sidebar(SidebarSection::Connections),
+                    Focus::Sidebar(SidebarSection::Connections) => {
+                        Focus::Sidebar(SidebarSection::Schema)
+                    }
+                    Focus::Sidebar(SidebarSection::Schema) => Focus::Notebook,
+                    Focus::Query | Focus::Grid => Focus::Notebook,
+                }
+            } else {
+                Focus::Notebook
+            };
+            self.set_focus(previous);
+            return;
+        }
+
         let previous = if self.sidebar_visible {
             match self.focus {
                 Focus::Query => Focus::Sidebar(SidebarSection::Connections),
@@ -4375,11 +4603,13 @@ impl App {
                 }
                 Focus::Sidebar(SidebarSection::Schema) => Focus::Grid,
                 Focus::Grid => Focus::Query,
+                Focus::Notebook => Focus::Sidebar(SidebarSection::Connections),
             }
         } else {
             match self.focus {
                 Focus::Query | Focus::Sidebar(SidebarSection::Schema) => Focus::Grid,
                 Focus::Grid | Focus::Sidebar(SidebarSection::Connections) => Focus::Query,
+                Focus::Notebook => Focus::Notebook,
             }
         };
         self.set_focus(previous);
@@ -4393,6 +4623,22 @@ impl App {
 
     /// Calculate the spatially adjacent pane, or None at a boundary.
     fn calculate_focus_for_direction(&self, direction: PanelDirection) -> Option<Focus> {
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            return match (self.focus, direction) {
+                (Focus::Notebook, PanelDirection::Left) => {
+                    Some(Focus::Sidebar(SidebarSection::Schema))
+                }
+                (Focus::Sidebar(_), PanelDirection::Right) => Some(Focus::Notebook),
+                (Focus::Sidebar(SidebarSection::Connections), PanelDirection::Down) => {
+                    Some(Focus::Sidebar(SidebarSection::Schema))
+                }
+                (Focus::Sidebar(SidebarSection::Schema), PanelDirection::Up) => {
+                    Some(Focus::Sidebar(SidebarSection::Connections))
+                }
+                _ => None,
+            };
+        }
+
         // Navigation follows the visible 2x2 layout. set_focus reveals the sidebar
         // when a leftward move targets one of its panes.
         // ┌─────────────────┬──────────────────┐
@@ -4508,9 +4754,7 @@ impl App {
                     }
                     SchemaTreeSelection::Column { column, .. } => {
                         // Column node: preserve existing behavior (insert column name)
-                        self.editor.textarea.insert_str(&column);
-                        self.set_focus(Focus::Query);
-                        self.mode = Mode::Insert;
+                        self.insert_into_editor_and_focus(&column);
                     }
                     SchemaTreeSelection::Unknown { raw } => {
                         // Fallback to previous behavior: insert last segment after ':'
@@ -4518,9 +4762,7 @@ impl App {
                             .rsplit_once(':')
                             .map(|(_, name)| name.to_string())
                             .unwrap_or(raw);
-                        self.editor.textarea.insert_str(&insert_name);
-                        self.set_focus(Focus::Query);
-                        self.mode = Mode::Insert;
+                        self.insert_into_editor_and_focus(&insert_name);
                     }
                 }
             }
@@ -4604,8 +4846,16 @@ impl App {
             match action {
                 PickerAction::Selected(entry) => {
                     // Load selected query into editor (mirror keyboard path)
-                    self.editor.set_text(entry.query);
-                    self.editor.mark_saved(); // Mark as unmodified since it's loaded content
+                    if self.workspace_mode == WorkspaceMode::Notebook {
+                        let cell = self.notebook.selected_cell_mut();
+                        cell.replace_source(entry.query);
+                        cell.editor.mark_saved();
+                        self.notebook.focus = NotebookFocus::Editor;
+                        self.set_focus(Focus::Notebook);
+                    } else {
+                        self.editor.set_text(entry.query);
+                        self.editor.mark_saved();
+                    }
                     self.history_picker = None;
                     self.history_picker_pinned_only = false;
                     self.last_status = Some("Loaded from history".to_string());
@@ -4626,7 +4876,7 @@ impl App {
                 PickerAction::Selected(entry) => {
                     self.connection_picker = None;
                     self.last_error = None;
-                    if self.editor.is_modified() {
+                    if self.workspace_has_unsaved_changes() {
                         self.confirm_prompt = Some(ConfirmPrompt::new(
                             "You have unsaved changes. Switch connection anyway?",
                             ConfirmContext::SwitchConnection {
@@ -4701,6 +4951,78 @@ impl App {
 
     /// Handle a mouse click at the given position
     fn handle_mouse_click(&mut self, x: u16, y: u16) {
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            let target = self.render_notebook_cells.iter().copied().find(|area| {
+                is_inside(x, y, area.composer)
+                    || area.output.is_some_and(|output| is_inside(x, y, output))
+            });
+            let Some(target) = target else {
+                return;
+            };
+
+            self.notebook.selected = target.cell_id;
+            self.set_focus(Focus::Notebook);
+            self.mode = Mode::Normal;
+            self.last_grid_click = None;
+
+            if target
+                .output_toggle
+                .is_some_and(|toggle| is_inside(x, y, toggle))
+            {
+                let cell = self.notebook.selected_cell_mut();
+                cell.output_collapsed = !cell.output_collapsed;
+                self.notebook.focus = NotebookFocus::Cell;
+            } else if target.output.is_some_and(|output| is_inside(x, y, output)) {
+                self.notebook.focus = NotebookFocus::Result;
+                let show_row_numbers = self.config.display.show_row_numbers;
+                if let Some(output) = self.notebook.selected_cell_mut().output.as_mut() {
+                    if let Some(mut grid_area) = target.grid {
+                        let body_rows = grid_area.height.saturating_sub(1) as usize;
+                        grid_area.width = grid_area
+                            .width
+                            .saturating_sub(u16::from(output.grid.rows.len() > body_rows));
+                        if let Some(grid_target) = grid_viewport_mouse_target(
+                            x,
+                            y,
+                            grid_area,
+                            show_row_numbers,
+                            output.grid.rows.len(),
+                            output.grid_state.row_offset,
+                            output.grid_state.col_offset,
+                            &output.grid.col_widths,
+                        ) {
+                            match grid_target {
+                                GridMouseTarget::Header { col } => {
+                                    if let Some(col) = col {
+                                        output.grid_state.cursor_col = col;
+                                    }
+                                }
+                                GridMouseTarget::Cell { row, col } => {
+                                    if row < output.grid.rows.len() {
+                                        output.grid_state.cursor_row = row;
+                                        if let Some(col) = col {
+                                            output.grid_state.cursor_col = col;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if target.compact {
+                let cell = self.notebook.selected_cell_mut();
+                if cell.output.is_some() {
+                    cell.output_collapsed = false;
+                    self.notebook.focus = NotebookFocus::Result;
+                } else {
+                    self.notebook.focus = NotebookFocus::Cell;
+                }
+            } else {
+                self.notebook.focus = NotebookFocus::Editor;
+            }
+            return;
+        }
+
         // Check if click is in query area
         if let Some(query_area) = self.render_query_area {
             if x >= query_area.x
@@ -4814,6 +5136,44 @@ impl App {
                 // Trigger auto-fetch when scrolling near the end of loaded rows
                 self.maybe_fetch_more_rows();
             }
+            Focus::Notebook => match self.notebook.focus {
+                NotebookFocus::Cell => {
+                    if delta < 0 {
+                        self.notebook.select_previous();
+                    } else {
+                        self.notebook.select_next();
+                    }
+                }
+                NotebookFocus::Editor => {
+                    let cell = self.notebook.selected_cell_mut();
+                    let direction = if delta < 0 {
+                        CursorMove::Up
+                    } else {
+                        CursorMove::Down
+                    };
+                    for _ in 0..delta.unsigned_abs() {
+                        cell.editor.textarea.move_cursor(direction);
+                    }
+                }
+                NotebookFocus::Result => {
+                    let Some(output) = self.notebook.selected_cell_mut().output.as_mut() else {
+                        return;
+                    };
+                    if output.grid.rows.is_empty() {
+                        return;
+                    }
+                    if delta < 0 {
+                        output.grid_state.cursor_row = output
+                            .grid_state
+                            .cursor_row
+                            .saturating_sub((-delta) as usize);
+                    } else {
+                        output.grid_state.cursor_row = (output.grid_state.cursor_row
+                            + delta as usize)
+                            .min(output.grid.rows.len().saturating_sub(1));
+                    }
+                }
+            },
             Focus::Sidebar(section) => {
                 // Scroll sidebar sections
                 match section {
@@ -4844,7 +5204,7 @@ impl App {
             match self.focus {
                 Focus::Sidebar(SidebarSection::Connections) => self.set_focus(Focus::Query),
                 Focus::Sidebar(SidebarSection::Schema) => self.set_focus(Focus::Grid),
-                Focus::Query | Focus::Grid => {}
+                Focus::Query | Focus::Grid | Focus::Notebook => {}
             }
         } else {
             self.sidebar_visible = true;
@@ -5032,6 +5392,26 @@ impl App {
         ));
     }
 
+    fn open_notebook_row_detail(&mut self, row: usize) {
+        let Some(output) = self.notebook.selected_cell().output.as_ref() else {
+            return;
+        };
+        if row >= output.grid.rows.len() {
+            return;
+        }
+
+        self.row_detail = Some(
+            RowDetailModal::new(
+                output.grid.headers.clone(),
+                output.grid.rows[row].clone(),
+                output.grid.col_types.clone(),
+                row,
+                self.syntax_theme.clone(),
+            )
+            .with_read_only(),
+        );
+    }
+
     /// Handle key events for the row detail modal.
     fn handle_row_detail_key(&mut self, key: KeyEvent) -> bool {
         // Take the modal temporarily to avoid borrow issues
@@ -5048,23 +5428,37 @@ impl App {
                 // Modal is already taken, just don't put it back
             }
             RowDetailAction::Edit { col } => {
+                if self.workspace_mode == WorkspaceMode::Notebook {
+                    self.last_status = Some("Notebook results are read-only".to_string());
+                    self.row_detail = Some(modal);
+                    return false;
+                }
                 let row = self.grid_state.cursor_row;
                 self.start_cell_edit(row, col);
             }
             RowDetailAction::Yank(fmt) => {
-                let row = self.grid_state.cursor_row;
+                let (grid, row) = if self.workspace_mode == WorkspaceMode::Notebook {
+                    let Some(output) = self.notebook.selected_cell().output.as_ref() else {
+                        self.last_status = Some("Cell has no result to copy".to_string());
+                        self.row_detail = Some(modal);
+                        return false;
+                    };
+                    (&output.grid, output.grid_state.cursor_row)
+                } else {
+                    (&self.grid, self.grid_state.cursor_row)
+                };
                 let indices = &[row];
                 let (text, label) = match fmt {
-                    YankFormat::Tsv => (self.grid.rows_as_tsv(indices, false), "TSV"),
+                    YankFormat::Tsv => (grid.rows_as_tsv(indices, false), "TSV"),
                     YankFormat::TsvHeaders => {
-                        (self.grid.rows_as_tsv(indices, true), "TSV (with headers)")
+                        (grid.rows_as_tsv(indices, true), "TSV (with headers)")
                     }
-                    YankFormat::Json => (self.grid.row_as_json(row).unwrap_or_default(), "JSON"),
-                    YankFormat::Csv => (self.grid.rows_as_csv(indices, false), "CSV"),
+                    YankFormat::Json => (grid.row_as_json(row).unwrap_or_default(), "JSON"),
+                    YankFormat::Csv => (grid.rows_as_csv(indices, false), "CSV"),
                     YankFormat::CsvHeaders => {
-                        (self.grid.rows_as_csv(indices, true), "CSV (with headers)")
+                        (grid.rows_as_csv(indices, true), "CSV (with headers)")
                     }
-                    YankFormat::Markdown => (self.grid.rows_as_markdown(indices), "Markdown"),
+                    YankFormat::Markdown => (grid.rows_as_markdown(indices), "Markdown"),
                 };
                 self.last_error = None;
                 self.copy_to_clipboard(&text);
@@ -5114,6 +5508,14 @@ impl App {
                 }
                 false
             }
+            ConfirmContext::DeleteNotebookCell { cell_id } => {
+                self.delete_notebook_cell(super::execution::CellId(cell_id));
+                false
+            }
+            ConfirmContext::ClearNotebookCellExecution { cell_id } => {
+                self.clear_notebook_cell_execution(super::execution::CellId(cell_id));
+                false
+            }
             ConfirmContext::CloseConnectionForm => {
                 // Close the connection form without saving
                 self.pending_duplicate_donor = None;
@@ -5159,6 +5561,13 @@ impl App {
             ConfirmContext::DeleteConnection { .. } => {
                 // Cancelled delete, nothing to do
                 self.last_status = Some("Delete cancelled".to_string());
+            }
+            ConfirmContext::DeleteNotebookCell { .. } => {
+                self.notebook.pending_delete = false;
+                self.last_status = Some("Cell deletion cancelled".to_string());
+            }
+            ConfirmContext::ClearNotebookCellExecution { .. } => {
+                self.last_status = Some("Cell execution clear cancelled".to_string());
             }
             ConfirmContext::CloseConnectionForm => {
                 // Keep the form open
@@ -5709,20 +6118,25 @@ impl App {
     }
 
     fn handle_editor_search(&mut self, pattern: String) {
+        let editor = if self.workspace_mode == WorkspaceMode::Notebook {
+            &mut self.notebook.selected_cell_mut().editor
+        } else {
+            &mut self.editor
+        };
         if pattern.is_empty() {
-            let _ = self.editor.textarea.set_search_pattern("");
+            let _ = editor.textarea.set_search_pattern("");
             self.search.last_applied = None;
             self.search.close();
             self.last_status = Some("Search cleared".to_string());
             return;
         }
 
-        match self.editor.textarea.set_search_pattern(&pattern) {
+        match editor.textarea.set_search_pattern(&pattern) {
             Ok(()) => {
                 self.search.last_applied = Some(pattern.clone());
                 self.search.close();
 
-                let found = self.editor.textarea.search_forward(true);
+                let found = editor.textarea.search_forward(true);
                 if found {
                     self.last_status = Some(format!("Search: /{}", pattern));
                 } else {
@@ -5737,6 +6151,30 @@ impl App {
     }
 
     fn handle_grid_search(&mut self, pattern: String) {
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            let Some(output) = self.notebook.selected_cell_mut().output.as_mut() else {
+                self.search.close();
+                self.last_status = Some("Cell has no result to search".to_string());
+                return;
+            };
+            if pattern.is_empty() {
+                output.grid_state.clear_search();
+                self.search.close();
+                self.last_status = Some("Grid search cleared".to_string());
+                return;
+            }
+
+            output.grid_state.apply_search(&pattern, &output.grid);
+            let match_count = output.grid_state.search.match_count();
+            self.search.close();
+            self.last_status = Some(if match_count > 0 {
+                format!("Grid: /{} ({} matches)", pattern, match_count)
+            } else {
+                format!("Grid: /{} (no matches)", pattern)
+            });
+            return;
+        }
+
         if pattern.is_empty() {
             self.grid_state.clear_search();
             self.search.close();
@@ -5789,6 +6227,30 @@ impl App {
         let command = parts[0];
         let args = parts.get(1).map(|s| s.trim()).unwrap_or("");
 
+        let opens_classic_result = matches!(
+            command,
+            "\\dt"
+                | "dt"
+                | "\\dn"
+                | "dn"
+                | "\\d"
+                | "d"
+                | "\\di"
+                | "di"
+                | "\\l"
+                | "l"
+                | "\\du"
+                | "du"
+                | "\\dv"
+                | "dv"
+                | "\\df"
+                | "df"
+        ) || command == "show"
+            && matches!(args, "dbs" | "databases" | "collections");
+        if self.workspace_mode == WorkspaceMode::Notebook && opens_classic_result {
+            self.switch_workspace(WorkspaceMode::Classic);
+        }
+
         match command {
             "q" | "quit" | "exit" => {
                 return true;
@@ -5804,6 +6266,9 @@ impl App {
                 }
             }
             "disconnect" | "dc" => {
+                self.invalidate_active_execution("Connection closed");
+                self.invalidate_pg_snapshots(true);
+                self.connect_generation = self.connect_generation.wrapping_add(1);
                 self.db.client = None;
                 self.db.mongo_client = None;
                 self.db.mongo_database = None;
@@ -5811,6 +6276,7 @@ impl App {
                 self.db.cancel_token = None;
                 self.db.status = DbStatus::Disconnected;
                 self.db.running = false;
+                self.db.transaction_state = TransactionState::Unknown;
                 self.last_executed_query = None;
                 self.active_query_kind = None;
                 self.current_connection_name = None;
@@ -5818,6 +6284,29 @@ impl App {
                 self.query_ui.clear();
                 self.last_status = Some("Disconnected".to_string());
             }
+            "notebook" => self.switch_workspace(WorkspaceMode::Notebook),
+            "rebase" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.rebase_selected_dependency();
+            }
+            "rebind" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.notebook
+                    .selected_cell_mut()
+                    .bound_connection_generation = None;
+                self.last_status = Some("Cell will bind to the active connection on run".into());
+            }
+            "run-without-snapshot" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.execute_notebook_cell_with_snapshot(false);
+            }
+            "rebase" | "rebind" | "run-without-snapshot" => {
+                self.last_status = Some("This command is only available in Notebook mode".into());
+            }
+            "mode" => match args {
+                "notebook" => self.switch_workspace(WorkspaceMode::Notebook),
+                "classic" => self.switch_workspace(WorkspaceMode::Classic),
+                _ => {
+                    self.last_status = Some("Usage: :mode classic|notebook".to_string());
+                }
+            },
             "help" | "h" => {
                 self.help_popup = Some(HelpPopup::new());
             }
@@ -5985,7 +6474,10 @@ impl App {
     }
 
     fn query_editor_has_content(&self) -> bool {
-        !self.editor.text().trim().is_empty()
+        match self.workspace_mode {
+            WorkspaceMode::Classic => !self.editor.text().trim().is_empty(),
+            WorkspaceMode::Notebook => !self.notebook.selected_cell().is_empty(),
+        }
     }
 
     fn handle_export_connections_command(&mut self, args: &str) {
@@ -6203,8 +6695,16 @@ impl App {
                     return;
                 };
 
-                self.editor.set_text(query.to_string());
-                self.set_focus(Focus::Query);
+                if self.workspace_mode == WorkspaceMode::Notebook {
+                    self.notebook
+                        .selected_cell_mut()
+                        .replace_source(query.to_string());
+                    self.notebook.focus = NotebookFocus::Editor;
+                    self.focus = Focus::Notebook;
+                } else {
+                    self.editor.set_text(query.to_string());
+                    self.set_focus(Focus::Query);
+                }
                 self.mode = Mode::Insert;
                 self.ai_modal = None;
                 self.ai_modal_previous_mode = None;
@@ -6491,6 +6991,27 @@ impl App {
     }
 
     fn goto_result_row(&mut self, row_num: usize) -> bool {
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            let Some(output) = self.notebook.selected_cell_mut().output.as_mut() else {
+                self.last_status = Some("Cell has no result to navigate".to_string());
+                return false;
+            };
+            if output.grid.rows.is_empty() {
+                self.last_status = Some("No results to navigate".to_string());
+                return false;
+            }
+
+            let target_row = row_num
+                .saturating_sub(1)
+                .min(output.grid.rows.len().saturating_sub(1));
+            output.grid_state.cursor_row = target_row;
+            let row_count = output.grid.rows.len();
+            self.notebook.focus = NotebookFocus::Result;
+            self.set_focus(Focus::Notebook);
+            self.last_status = Some(format!("Row {} of {}", target_row + 1, row_count));
+            return false;
+        }
+
         if self.grid.rows.is_empty() {
             self.last_status = Some("No results to navigate".to_string());
             return false;
@@ -6734,7 +7255,20 @@ impl App {
     }
 
     fn handle_export_command(&mut self, args: &str) {
-        if self.grid.rows.is_empty() {
+        let grid = if self.workspace_mode == WorkspaceMode::Notebook {
+            self.notebook
+                .selected_cell()
+                .output
+                .as_ref()
+                .map(|output| &output.grid)
+        } else {
+            Some(&self.grid)
+        };
+        let Some(grid) = grid else {
+            self.last_error = Some("No data to export".to_string());
+            return;
+        };
+        if grid.rows.is_empty() {
             self.last_error = Some("No data to export".to_string());
             return;
         }
@@ -6754,12 +7288,12 @@ impl App {
         }
 
         // Get all row indices
-        let indices: Vec<usize> = (0..self.grid.rows.len()).collect();
+        let indices: Vec<usize> = (0..grid.rows.len()).collect();
 
         let content = match format.as_str() {
-            "csv" => self.grid.rows_as_csv(&indices, true),
-            "json" => self.grid.rows_as_json(&indices),
-            "tsv" => self.grid.rows_as_tsv(&indices, true),
+            "csv" => grid.rows_as_csv(&indices, true),
+            "json" => grid.rows_as_json(&indices),
+            "tsv" => grid.rows_as_tsv(&indices, true),
             _ => {
                 self.last_error = Some(format!(
                     "Unknown format: {}. Use csv, json, or tsv.",
@@ -6782,7 +7316,7 @@ impl App {
 
         match std::fs::write(&expanded_path, &content) {
             Ok(()) => {
-                let rows = self.grid.rows.len();
+                let rows = indices.len();
                 self.last_status = Some(format!(
                     "Exported {} rows to {} as {}",
                     rows,
@@ -7965,6 +8499,8 @@ impl App {
     }
 
     pub fn start_connect(&mut self, conn_str: String) {
+        self.invalidate_active_execution("Connection changed");
+        self.invalidate_pg_snapshots(true);
         self.invalidate_password_resolves();
         self.db.status = DbStatus::Connecting;
         self.db.kind = None;
@@ -7973,6 +8509,7 @@ impl App {
         self.db.mongo_client = None;
         self.db.mongo_database = None;
         self.db.running = false;
+        self.db.transaction_state = TransactionState::Unknown;
         self.last_executed_query = None;
         self.active_query_kind = None;
         self.query_ui.clear();
@@ -8423,7 +8960,7 @@ impl App {
             PickerAction::Continue => false,
             PickerAction::Selected(entry) => {
                 self.connection_picker = None;
-                if self.editor.is_modified() {
+                if self.workspace_has_unsaved_changes() {
                     self.confirm_prompt = Some(ConfirmPrompt::new(
                         "You have unsaved changes. Switch connection anyway?",
                         ConfirmContext::SwitchConnection {
@@ -8553,14 +9090,28 @@ impl App {
     }
 
     fn insert_into_editor_and_focus(&mut self, text: &str) {
-        self.editor.textarea.insert_str(text);
-        self.set_focus(Focus::Query);
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            let cell = self.notebook.selected_cell_mut();
+            cell.editor.textarea.insert_str(text);
+            cell.mark_edited();
+            self.notebook.focus = NotebookFocus::Editor;
+            self.focus = Focus::Notebook;
+        } else {
+            self.editor.textarea.insert_str(text);
+            self.set_focus(Focus::Query);
+        }
         self.mode = Mode::Insert;
     }
 
     fn replace_editor_with_schema_template(&mut self, query: String) {
-        self.editor.set_text(query);
-        self.set_focus(Focus::Query);
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            self.notebook.selected_cell_mut().replace_source(query);
+            self.notebook.focus = NotebookFocus::Editor;
+            self.focus = Focus::Notebook;
+        } else {
+            self.editor.set_text(query);
+            self.set_focus(Focus::Query);
+        }
         self.mode = Mode::Insert;
         self.last_status = Some("Query replaced with schema template".to_string());
     }
@@ -8593,6 +9144,20 @@ impl App {
                         self.editor.textarea.move_cursor(CursorMove::Top);
                         self.editor.textarea.move_cursor(CursorMove::Head);
                     }
+                    Focus::Notebook => match self.notebook.focus {
+                        NotebookFocus::Cell => self.notebook.select_first(),
+                        NotebookFocus::Editor => {
+                            let editor = &mut self.notebook.selected_cell_mut().editor.textarea;
+                            editor.move_cursor(CursorMove::Top);
+                            editor.move_cursor(CursorMove::Head);
+                        }
+                        NotebookFocus::Result => {
+                            if let Some(output) = self.notebook.selected_cell_mut().output.as_mut()
+                            {
+                                output.grid_state.cursor_row = 0;
+                            }
+                        }
+                    },
                     Focus::Sidebar(_) => {
                         // In sidebar, just go to first item (connections section)
                         self.set_focus(Focus::Sidebar(SidebarSection::Connections));
@@ -8601,7 +9166,12 @@ impl App {
                 }
             }
             KeySequenceAction::GotoEditor => {
-                self.set_focus(Focus::Query);
+                if self.workspace_mode == WorkspaceMode::Notebook {
+                    self.set_focus(Focus::Notebook);
+                    self.notebook.focus = NotebookFocus::Editor;
+                } else {
+                    self.set_focus(Focus::Query);
+                }
             }
             KeySequenceAction::GotoConnections => {
                 self.set_focus(Focus::Sidebar(SidebarSection::Connections));
@@ -8610,7 +9180,12 @@ impl App {
                 self.focus_schema();
             }
             KeySequenceAction::GotoResults => {
-                self.set_focus(Focus::Grid);
+                if self.workspace_mode == WorkspaceMode::Notebook {
+                    self.set_focus(Focus::Notebook);
+                    self.notebook.focus = NotebookFocus::Result;
+                } else {
+                    self.set_focus(Focus::Grid);
+                }
             }
             KeySequenceAction::GotoHistory => {
                 self.open_history_picker();
@@ -8725,7 +9300,7 @@ impl App {
             }
             ConnectionManagerAction::Connect { entry } => {
                 self.connection_manager = None;
-                if self.editor.is_modified() {
+                if self.workspace_has_unsaved_changes() {
                     self.confirm_prompt = Some(ConfirmPrompt::new(
                         "You have unsaved changes. Switch connection anyway?",
                         ConfirmContext::SwitchConnection {
@@ -8915,7 +9490,7 @@ impl App {
                     .into_iter()
                     .find(|e| e.name == name)
                 {
-                    if self.editor.is_modified() {
+                    if self.workspace_has_unsaved_changes() {
                         self.confirm_prompt = Some(ConfirmPrompt::new(
                             "You have unsaved changes. Switch connection anyway?",
                             ConfirmContext::SwitchConnection {
@@ -9163,11 +9738,549 @@ impl App {
         match self.focus {
             Focus::Sidebar(SidebarSection::Schema) => self.refresh_schema(),
             Focus::Query | Focus::Grid => self.refresh_last_query(),
+            Focus::Notebook => self.execute_notebook_cell(),
             Focus::Sidebar(SidebarSection::Connections) => {
                 self.last_status =
                     Some("Nothing to refresh while connections are focused".to_string());
             }
         }
+    }
+
+    pub fn switch_workspace(&mut self, workspace_mode: WorkspaceMode) {
+        if self.workspace_mode == workspace_mode {
+            return;
+        }
+
+        if workspace_mode == WorkspaceMode::Notebook {
+            if self.notebook.cells.len() == 1
+                && self.notebook.cells[0].is_empty()
+                && !self.editor.text().trim().is_empty()
+            {
+                self.notebook.cells[0].replace_source(self.editor.text());
+            }
+            self.focus = Focus::Notebook;
+            self.notebook.focus = NotebookFocus::Cell;
+            self.mode = Mode::Normal;
+            self.completion.close();
+            self.last_status = Some("Notebook mode".to_string());
+        } else {
+            self.focus = Focus::Query;
+            self.mode = Mode::Normal;
+            self.last_status = Some("Classic mode".to_string());
+        }
+        self.workspace_mode = workspace_mode;
+    }
+
+    fn workspace_has_unsaved_changes(&self) -> bool {
+        match self.workspace_mode {
+            WorkspaceMode::Classic => self.editor.is_modified(),
+            WorkspaceMode::Notebook => self.notebook.cells.iter().any(|cell| {
+                !cell.is_empty()
+                    && (cell.output.is_none() || cell.is_dirty() || cell.editor.is_modified())
+            }),
+        }
+    }
+
+    fn handle_notebook_key(&mut self, key: KeyEvent) {
+        match self.notebook.focus {
+            NotebookFocus::Cell => {
+                if key.code == KeyCode::Char('d') && key.modifiers == KeyModifiers::NONE {
+                    if self.notebook.pending_delete {
+                        self.notebook.pending_delete = false;
+                        self.request_delete_notebook_cell();
+                    } else {
+                        self.notebook.pending_delete = true;
+                        self.last_status = Some("d: press d again to delete cell".to_string());
+                    }
+                    return;
+                }
+                self.notebook.pending_delete = false;
+                let Some(action) = self.notebook_keymap.get_action(&key) else {
+                    return;
+                };
+                match action {
+                    Action::PreviousCell => self.notebook.select_previous(),
+                    Action::NextCell => self.notebook.select_next(),
+                    Action::FirstCell => self.notebook.select_first(),
+                    Action::LastCell => self.notebook.select_last(),
+                    Action::PageUp | Action::HalfPageUp => {
+                        for _ in 0..5 {
+                            self.notebook.select_previous();
+                        }
+                    }
+                    Action::PageDown | Action::HalfPageDown => {
+                        for _ in 0..5 {
+                            self.notebook.select_next();
+                        }
+                    }
+                    Action::EnterCellEditor => {
+                        self.notebook.focus = NotebookFocus::Editor;
+                        self.mode = Mode::Normal;
+                    }
+                    Action::InspectCellResult => {
+                        if self.notebook.selected_cell().output.is_some() {
+                            self.notebook.selected_cell_mut().output_collapsed = false;
+                            self.notebook.focus = NotebookFocus::Result;
+                        } else {
+                            self.last_status = Some("Cell has no result to inspect".to_string());
+                        }
+                    }
+                    Action::NewNotebookCell => {
+                        self.notebook.select_or_create_draft();
+                        self.mode = Mode::Insert;
+                    }
+                    Action::ToggleCellOutput => {
+                        let cell = self.notebook.selected_cell_mut();
+                        cell.output_collapsed = !cell.output_collapsed;
+                    }
+                    Action::CollapseCellOutput => {
+                        self.notebook.selected_cell_mut().output_collapsed = true;
+                    }
+                    Action::ExpandCellOutput => {
+                        self.notebook.selected_cell_mut().output_collapsed = false;
+                    }
+                    Action::ClearNotebookCellExecution => {
+                        self.request_clear_notebook_cell_execution();
+                    }
+                    Action::ExecuteQuery => self.execute_notebook_cell(),
+                    Action::ExecuteCellAndAdvance => {
+                        let can_start = !self.db.running;
+                        self.execute_notebook_cell();
+                        if can_start && self.db.running {
+                            self.notebook.select_next();
+                        }
+                    }
+                    Action::RefineNotebookCell => {
+                        self.refine_selected_cell();
+                    }
+                    Action::DeleteNotebookCell => {
+                        self.request_delete_notebook_cell();
+                    }
+                    Action::EnterCommandMode => self.command.open(),
+                    _ => {}
+                }
+            }
+            NotebookFocus::Editor => {
+                if key.code == KeyCode::Char('e') && key.modifiers == KeyModifiers::CONTROL
+                    || key.code == KeyCode::Enter && self.mode == Mode::Normal
+                {
+                    self.execute_notebook_cell();
+                    return;
+                }
+
+                let index = self.notebook.selected_index();
+                let before = self.notebook.cells[index].source();
+                let mut notebook_editor = std::mem::take(&mut self.notebook.cells[index].editor);
+                std::mem::swap(&mut self.editor, &mut notebook_editor);
+                self.handle_editor_key(key);
+                std::mem::swap(&mut self.editor, &mut notebook_editor);
+                self.notebook.cells[index].editor = notebook_editor;
+                if self.notebook.cells[index].source() != before {
+                    self.notebook.cells[index].mark_edited();
+                }
+            }
+            NotebookFocus::Result => {
+                let pending_yank = self
+                    .notebook
+                    .selected_cell()
+                    .output
+                    .as_ref()
+                    .is_some_and(|output| output.grid_state.pending_yank);
+                let action = (!pending_yank)
+                    .then(|| self.grid_keymap.get_action(&key))
+                    .flatten();
+                let result = match action {
+                    Some(Action::FocusQuery) => {
+                        self.notebook.focus = NotebookFocus::Editor;
+                        self.mode = Mode::Insert;
+                        None
+                    }
+                    Some(Action::GotoEditor) => {
+                        self.notebook.focus = NotebookFocus::Editor;
+                        self.mode = Mode::Normal;
+                        None
+                    }
+                    Some(Action::GotoConnections) => {
+                        self.set_focus(Focus::Sidebar(SidebarSection::Connections));
+                        None
+                    }
+                    Some(Action::GotoTables) => {
+                        self.focus_schema();
+                        None
+                    }
+                    Some(Action::GotoResults) => None,
+                    Some(Action::ToggleSidebar) => {
+                        self.toggle_sidebar();
+                        None
+                    }
+                    Some(Action::Refresh) => {
+                        self.execute_notebook_cell();
+                        None
+                    }
+                    Some(Action::Help) => {
+                        self.help_popup = Some(HelpPopup::new());
+                        None
+                    }
+                    Some(Action::GotoFirst) => {
+                        if let Some(output) = self.notebook.selected_cell_mut().output.as_mut() {
+                            output.grid_state.cursor_row = 0;
+                        }
+                        None
+                    }
+                    Some(action) => self
+                        .notebook
+                        .selected_cell_mut()
+                        .output
+                        .as_mut()
+                        .map(|output| output.grid_state.handle_action(action, &output.grid)),
+                    None => self
+                        .notebook
+                        .selected_cell_mut()
+                        .output
+                        .as_mut()
+                        .map(|output| output.grid_state.handle_key(key, &output.grid)),
+                };
+                match result {
+                    Some(GridKeyResult::OpenSearch) => {
+                        self.search_target = SearchTarget::Grid;
+                        self.search.open();
+                    }
+                    Some(GridKeyResult::OpenCommand) => self.command.open(),
+                    Some(GridKeyResult::CopyToClipboard(text)) => {
+                        self.copy_to_clipboard(&text);
+                    }
+                    Some(GridKeyResult::Yank { text, status }) => {
+                        self.last_error = None;
+                        self.copy_to_clipboard(&text);
+                        if self.last_error.is_none() {
+                            self.last_status = Some(status);
+                        }
+                    }
+                    Some(GridKeyResult::ResizeColumn { col, action }) => {
+                        let Some(output) = self.notebook.selected_cell_mut().output.as_mut() else {
+                            return;
+                        };
+                        match action {
+                            ResizeAction::Widen => output.grid.widen_column(col, 2),
+                            ResizeAction::Narrow => output.grid.narrow_column(col, 2),
+                            ResizeAction::AutoFit => output.grid.autofit_column(col),
+                        }
+                    }
+                    Some(GridKeyResult::EditCell { .. }) => {
+                        self.last_status = Some("Notebook results are read-only".to_string());
+                    }
+                    Some(GridKeyResult::OpenRowDetail { row }) => {
+                        self.open_notebook_row_detail(row);
+                    }
+                    Some(GridKeyResult::StatusMessage(status)) => {
+                        self.last_status = Some(status);
+                    }
+                    Some(GridKeyResult::GotoFirstRow) => {
+                        if let Some(output) = self.notebook.selected_cell_mut().output.as_mut() {
+                            output.grid_state.cursor_row = 0;
+                        }
+                    }
+                    Some(GridKeyResult::None) | None => {}
+                }
+            }
+        }
+    }
+
+    fn handle_notebook_completion_key(&mut self, key: KeyEvent) -> bool {
+        match (key.code, key.modifiers) {
+            (KeyCode::Enter, KeyModifiers::NONE) => {
+                let index = self.notebook.selected_index();
+                let before = self.notebook.cells[index].source();
+                let mut notebook_editor = std::mem::take(&mut self.notebook.cells[index].editor);
+                std::mem::swap(&mut self.editor, &mut notebook_editor);
+                self.apply_completion();
+                std::mem::swap(&mut self.editor, &mut notebook_editor);
+                self.notebook.cells[index].editor = notebook_editor;
+                if self.notebook.cells[index].source() != before {
+                    self.notebook.cells[index].mark_edited();
+                }
+            }
+            (KeyCode::Tab | KeyCode::Down, KeyModifiers::NONE)
+            | (KeyCode::Char('n' | 'j'), KeyModifiers::CONTROL) => {
+                self.completion.select_next();
+            }
+            (KeyCode::BackTab, KeyModifiers::SHIFT)
+            | (KeyCode::Tab, KeyModifiers::SHIFT)
+            | (KeyCode::Up, KeyModifiers::NONE)
+            | (KeyCode::Char('p' | 'k'), KeyModifiers::CONTROL) => {
+                self.completion.select_prev();
+            }
+            (KeyCode::Esc, KeyModifiers::NONE) => self.completion.close(),
+            _ => {
+                self.completion.close();
+                self.handle_notebook_key(key);
+            }
+        }
+        false
+    }
+
+    fn refine_selected_cell(&mut self) {
+        let output = self.notebook.selected_cell().output.as_ref();
+        let retained = output.and_then(|output| output.retained.clone());
+        let Some(retained) = retained else {
+            self.last_status = Some(
+                match output.map(|output| &output.refinement) {
+                    Some(RefinementAvailability::Unavailable(
+                        RefinementUnavailableReason::SnapshotDisabled,
+                    )) => "Snapshot retention is disabled; enable notebook.snapshot_mode to refine",
+                    Some(RefinementAvailability::Unavailable(
+                        RefinementUnavailableReason::UnsupportedBackend,
+                    )) => "Refine is available only for PostgreSQL notebook results",
+                Some(RefinementAvailability::Unavailable(
+                    RefinementUnavailableReason::TransactionNotIdle,
+                )) => {
+                    "Connection transaction state is not idle; finish it in Classic mode or reconnect"
+                }
+                    Some(RefinementAvailability::Unavailable(
+                        RefinementUnavailableReason::IneligibleStatement,
+                    )) => "This statement does not produce an eligible snapshot result",
+                    Some(RefinementAvailability::Unavailable(
+                        RefinementUnavailableReason::SnapshotEvicted,
+                    )) => "This session snapshot was evicted; rerun the source cell",
+                    Some(RefinementAvailability::Unavailable(
+                        RefinementUnavailableReason::ConnectionChanged,
+                    )) => "This snapshot belongs to a previous connection; rerun the source cell",
+                    Some(RefinementAvailability::Unavailable(
+                        RefinementUnavailableReason::ResultIncomplete,
+                    )) => "Refine requires a complete result within the configured snapshot limits",
+                    Some(RefinementAvailability::Available(_)) | None => {
+                        "Refine requires a complete retained PostgreSQL session snapshot"
+                    }
+                }
+                .to_string(),
+            );
+            return;
+        };
+        if retained.connection_generation != self.connect_generation
+            || !self.pg_snapshots.contains_key(&retained.handle)
+        {
+            self.last_status = Some("Session snapshot is no longer available".to_string());
+            return;
+        }
+        self.notebook.insert_refinement(retained.version);
+        self.mode = Mode::Normal;
+        self.last_status = Some(format!(
+            "Refining cell {} run {}",
+            retained.version.source_cell.0, retained.version.source_execution.0
+        ));
+    }
+
+    fn rebase_selected_dependency(&mut self) {
+        let Some(current) = self.notebook.selected_cell().dependency else {
+            self.last_status = Some("Selected cell has no result dependency".to_string());
+            return;
+        };
+        let replacement = self
+            .notebook
+            .cells
+            .iter()
+            .find(|cell| cell.id == current.source_cell)
+            .and_then(|cell| cell.output.as_ref())
+            .and_then(|output| output.retained.as_ref())
+            .map(|retained| retained.version);
+        let Some(replacement) = replacement else {
+            self.last_status = Some("Source cell has no current session snapshot".to_string());
+            return;
+        };
+        self.notebook.selected_cell_mut().dependency = Some(replacement);
+        self.last_status = Some(format!(
+            "Rebased to cell {} run {}",
+            replacement.source_cell.0, replacement.source_execution.0
+        ));
+    }
+
+    fn request_delete_notebook_cell(&mut self) {
+        let cell = self.notebook.selected_cell();
+        let needs_confirmation = !cell.is_empty()
+            || cell.output.is_some()
+            || cell.dependency.is_some()
+            || cell.execution != CellExecutionState::NeverRun;
+        if needs_confirmation {
+            let dependent_count = self
+                .notebook
+                .cells
+                .iter()
+                .filter(|candidate| {
+                    candidate
+                        .dependency
+                        .is_some_and(|version| version.source_cell == cell.id)
+                })
+                .count();
+            self.confirm_prompt = Some(ConfirmPrompt::new(
+                format!(
+                    "Delete cell {}? {} dependent cell(s) will lose their source snapshot.",
+                    self.notebook.selected_index() + 1,
+                    dependent_count
+                ),
+                ConfirmContext::DeleteNotebookCell { cell_id: cell.id.0 },
+            ));
+        } else {
+            self.delete_notebook_cell(cell.id);
+        }
+    }
+
+    fn delete_notebook_cell(&mut self, cell_id: super::execution::CellId) {
+        let removed = self.notebook.remove_cell(cell_id);
+        let retained_handle = removed
+            .as_ref()
+            .and_then(|cell| cell.output.as_ref())
+            .and_then(|output| output.retained.as_ref())
+            .map(|retained| retained.handle);
+        if let Some(handle) = retained_handle {
+            self.pg_snapshot_order
+                .retain(|candidate| *candidate != handle);
+            self.retained_versions
+                .retain(|_, candidate| *candidate != handle);
+            if let Some(snapshot) = self.pg_snapshots.remove(&handle) {
+                if let Some(client) = self.db.client.clone() {
+                    self.rt.spawn(async move {
+                        let guard = client.lock().await;
+                        let physical_name = snapshot.physical_name.replace('"', "\"\"");
+                        let _ = guard
+                            .batch_execute(&format!(
+                                "DROP TABLE IF EXISTS pg_temp.\"{physical_name}\""
+                            ))
+                            .await;
+                    });
+                }
+            }
+        }
+        self.last_status = Some("Notebook cell deleted".to_string());
+    }
+
+    fn notebook_execution_tree(&self, root: CellId) -> HashSet<CellId> {
+        let mut affected = HashSet::from([root]);
+        loop {
+            let previous_len = affected.len();
+            for cell in &self.notebook.cells {
+                let bound_to_affected = cell
+                    .dependency
+                    .is_some_and(|version| affected.contains(&version.source_cell));
+                let references_affected = matches!(
+                    logical_result_reference(&cell.source()),
+                    Ok(Some(LogicalResultReference::Cell(source_cell)))
+                        if affected.contains(&source_cell)
+                );
+                if bound_to_affected || references_affected {
+                    affected.insert(cell.id);
+                }
+            }
+            if affected.len() == previous_len {
+                return affected;
+            }
+        }
+    }
+
+    fn request_clear_notebook_cell_execution(&mut self) {
+        if self.db.running {
+            self.last_status = Some("Wait for the running query before clearing cells".to_string());
+            return;
+        }
+
+        let cell_id = self.notebook.selected;
+        let affected = self.notebook_execution_tree(cell_id);
+        let has_execution = self.notebook.cells.iter().any(|cell| {
+            affected.contains(&cell.id)
+                && (cell.output.is_some()
+                    || cell.failure.is_some()
+                    || cell.execution != CellExecutionState::NeverRun)
+        }) || self
+            .retained_versions
+            .keys()
+            .any(|version| affected.contains(&version.source_cell));
+        if !has_execution {
+            self.last_status = Some("Selected cell has no execution to clear".to_string());
+            return;
+        }
+
+        let dependent_count = affected.len().saturating_sub(1);
+        let message = if dependent_count == 0 {
+            format!("Clear execution for cell {}? SQL will be kept.", cell_id.0)
+        } else {
+            format!(
+                "Clear cell {} and {} dependent execution(s)? SQL and lineage will be kept.",
+                cell_id.0, dependent_count
+            )
+        };
+        self.confirm_prompt = Some(ConfirmPrompt::new(
+            message,
+            ConfirmContext::ClearNotebookCellExecution { cell_id: cell_id.0 },
+        ));
+    }
+
+    fn clear_notebook_cell_execution(&mut self, cell_id: CellId) {
+        if self.db.running {
+            self.last_status = Some("Wait for the running query before clearing cells".to_string());
+            return;
+        }
+
+        let affected = self.notebook_execution_tree(cell_id);
+        let mut handles = self
+            .retained_versions
+            .iter()
+            .filter_map(|(version, handle)| {
+                affected.contains(&version.source_cell).then_some(*handle)
+            })
+            .collect::<HashSet<_>>();
+        handles.extend(self.notebook.cells.iter().filter_map(|cell| {
+            affected
+                .contains(&cell.id)
+                .then(|| {
+                    cell.output
+                        .as_ref()?
+                        .retained
+                        .as_ref()
+                        .map(|value| value.handle)
+                })
+                .flatten()
+        }));
+
+        self.retained_versions.retain(|version, handle| {
+            !affected.contains(&version.source_cell) && !handles.contains(handle)
+        });
+        self.pg_snapshot_order
+            .retain(|handle| !handles.contains(handle));
+        let snapshots = handles
+            .into_iter()
+            .filter_map(|handle| self.pg_snapshots.remove(&handle))
+            .collect::<Vec<_>>();
+
+        for cell in &mut self.notebook.cells {
+            if affected.contains(&cell.id) {
+                cell.output = None;
+                cell.failure = None;
+                cell.execution = CellExecutionState::NeverRun;
+                cell.bound_connection_generation = None;
+                cell.output_collapsed = false;
+            }
+        }
+
+        if let Some(client) = self.db.client.clone().filter(|_| !snapshots.is_empty()) {
+            self.rt.spawn(async move {
+                let guard = client.lock().await;
+                for snapshot in snapshots {
+                    let physical_name = snapshot.physical_name.replace('"', "\"\"");
+                    let _ = guard
+                        .batch_execute(&format!("DROP TABLE IF EXISTS pg_temp.\"{physical_name}\""))
+                        .await;
+                }
+            });
+        }
+
+        let dependent_count = affected.len().saturating_sub(1);
+        self.last_status = Some(if dependent_count == 0 {
+            format!("Cleared execution for cell {}", cell_id.0)
+        } else {
+            format!(
+                "Cleared cell {} and {} dependent execution(s)",
+                cell_id.0, dependent_count
+            )
+        });
     }
 
     fn refresh_schema(&mut self) {
@@ -9214,6 +10327,8 @@ impl App {
                 JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
                 WHERE c.relkind IN ('r', 'v', 'm')
                     AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+                    AND n.nspname NOT LIKE 'pg_temp_%'
+                    AND n.nspname NOT LIKE 'pg_toast_temp_%'
                     AND a.attnum > 0
                     AND NOT a.attisdropped
                 ORDER BY n.nspname, c.relname, a.attnum
@@ -9446,8 +10561,406 @@ impl App {
         Ok(())
     }
 
+    fn open_active_external_editor(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<()> {
+        if self.workspace_mode != WorkspaceMode::Notebook {
+            return self.open_in_external_editor(terminal);
+        }
+        let index = self.notebook.selected_index();
+        let before = self.notebook.cells[index].source();
+        let mut notebook_editor = std::mem::take(&mut self.notebook.cells[index].editor);
+        std::mem::swap(&mut self.editor, &mut notebook_editor);
+        let result = self.open_in_external_editor(terminal);
+        std::mem::swap(&mut self.editor, &mut notebook_editor);
+        self.notebook.cells[index].editor = notebook_editor;
+        if self.notebook.cells[index].source() != before {
+            self.notebook.cells[index].mark_edited();
+        }
+        result
+    }
+
     fn execute_query(&mut self) {
         self.execute_query_text(self.editor.text(), QueryExecutionKind::New);
+    }
+
+    fn invalidate_active_execution(&mut self, reason: &str) {
+        if let Some(active) = self.active_execution.take() {
+            if let ExecutionTarget::Notebook(cell_id) = active.context.target {
+                if let Some(cell) = self.notebook.cell_mut(cell_id) {
+                    cell.execution = CellExecutionState::Cancelled;
+                    cell.failure = Some(reason.to_string());
+                }
+            }
+        }
+        self.db.running = false;
+        self.active_query_kind = None;
+        self.query_ui.clear();
+    }
+
+    fn invalidate_pg_snapshots(&mut self, drop_relations: bool) {
+        let snapshots = std::mem::take(&mut self.pg_snapshots);
+        self.retained_versions.clear();
+        self.pg_snapshot_order.clear();
+        for cell in &mut self.notebook.cells {
+            if let Some(output) = &mut cell.output {
+                if output.retained.is_some() {
+                    output.refinement = RefinementAvailability::Unavailable(
+                        RefinementUnavailableReason::ConnectionChanged,
+                    );
+                }
+            }
+        }
+        if !drop_relations || snapshots.is_empty() {
+            return;
+        }
+        let Some(client) = self.db.client.clone() else {
+            return;
+        };
+        self.rt.spawn(async move {
+            let guard = client.lock().await;
+            for snapshot in snapshots.into_values() {
+                let physical_name = snapshot.physical_name.replace('"', "\"\"");
+                let _ = guard
+                    .batch_execute(&format!("DROP TABLE IF EXISTS pg_temp.\"{physical_name}\""))
+                    .await;
+            }
+        });
+    }
+
+    fn register_pg_snapshot(
+        &mut self,
+        retained: &super::refinement::RetainedResult,
+        snapshot: PgTempSnapshot,
+    ) {
+        self.pg_snapshot_order.push_back(retained.handle);
+        self.retained_versions
+            .insert(retained.version, retained.handle);
+        self.pg_snapshots.insert(retained.handle, snapshot);
+
+        loop {
+            let total_bytes: u64 = self
+                .pg_snapshots
+                .values()
+                .map(|snapshot| snapshot.byte_size)
+                .sum();
+            let over_count =
+                self.pg_snapshots.len() > self.config.notebook.max_retained_snapshots.max(1);
+            let over_bytes = total_bytes > self.config.notebook.snapshot_total_bytes;
+            if !over_count && !over_bytes {
+                break;
+            }
+            let Some(handle) = self.pg_snapshot_order.pop_front() else {
+                break;
+            };
+            let Some(evicted) = self.pg_snapshots.remove(&handle) else {
+                continue;
+            };
+            self.retained_versions
+                .retain(|_, candidate| *candidate != handle);
+            for cell in &mut self.notebook.cells {
+                if let Some(output) = &mut cell.output {
+                    if output.retained.as_ref().map(|value| value.handle) == Some(handle) {
+                        output.refinement = RefinementAvailability::Unavailable(
+                            RefinementUnavailableReason::SnapshotEvicted,
+                        );
+                    }
+                }
+            }
+            if let Some(client) = self.db.client.clone() {
+                self.rt.spawn(async move {
+                    let guard = client.lock().await;
+                    let physical_name = evicted.physical_name.replace('"', "\"\"");
+                    let _ = guard
+                        .batch_execute(&format!("DROP TABLE IF EXISTS pg_temp.\"{physical_name}\""))
+                        .await;
+                });
+            }
+        }
+    }
+
+    fn latest_notebook_result_version(&self, source_cell: Option<CellId>) -> Option<ResultVersion> {
+        self.pg_snapshot_order.iter().rev().find_map(|handle| {
+            let snapshot = self.pg_snapshots.get(handle)?;
+            if snapshot.connection_generation != self.connect_generation {
+                return None;
+            }
+
+            self.notebook.cells.iter().find_map(|cell| {
+                let output = cell.output.as_ref()?;
+                let retained = output.retained.as_ref()?;
+                let RefinementAvailability::Available(available) = &output.refinement else {
+                    return None;
+                };
+                (retained.handle == *handle
+                    && available.handle == *handle
+                    && retained.connection_generation == self.connect_generation
+                    && self.retained_versions.get(&retained.version) == Some(handle)
+                    && source_cell
+                        .is_none_or(|source_cell| retained.version.source_cell == source_cell))
+                .then_some(retained.version)
+            })
+        })
+    }
+
+    fn execute_notebook_cell(&mut self) {
+        self.execute_notebook_cell_with_snapshot(true);
+    }
+
+    fn notebook_snapshot_for_version(&self, version: ResultVersion) -> Option<PgTempSnapshot> {
+        let handle = self.retained_versions.get(&version)?;
+        let snapshot = self.pg_snapshots.get(handle)?;
+        (snapshot.connection_generation == self.connect_generation).then(|| snapshot.clone())
+    }
+
+    fn resolve_notebook_result_dependency(
+        &self,
+        source: &str,
+        dependency: Option<ResultVersion>,
+    ) -> Result<Option<(ResultVersion, PgTempSnapshot)>, String> {
+        let reference = logical_result_reference(source)?;
+
+        match reference {
+            Some(LogicalResultReference::Latest) => self
+                .latest_notebook_result_version(None)
+                .and_then(|version| {
+                    self.notebook_snapshot_for_version(version)
+                        .map(|snapshot| (version, snapshot))
+                })
+                .map(Some)
+                .ok_or_else(|| {
+                    "No retained result is available for @result. Run a source cell first"
+                        .to_string()
+                }),
+            Some(LogicalResultReference::Cell(source_cell)) => {
+                if dependency.is_some_and(|version| version.source_cell != source_cell) {
+                    return Err("logical result reference does not match cell dependency".into());
+                }
+
+                if let Some((version, snapshot)) = dependency.and_then(|version| {
+                    self.notebook_snapshot_for_version(version)
+                        .map(|snapshot| (version, snapshot))
+                }) {
+                    return Ok(Some((version, snapshot)));
+                }
+
+                self.latest_notebook_result_version(Some(source_cell))
+                    .and_then(|version| {
+                        self.notebook_snapshot_for_version(version)
+                            .map(|snapshot| (version, snapshot))
+                    })
+                    .map(Some)
+                    .ok_or_else(|| {
+                        format!(
+                            "Result for cell {} is unavailable. Run cell {} first",
+                            source_cell.0, source_cell.0
+                        )
+                    })
+            }
+            None => dependency
+                .map(|version| {
+                    self.notebook_snapshot_for_version(version)
+                        .map(|snapshot| (version, snapshot))
+                        .ok_or_else(|| {
+                            "Source snapshot is unavailable. Run the source cell first".to_string()
+                        })
+                })
+                .transpose(),
+        }
+    }
+
+    fn execute_notebook_cell_with_snapshot(&mut self, allow_snapshot: bool) {
+        if self.db.running {
+            self.last_status = Some("A query is already running".to_string());
+            return;
+        }
+
+        let (cell_id, source_revision, logical_query, dependency) = {
+            let cell = self.notebook.selected_cell();
+            if cell
+                .bound_connection_generation
+                .is_some_and(|generation| generation != self.connect_generation)
+            {
+                self.last_status = Some(
+                    "Cell belongs to a previous connection; use :rebind to run it here".to_string(),
+                );
+                return;
+            }
+            (cell.id, cell.revision, cell.source(), cell.dependency)
+        };
+        if logical_query.trim().is_empty() {
+            self.last_status = Some("No query to run".to_string());
+            return;
+        }
+        let is_mongo = self.db.kind == Some(DbKind::Mongo);
+        if is_mongo && self.db.mongo_client.is_none() || !is_mongo && self.db.client.is_none() {
+            self.last_error =
+                Some("Not connected. Use :connect <url> or select a connection first.".to_string());
+            return;
+        }
+        let resolved_dependency =
+            match self.resolve_notebook_result_dependency(&logical_query, dependency) {
+                Ok(dependency) => dependency,
+                Err(error) => {
+                    if let Some(cell) = self.notebook.cell_mut(cell_id) {
+                        cell.execution = CellExecutionState::Failed;
+                        cell.failure = Some(error);
+                    }
+                    self.last_status = Some(format!("Notebook cell {} failed", cell_id.0));
+                    return;
+                }
+            };
+        let (query, source_snapshot) = if let Some((version, snapshot)) = resolved_dependency {
+            match compile_logical_reference(
+                &logical_query,
+                version,
+                &snapshot.physical_name,
+                &snapshot.public_columns,
+            ) {
+                Ok(compiled) => {
+                    self.notebook.selected_cell_mut().dependency = Some(version);
+                    (compiled, Some(snapshot))
+                }
+                Err(error) => {
+                    if let Some(cell) = self.notebook.cell_mut(cell_id) {
+                        cell.execution = CellExecutionState::Failed;
+                        cell.failure = Some(error);
+                    }
+                    self.last_status = Some(format!("Notebook cell {} failed", cell_id.0));
+                    return;
+                }
+            }
+        } else {
+            (logical_query.clone(), None)
+        };
+        if !is_mongo
+            && matches!(
+                classify_transaction_control(&query),
+                TransactionControl::Begin
+                    | TransactionControl::Commit
+                    | TransactionControl::CommitAndChain
+                    | TransactionControl::Rollback
+                    | TransactionControl::RollbackAndChain
+            )
+        {
+            self.last_status = Some(
+                "Transaction control is available in Classic mode for this release".to_string(),
+            );
+            return;
+        }
+
+        let context = ExecutionContext {
+            id: ExecutionId(self.next_execution_id),
+            target: ExecutionTarget::Notebook(cell_id),
+            source_revision,
+            connection_generation: self.connect_generation,
+        };
+        self.next_execution_id = self.next_execution_id.wrapping_add(1);
+        self.active_execution = Some(ActiveExecution {
+            context,
+            kind: QueryExecutionKind::New,
+            cancelling: false,
+        });
+        if let Some(cell) = self.notebook.cell_mut(cell_id) {
+            cell.execution = CellExecutionState::Running(context);
+            cell.failure = None;
+        }
+        self.notebook.ensure_trailing_draft();
+        self.db.running = true;
+        self.query_ui.start();
+        self.last_status = Some(format!("Running notebook cell {}...", cell_id.0));
+
+        let conn_info = self
+            .db
+            .conn_str
+            .as_ref()
+            .map(|connection| ConnectionInfo::parse(connection).format(50));
+        self.history.push(logical_query, conn_info);
+
+        let max_rows = effective_max_rows(self.config.connection.max_rows);
+        if is_mongo {
+            let Some(mongo_client) = self.db.mongo_client.clone() else {
+                return;
+            };
+            let database = self
+                .db
+                .mongo_database
+                .clone()
+                .unwrap_or_else(|| "admin".to_string());
+            let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
+            self.execute_query_mongo(mongo_client, database, query, max_rows, proxy_tx);
+            let tx = self.db_events_tx.clone();
+            self.rt.spawn(async move {
+                while let Some(event) = proxy_rx.recv().await {
+                    match event {
+                        DbEvent::QueryFinished { result } => {
+                            let _ = tx.send(DbEvent::NotebookQueryFinished {
+                                context,
+                                result,
+                                retained: None,
+                                snapshot: None,
+                            });
+                            break;
+                        }
+                        DbEvent::QueryError { error } => {
+                            let _ = tx.send(DbEvent::NotebookQueryError { context, error });
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            });
+            return;
+        }
+
+        let Some(client) = self.db.client.clone() else {
+            return;
+        };
+        let source_table = extract_table_from_query(&query);
+        let can_snapshot = allow_snapshot
+            && self.config.notebook.snapshot_mode == SnapshotMode::Auto
+            && self.db.transaction_state == TransactionState::Idle
+            && pg_snapshot::is_snapshot_candidate(&query);
+        if can_snapshot {
+            let handle = RetainedResultHandle(self.next_retained_handle);
+            self.next_retained_handle = self.next_retained_handle.wrapping_add(1);
+            let request = PgSnapshotRequest {
+                context,
+                query,
+                handle,
+                max_rows: self.config.notebook.snapshot_max_rows,
+                display_max_rows: max_rows,
+                max_bytes: self.config.notebook.snapshot_max_bytes,
+                timeout_secs: self.config.connection.query_timeout_secs,
+                source_snapshot,
+            };
+            let tx = self.db_events_tx.clone();
+            self.rt.spawn(async move {
+                match pg_snapshot::execute(client, request).await {
+                    Ok(snapshot_result) => {
+                        let _ = tx.send(DbEvent::NotebookQueryFinished {
+                            context,
+                            result: snapshot_result.query_result,
+                            retained: snapshot_result.retained,
+                            snapshot: snapshot_result.snapshot,
+                        });
+                    }
+                    Err(error) => {
+                        let _ = tx.send(DbEvent::NotebookQueryError { context, error });
+                    }
+                }
+            });
+            return;
+        }
+        self.execute_query_simple(
+            client,
+            query,
+            max_rows,
+            source_table,
+            self.db_events_tx.clone(),
+            Some(context),
+        );
     }
 
     fn execute_query_text(&mut self, query: String, kind: QueryExecutionKind) {
@@ -9549,7 +11062,7 @@ impl App {
             );
         } else {
             self.paged_query = None;
-            self.execute_query_simple(client, query, max_rows, source_table, tx);
+            self.execute_query_simple(client, query, max_rows, source_table, tx, None);
         }
     }
 
@@ -9829,6 +11342,7 @@ impl App {
         max_rows: usize,
         source_table: Option<String>,
         tx: mpsc::UnboundedSender<DbEvent>,
+        context: Option<ExecutionContext>,
     ) {
         let started = Instant::now();
 
@@ -9934,12 +11448,26 @@ impl App {
                         col_types,
                     };
 
-                    let _ = tx.send(DbEvent::QueryFinished { result });
+                    let event = if let Some(context) = context {
+                        DbEvent::NotebookQueryFinished {
+                            context,
+                            result,
+                            retained: None,
+                            snapshot: None,
+                        }
+                    } else {
+                        DbEvent::QueryFinished { result }
+                    };
+                    let _ = tx.send(event);
                 }
                 Err(e) => {
-                    let _ = tx.send(DbEvent::QueryError {
-                        error: format_pg_error(&e),
-                    });
+                    let error = format_pg_error(&e);
+                    let event = if let Some(context) = context {
+                        DbEvent::NotebookQueryError { context, error }
+                    } else {
+                        DbEvent::QueryError { error }
+                    };
+                    let _ = tx.send(event);
                 }
             }
         });
@@ -10353,6 +11881,9 @@ impl App {
         };
 
         self.last_status = Some("Cancelling...".to_string());
+        if let Some(active) = &mut self.active_execution {
+            active.cancelling = true;
+        }
 
         // If cancelling a paged fetch, clear the paged_query state.
         // This closes the fetch-more channel, causing the cursor task to exit
@@ -10404,6 +11935,7 @@ impl App {
                 self.db.mongo_database = None;
                 self.db.cancel_token = Some(cancel_token);
                 self.db.running = false;
+                self.db.transaction_state = TransactionState::Idle;
                 self.db.connected_with_tls = connected_with_tls;
                 self.query_ui.clear();
                 self.last_status = Some("Connected, loading schema...".to_string());
@@ -10426,7 +11958,7 @@ impl App {
                 self.db.mongo_database = Some(database.clone());
                 self.db.cancel_token = None;
                 self.db.running = false;
-                self.db.in_transaction = false;
+                self.db.transaction_state = TransactionState::Unknown;
                 self.db.connected_with_tls = true;
                 self.query_ui.clear();
                 self.last_status = Some(format!(
@@ -10442,6 +11974,8 @@ impl App {
                 if connect_generation != self.connect_generation {
                     return;
                 }
+                self.invalidate_active_execution("Connection failed");
+                self.invalidate_pg_snapshots(false);
                 self.db.status = DbStatus::Error;
                 self.db.kind = None;
                 self.db.client = None;
@@ -10464,6 +11998,8 @@ impl App {
                 if connect_generation != self.connect_generation {
                     return;
                 }
+                self.invalidate_active_execution("Connection lost");
+                self.invalidate_pg_snapshots(false);
                 self.db.status = DbStatus::Error;
                 self.db.kind = None;
                 self.db.client = None;
@@ -10490,18 +12026,12 @@ impl App {
                 self.db.last_elapsed = Some(result.elapsed);
                 self.last_error = None; // Clear any previous error.
 
-                // Track transaction state based on command tag (skip for paged queries)
-                if !is_paged {
-                    if let Some(ref tag) = result.command_tag {
-                        let tag_upper = tag.to_uppercase();
-                        if tag_upper.starts_with("BEGIN") {
-                            self.db.in_transaction = true;
-                        } else if tag_upper.starts_with("COMMIT")
-                            || tag_upper.starts_with("ROLLBACK")
-                            || tag_upper.starts_with("END")
-                        {
-                            self.db.in_transaction = false;
-                        }
+                // Internal paging owns its own transaction. Only user-submitted,
+                // non-paged SQL contributes to the user transaction reducer.
+                if !is_paged && query_kind.is_some() {
+                    if let Some(sql) = self.last_executed_query.as_deref() {
+                        self.db.transaction_state =
+                            self.db.transaction_state.after_execution(sql, true);
                     }
                 }
 
@@ -10524,8 +12054,10 @@ impl App {
                     paged.loading = false;
                 }
 
-                // Move focus to grid to show results
-                self.set_focus(Focus::Grid);
+                // Completing Classic work must not steal Notebook focus after a mode switch.
+                if self.workspace_mode == WorkspaceMode::Classic {
+                    self.set_focus(Focus::Grid);
+                }
 
                 // A refresh may complete after the user has edited the buffer. Only
                 // mark a newly executed buffer as saved when it still matches the SQL
@@ -10548,7 +12080,90 @@ impl App {
                     self.last_status = Some("Ready".to_string());
                 }
             }
+            DbEvent::NotebookQueryFinished {
+                context,
+                result,
+                retained,
+                snapshot,
+            } => {
+                let is_current = self
+                    .active_execution
+                    .is_some_and(|active| active.context == context)
+                    && context.connection_generation == self.connect_generation;
+                if !is_current {
+                    return;
+                }
+                self.active_execution = None;
+                self.db.running = false;
+                self.query_ui.clear();
+
+                let ExecutionTarget::Notebook(cell_id) = context.target else {
+                    return;
+                };
+                if let (Some(retained), Some(snapshot)) = (&retained, snapshot) {
+                    self.register_pg_snapshot(retained, snapshot);
+                }
+                let Some(cell) = self.notebook.cell_mut(cell_id) else {
+                    return;
+                };
+                if cell.revision != context.source_revision {
+                    cell.execution = CellExecutionState::Succeeded;
+                    self.last_status = Some(format!(
+                        "Cell {} finished, but its source changed; output was ignored",
+                        cell_id.0
+                    ));
+                    return;
+                }
+
+                if self.db.kind == Some(DbKind::Postgres) {
+                    self.db.transaction_state = self
+                        .db
+                        .transaction_state
+                        .after_execution(&cell.source(), true);
+                }
+                cell.execution = CellExecutionState::Succeeded;
+                cell.bound_connection_generation = Some(context.connection_generation);
+                cell.output = Some(NotebookOutput {
+                    grid: GridModel::new(result.headers, result.rows)
+                        .with_source_table(result.source_table)
+                        .with_primary_keys(result.primary_keys)
+                        .with_col_types(result.col_types),
+                    grid_state: GridState::default(),
+                    command_tag: result.command_tag,
+                    elapsed: result.elapsed,
+                    error: None,
+                    refinement: retained.clone().map_or_else(
+                        || {
+                            let reason = if self.db.kind == Some(DbKind::Mongo) {
+                                RefinementUnavailableReason::UnsupportedBackend
+                            } else if self.config.notebook.snapshot_mode == SnapshotMode::Off {
+                                RefinementUnavailableReason::SnapshotDisabled
+                            } else if self.db.transaction_state != TransactionState::Idle {
+                                RefinementUnavailableReason::TransactionNotIdle
+                            } else if !pg_snapshot::is_snapshot_candidate(&cell.source()) {
+                                RefinementUnavailableReason::IneligibleStatement
+                            } else {
+                                RefinementUnavailableReason::ResultIncomplete
+                            };
+                            RefinementAvailability::Unavailable(reason)
+                        },
+                        RefinementAvailability::Available,
+                    ),
+                    retained,
+                    executed_revision: context.source_revision,
+                    truncated: result.truncated,
+                });
+                cell.editor.mark_saved();
+                self.last_error = None;
+                self.last_status = Some(format!("Notebook cell {} finished", cell_id.0));
+            }
             DbEvent::QueryError { error } => {
+                if self.active_query_kind.is_some() {
+                    if let Some(sql) = self.last_executed_query.as_deref() {
+                        self.db.transaction_state =
+                            self.db.transaction_state.after_execution(sql, false);
+                    }
+                }
                 self.db.running = false;
                 self.active_query_kind = None;
                 self.query_ui.clear();
@@ -10556,7 +12171,48 @@ impl App {
                 self.last_status = Some("Query error (see above)".to_string());
                 self.last_error = Some(error);
             }
+            DbEvent::NotebookQueryError { context, error } => {
+                let active = self
+                    .active_execution
+                    .filter(|active| active.context == context);
+                if active.is_none() || context.connection_generation != self.connect_generation {
+                    return;
+                }
+                let was_cancelled = active.is_some_and(|active| active.cancelling);
+                self.active_execution = None;
+                self.db.running = false;
+                self.query_ui.clear();
+                let ExecutionTarget::Notebook(cell_id) = context.target else {
+                    return;
+                };
+                if let Some(cell) = self.notebook.cell_mut(cell_id) {
+                    if cell.revision == context.source_revision
+                        && self.db.kind == Some(DbKind::Postgres)
+                    {
+                        self.db.transaction_state = self
+                            .db
+                            .transaction_state
+                            .after_execution(&cell.source(), false);
+                    }
+                    if was_cancelled {
+                        cell.execution = CellExecutionState::Cancelled;
+                        cell.failure = None;
+                    } else {
+                        cell.execution = CellExecutionState::Failed;
+                        cell.failure = Some(error);
+                    }
+                }
+                self.last_status = Some(if was_cancelled {
+                    format!("Notebook cell {} cancelled", cell_id.0)
+                } else {
+                    format!("Notebook cell {} failed", cell_id.0)
+                });
+            }
             DbEvent::QueryCancelled => {
+                if self.active_execution.is_some() {
+                    self.last_status = Some("Cancelling notebook cell...".to_string());
+                    return;
+                }
                 self.paged_query = None; // Clear paged query state on cancel
                 self.db.running = false;
                 self.active_query_kind = None;
@@ -10771,16 +12427,492 @@ impl App {
         }
     }
 
+    fn render_notebook_workspace(&mut self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        self.render_query_area = None;
+        self.render_grid_area = None;
+        self.render_notebook_cells.clear();
+        frame.render_widget(Clear, area);
+        frame.render_widget(
+            Paragraph::new("").style(self.ui_theme.notebook_canvas),
+            area,
+        );
+
+        let selected_index = self.notebook.selected_index();
+        let composer_max_rows = self.config.notebook.composer_max_rows.max(1);
+        let output_preview_rows = self.config.notebook.output_preview_rows;
+        let available_height = area.height.saturating_sub(1) as usize;
+        let focused_result_layout = self.focus == Focus::Notebook
+            && self.notebook.focus == NotebookFocus::Result
+            && self.notebook.cells[selected_index]
+                .output
+                .as_ref()
+                .is_some_and(|_| !self.notebook.cells[selected_index].output_collapsed);
+        let (start, end) = if focused_result_layout {
+            notebook_focused_cell_window(
+                self.notebook.cells.len(),
+                selected_index,
+                available_height,
+            )
+        } else {
+            let mut start = selected_index;
+            let mut used_height = notebook_cell_render_height(
+                &self.notebook.cells[selected_index],
+                composer_max_rows,
+                output_preview_rows,
+            )
+            .min(available_height);
+            while start > 0 {
+                let previous_height = notebook_cell_render_height(
+                    &self.notebook.cells[start - 1],
+                    composer_max_rows,
+                    output_preview_rows,
+                );
+                if used_height.saturating_add(previous_height) > available_height {
+                    break;
+                }
+                start -= 1;
+                used_height = used_height.saturating_add(previous_height);
+            }
+            (start, self.notebook.cells.len())
+        };
+        self.notebook.scroll_cell = start;
+        let mut y = area.y.saturating_add(1);
+        let bottom = area.y.saturating_add(area.height);
+        let language = if self.db.kind == Some(DbKind::Mongo) {
+            "MONGOSH"
+        } else {
+            "SQL"
+        };
+        let notebook_focus = self.notebook.focus;
+        let selected_cell = self.notebook.selected;
+        let retained_versions = &self.retained_versions;
+        let pg_snapshots = &self.pg_snapshots;
+        let has_latest_result = self.latest_notebook_result_version(None).is_some();
+        let available_source_cells = self
+            .notebook
+            .cells
+            .iter()
+            .filter_map(|cell| {
+                self.latest_notebook_result_version(Some(cell.id))
+                    .map(|_| cell.id)
+            })
+            .collect::<HashSet<_>>();
+        let mut render_areas = Vec::new();
+
+        for (index, cell) in self
+            .notebook
+            .cells
+            .iter_mut()
+            .enumerate()
+            .skip(start)
+            .take(end.saturating_sub(start))
+        {
+            if y >= bottom {
+                break;
+            }
+            let selected = cell.id == selected_cell;
+            let source_lines = cell.editor.textarea.lines();
+            let source_height = if focused_result_layout {
+                1
+            } else {
+                source_lines.len().clamp(1, composer_max_rows) as u16
+            };
+            let composer_height = if focused_result_layout {
+                if selected {
+                    2
+                } else {
+                    1
+                }
+            } else {
+                source_height.saturating_add(3)
+            };
+            let remaining = bottom.saturating_sub(y);
+            if remaining < if focused_result_layout { 1 } else { 3 } {
+                break;
+            }
+            let composer_area = Rect {
+                x: area.x.saturating_add(1),
+                y,
+                width: area.width.saturating_sub(2),
+                height: composer_height.min(remaining),
+            };
+            let rail_area = Rect {
+                x: composer_area.x,
+                y: composer_area.y,
+                width: 1,
+                height: composer_area.height,
+            };
+            let composer_body = Rect {
+                x: composer_area.x.saturating_add(1),
+                y: composer_area.y,
+                width: composer_area.width.saturating_sub(1),
+                height: composer_area.height,
+            };
+            let output_toggle = cell.output.as_ref().and_then(|_| {
+                (composer_body.width >= 3).then_some(Rect::new(
+                    composer_body.right().saturating_sub(2),
+                    composer_body.y,
+                    1,
+                    1,
+                ))
+            });
+            let accent = if selected {
+                self.ui_theme.accent
+            } else {
+                self.ui_theme.text_muted
+            };
+            let rail = "┃\n".repeat(composer_area.height as usize);
+            frame.render_widget(
+                Paragraph::new(rail).style(
+                    self.ui_theme
+                        .notebook_rail
+                        .fg(accent)
+                        .bg(self.ui_theme.bg_elevated),
+                ),
+                rail_area,
+            );
+
+            let live_dependency = cell.dependency.is_some_and(|version| {
+                retained_versions
+                    .get(&version)
+                    .and_then(|handle| pg_snapshots.get(handle))
+                    .is_some_and(|snapshot| {
+                        snapshot.connection_generation == self.connect_generation
+                    })
+            });
+            let source_available = match logical_result_reference(&cell.source()) {
+                Ok(Some(LogicalResultReference::Latest)) => has_latest_result,
+                Ok(Some(LogicalResultReference::Cell(source_cell))) => {
+                    cell.dependency
+                        .is_none_or(|dependency| dependency.source_cell == source_cell)
+                        && (live_dependency || available_source_cells.contains(&source_cell))
+                }
+                Ok(None) => cell.dependency.is_none() || live_dependency,
+                Err(_) => true,
+            };
+            let state = match cell.execution {
+                CellExecutionState::NeverRun if cell.is_empty() => "DRAFT",
+                CellExecutionState::NeverRun if !source_available => "SOURCE UNAVAILABLE",
+                CellExecutionState::NeverRun => "NEEDS RUN",
+                CellExecutionState::Running(_) => "RUNNING",
+                CellExecutionState::Succeeded if cell.is_dirty() => "DIRTY",
+                CellExecutionState::Succeeded => "SUCCEEDED",
+                CellExecutionState::Failed => "FAILED",
+                CellExecutionState::Cancelled => "CANCELLED",
+            };
+            let header_style = if cell.is_dirty() {
+                self.ui_theme.notebook_stale
+            } else {
+                Style::default().fg(accent)
+            }
+            .add_modifier(Modifier::BOLD);
+            let focus_label = if selected {
+                match notebook_focus {
+                    NotebookFocus::Cell => " · CELL",
+                    NotebookFocus::Editor => " · EDITOR",
+                    NotebookFocus::Result => " · RESULT",
+                }
+            } else {
+                ""
+            };
+            let dependency = cell.dependency.map_or_else(String::new, |version| {
+                format!(
+                    " · from cell {}/run {}",
+                    version.source_cell.0, version.source_execution.0
+                )
+            });
+            let output_summary = cell.output.as_ref().map_or_else(String::new, |output| {
+                format!(
+                    " · {}",
+                    notebook_output_summary(output, cell.output_is_stale(), focused_result_layout)
+                )
+            });
+            let mut lines = Vec::with_capacity(source_lines.len().saturating_add(2));
+            let (cursor_row, cursor_col) = cell.editor.textarea.cursor();
+            let source_scroll = if selected && notebook_focus == NotebookFocus::Editor {
+                cell.editor_scroll = calculate_editor_scroll(
+                    cursor_row,
+                    cursor_col,
+                    cell.editor_scroll,
+                    source_height as usize,
+                    composer_body.width.saturating_sub(4) as usize,
+                );
+                cell.editor_scroll
+            } else {
+                (0, 0)
+            };
+            if focused_result_layout && !selected {
+                let source = notebook_source_summary(source_lines);
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "▸ CELL {} · {language} · {state}{dependency}{output_summary}{}",
+                        cell.id.0,
+                        if source.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" · {source}")
+                        }
+                    ),
+                    header_style,
+                )));
+            } else {
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "{}CELL {} · {language} · {state}{dependency}{focus_label}{}",
+                        if focused_result_layout { "▾ " } else { "" },
+                        cell.id.0,
+                        if focused_result_layout {
+                            output_summary.as_str()
+                        } else {
+                            ""
+                        }
+                    ),
+                    header_style,
+                )));
+                if focused_result_layout {
+                    lines.push(Line::from(notebook_source_summary(source_lines)));
+                } else {
+                    lines.extend(
+                        source_lines
+                            .iter()
+                            .skip(source_scroll.0 as usize)
+                            .take(composer_max_rows)
+                            .map(|line| {
+                                Line::from(
+                                    line.chars()
+                                        .skip(source_scroll.1 as usize)
+                                        .collect::<String>(),
+                                )
+                            }),
+                    );
+                    lines.push(Line::from(Span::styled(
+                        if selected {
+                            match notebook_focus {
+                                NotebookFocus::Cell => {
+                                    "j/k cells · h/l output · x clear · Enter edit · Ctrl+E run"
+                                }
+                                NotebookFocus::Editor => "Ctrl+E run · Esc cell mode",
+                                NotebookFocus::Result => {
+                                    "h/j/k/l table · / search · yy copy · Esc cell"
+                                }
+                            }
+                        } else {
+                            ""
+                        },
+                        Style::default().fg(self.ui_theme.text_muted),
+                    )));
+                }
+            }
+            frame.render_widget(
+                Paragraph::new(lines)
+                    .block(Block::default().padding(Padding::new(
+                        2,
+                        if output_toggle.is_some() { 4 } else { 2 },
+                        0,
+                        0,
+                    )))
+                    .style(if selected {
+                        self.ui_theme.notebook_composer_focused
+                    } else {
+                        self.ui_theme.notebook_composer
+                    }),
+                composer_body,
+            );
+            if let Some(output_toggle) = output_toggle {
+                frame.render_widget(
+                    Paragraph::new(if cell.output_collapsed { "▸" } else { "▾" })
+                        .style(header_style),
+                    output_toggle,
+                );
+            }
+
+            if selected && notebook_focus == NotebookFocus::Editor {
+                let visible_row = cursor_row.saturating_sub(source_scroll.0 as usize);
+                let visible_col = cursor_col.saturating_sub(source_scroll.1 as usize);
+                if visible_row < composer_max_rows {
+                    let cursor_x = composer_body
+                        .x
+                        .saturating_add(2)
+                        .saturating_add(visible_col as u16)
+                        .min(composer_body.right().saturating_sub(1));
+                    let cursor_y = composer_body
+                        .y
+                        .saturating_add(1)
+                        .saturating_add(visible_row as u16)
+                        .min(composer_body.bottom().saturating_sub(1));
+                    frame.set_cursor_position((cursor_x, cursor_y));
+                }
+            }
+
+            y = y.saturating_add(composer_area.height);
+            let mut output_area = None;
+            let mut grid_area = None;
+            if let Some(failure) = cell
+                .failure
+                .as_ref()
+                .filter(|_| !focused_result_layout || selected)
+            {
+                let error_height =
+                    if focused_result_layout { 1 } else { 2 }.min(bottom.saturating_sub(y));
+                if error_height > 0 {
+                    frame.render_widget(
+                        Paragraph::new(format!("  ERROR · {failure}"))
+                            .style(Style::default().fg(self.ui_theme.error)),
+                        Rect::new(composer_body.x, y, composer_body.width, error_height),
+                    );
+                    y = y.saturating_add(error_height);
+                }
+            }
+            let output_is_stale = cell.output_is_stale();
+            if let Some(output) = cell.output.as_mut() {
+                if !cell.output_collapsed && (!focused_result_layout || selected) {
+                    let preview_rows = output.grid.rows.len().min(output_preview_rows);
+                    let desired_height = if output.grid.headers.is_empty() {
+                        1
+                    } else {
+                        preview_rows.max(1) as u16 + 2
+                    };
+                    let remaining_summaries = if focused_result_layout {
+                        end.saturating_sub(index + 1) as u16
+                    } else {
+                        0
+                    };
+                    let available_output_height =
+                        bottom.saturating_sub(y).saturating_sub(remaining_summaries);
+                    let output_height = if focused_result_layout {
+                        available_output_height
+                    } else {
+                        desired_height.min(available_output_height)
+                    };
+                    if output_height > 0 {
+                        let result_focused = selected && notebook_focus == NotebookFocus::Result;
+                        let visible_rows =
+                            output_height.saturating_sub(if focused_result_layout { 1 } else { 2 })
+                                as usize;
+                        if result_focused {
+                            let row_number_width = if self.config.display.show_row_numbers
+                                && !output.grid.rows.is_empty()
+                            {
+                                output.grid.rows.len().to_string().len() as u16 + 1
+                            } else {
+                                0
+                            };
+                            let marker_width = 3 + row_number_width;
+                            let scrollbar_width = u16::from(output.grid.rows.len() > visible_rows);
+                            output.grid_state.ensure_cursor_visible(
+                                visible_rows,
+                                output.grid.rows.len(),
+                                output.grid.headers.len(),
+                                &output.grid.col_widths,
+                                composer_body
+                                    .width
+                                    .saturating_sub(marker_width)
+                                    .saturating_sub(scrollbar_width),
+                            );
+                        }
+                        let area =
+                            Rect::new(composer_body.x, y, composer_body.width, output_height);
+                        output_area = Some(area);
+                        frame.render_widget(
+                            Block::default().style(self.ui_theme.notebook_output),
+                            area,
+                        );
+                        if !focused_result_layout {
+                            frame.render_widget(
+                                Paragraph::new(Line::from(Span::styled(
+                                    format!(
+                                        "  {}",
+                                        notebook_output_summary(output, output_is_stale, false)
+                                    ),
+                                    self.ui_theme.notebook_meta,
+                                ))),
+                                Rect::new(area.x, area.y, area.width, 1),
+                            );
+                        }
+                        if !output.grid.headers.is_empty() {
+                            let viewport = Rect::new(
+                                area.x,
+                                area.y.saturating_add(u16::from(!focused_result_layout)),
+                                area.width,
+                                area.height
+                                    .saturating_sub(u16::from(!focused_result_layout)),
+                            );
+                            grid_area = Some(viewport);
+                            frame.render_widget(
+                                GridViewport {
+                                    model: &output.grid,
+                                    state: &output.grid_state,
+                                    theme: &self.ui_theme,
+                                    focused: result_focused,
+                                    show_row_numbers: self.config.display.show_row_numbers,
+                                    show_scrollbar: true,
+                                },
+                                viewport,
+                            );
+                        }
+                        y = y.saturating_add(output_height);
+                    }
+                }
+            }
+            if !focused_result_layout {
+                y = y.saturating_add(1);
+            }
+            render_areas.push(NotebookCellRenderArea {
+                cell_id: cell.id,
+                composer: composer_area,
+                output_toggle,
+                output: output_area,
+                grid: grid_area,
+                compact: focused_result_layout && !selected,
+            });
+        }
+        self.render_notebook_cells = render_areas;
+    }
+
     fn status_line(&self, width: u16) -> Paragraph<'static> {
-        let row_count = self.grid.rows.len();
-        let selected_count = self.grid_state.selected_rows.len();
+        let notebook_main_focused = self.focus == Focus::Notebook;
+        let notebook_output = (self.workspace_mode == WorkspaceMode::Notebook)
+            .then(|| self.notebook.selected_cell().output.as_ref())
+            .flatten();
+        let row_count = if self.workspace_mode == WorkspaceMode::Notebook {
+            notebook_output.map_or(0, |output| output.grid.rows.len())
+        } else {
+            self.grid.rows.len()
+        };
+        let col_count = if self.workspace_mode == WorkspaceMode::Notebook {
+            notebook_output.map_or(0, |output| output.grid.headers.len())
+        } else {
+            self.grid.headers.len()
+        };
+        let selected_count = if self.workspace_mode == WorkspaceMode::Notebook {
+            notebook_output.map_or(0, |output| output.grid_state.selected_rows.len())
+        } else {
+            self.grid_state.selected_rows.len()
+        };
         let cursor_row = if row_count == 0 {
             0
         } else {
-            self.grid_state.cursor_row.saturating_add(1)
+            notebook_output
+                .map_or(self.grid_state.cursor_row, |output| {
+                    output.grid_state.cursor_row
+                })
+                .saturating_add(1)
+        };
+        let cursor_col = if col_count == 0 {
+            0
+        } else {
+            notebook_output
+                .map_or(self.grid_state.cursor_col, |output| {
+                    output.grid_state.cursor_col
+                })
+                .saturating_add(1)
         };
 
-        let mode_text = format!(" {} ", self.mode.label());
+        let mode_text = if self.workspace_mode == WorkspaceMode::Notebook {
+            " NOTEBOOK ".to_string()
+        } else {
+            format!(" {} ", self.mode.label())
+        };
         let mode_style = Style::default()
             .fg(self.ui_theme.pill_fg)
             .bg(self.ui_theme.mode_accent(self.mode))
@@ -10816,7 +12948,22 @@ impl App {
         };
 
         // Row info
-        let row_info = format!("Row {}/{}", cursor_row, row_count);
+        let row_info = if self.workspace_mode == WorkspaceMode::Notebook {
+            if notebook_main_focused && self.notebook.focus == NotebookFocus::Result {
+                format!(
+                    "Row {}/{} · Col {}/{} · {} cells",
+                    cursor_row,
+                    row_count,
+                    cursor_col,
+                    col_count,
+                    self.notebook.cells.len()
+                )
+            } else {
+                format!("{} cells", self.notebook.cells.len())
+            }
+        } else {
+            format!("Row {}/{}", cursor_row, row_count)
+        };
 
         // Selection info (only if selected)
         let selection_info = if selected_count > 0 {
@@ -10826,7 +12973,14 @@ impl App {
         };
 
         // Query timing info
-        let timing_info = if let Some(ref tag) = self.db.last_command_tag {
+        let timing_info = if let Some(output) = notebook_output {
+            output
+                .command_tag
+                .as_ref()
+                .map(|tag| format!("{} ({}ms)", tag, output.elapsed.as_millis()))
+        } else if self.workspace_mode == WorkspaceMode::Notebook {
+            None
+        } else if let Some(ref tag) = self.db.last_command_tag {
             let time_part = self
                 .db
                 .last_elapsed
@@ -10859,7 +13013,19 @@ impl App {
         let focus_style = Style::default()
             .fg(self.ui_theme.accent)
             .add_modifier(Modifier::BOLD);
-        let navigation_hint = if self.focus == Focus::Query && self.mode != Mode::Normal {
+        let navigation_hint = if self.workspace_mode == WorkspaceMode::Notebook {
+            if notebook_main_focused {
+                match self.notebook.focus {
+                    NotebookFocus::Cell => "j/k cells · Enter edit · Ctrl+E run",
+                    NotebookFocus::Editor => "Ctrl+E run · Esc cell mode",
+                    NotebookFocus::Result => {
+                        "h/j/k/l table · / search · yy copy · Esc restore cells"
+                    }
+                }
+            } else {
+                "Esc notebook · Tab/S-Tab cycle · Ctrl/Alt-hjkl move"
+            }
+        } else if self.focus == Focus::Query && self.mode != Mode::Normal {
             "Alt-hjkl move · Esc then Tab/S-Tab cycle"
         } else {
             "Tab/S-Tab cycle · Ctrl/Alt-hjkl move · g… jump"
@@ -10873,8 +13039,24 @@ impl App {
             .segment(StatusSegment::new(mode_text, Priority::Critical).style(mode_style))
             // Critical: active pane (always shown)
             .segment(
-                StatusSegment::new(self.focus.label().to_string(), Priority::Critical)
-                    .style(focus_style),
+                StatusSegment::new(
+                    if self.workspace_mode == WorkspaceMode::Notebook && notebook_main_focused {
+                        format!(
+                            "{} · {}/{}",
+                            match self.notebook.focus {
+                                NotebookFocus::Cell => "CELL".to_string(),
+                                NotebookFocus::Editor => format!("EDITOR · {}", self.mode.label()),
+                                NotebookFocus::Result => "RESULT".to_string(),
+                            },
+                            self.notebook.selected_index() + 1,
+                            self.notebook.cells.len()
+                        )
+                    } else {
+                        self.focus.label().to_string()
+                    },
+                    Priority::Critical,
+                )
+                .style(focus_style),
             )
             // Critical: Connection info
             .segment(
@@ -10894,7 +13076,8 @@ impl App {
             )
             // High: Transaction indicator (if in transaction)
             .segment_if(
-                self.db.in_transaction,
+                self.db.transaction_state == TransactionState::Active
+                    || self.db.transaction_state == TransactionState::Failed,
                 StatusSegment::new("TXN", Priority::High)
                     .style(Style::default().fg(self.ui_theme.transaction)),
             )
@@ -11059,8 +13242,15 @@ impl App {
             PickerAction::Continue => false,
             PickerAction::Selected(entry) => {
                 // Load selected query into editor.
-                self.editor.set_text(entry.query);
-                self.editor.mark_saved(); // Mark as unmodified since it's loaded content
+                if self.workspace_mode == WorkspaceMode::Notebook {
+                    let cell = self.notebook.selected_cell_mut();
+                    cell.replace_source(entry.query);
+                    cell.editor.mark_saved();
+                    self.notebook.focus = NotebookFocus::Editor;
+                } else {
+                    self.editor.set_text(entry.query);
+                    self.editor.mark_saved(); // Mark as unmodified since it's loaded content
+                }
                 self.history_picker = None;
                 self.history_picker_pinned_only = false;
                 self.last_status = Some("Loaded from history".to_string());
@@ -11102,7 +13292,30 @@ fn grid_mouse_target(
     col_offset: usize,
     col_widths: &[u16],
 ) -> Option<GridMouseTarget> {
-    let inner = zone_inner(grid_area);
+    grid_viewport_mouse_target(
+        x,
+        y,
+        zone_inner(grid_area),
+        show_row_numbers,
+        row_count,
+        row_offset,
+        col_offset,
+        col_widths,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn grid_viewport_mouse_target(
+    x: u16,
+    y: u16,
+    viewport: Rect,
+    show_row_numbers: bool,
+    row_count: usize,
+    row_offset: usize,
+    col_offset: usize,
+    col_widths: &[u16],
+) -> Option<GridMouseTarget> {
+    let inner = viewport;
 
     if inner.width == 0 || inner.height == 0 {
         return None;
@@ -11191,6 +13404,114 @@ fn hit_test_data_column(
     }
 
     None
+}
+
+fn notebook_source_summary(lines: &[String]) -> String {
+    lines
+        .iter()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn notebook_output_summary(output: &NotebookOutput, stale: bool, compact: bool) -> String {
+    let completeness = if output.retained.is_some() {
+        if compact {
+            "SNAPSHOT"
+        } else {
+            "SESSION SNAPSHOT · COMPLETE"
+        }
+    } else if output.truncated {
+        "PREVIEW · NO SNAPSHOT"
+    } else {
+        "COMPLETE · NO SNAPSHOT"
+    };
+    let extent = if output.truncated {
+        if compact {
+            format!("≥{} rows", output.grid.rows.len().saturating_add(1))
+        } else {
+            format!(
+                "{} fetched · at least {} total",
+                output.grid.rows.len(),
+                output.grid.rows.len().saturating_add(1)
+            )
+        }
+    } else {
+        format!("{} rows", output.grid.rows.len())
+    };
+    format!(
+        "{}{completeness} · {extent} · {}ms",
+        if stale { "STALE OUTPUT · " } else { "" },
+        output.elapsed.as_millis()
+    )
+}
+
+fn notebook_focused_cell_window(
+    cell_count: usize,
+    selected_index: usize,
+    available_height: usize,
+) -> (usize, usize) {
+    const MAX_SUMMARY_ROWS: usize = 6;
+    const MIN_ACTIVE_ROWS: usize = 4;
+
+    let summary_budget = cell_count
+        .saturating_sub(1)
+        .min(MAX_SUMMARY_ROWS)
+        .min(available_height.saturating_sub(MIN_ACTIVE_ROWS));
+    let mut before = selected_index.min(summary_budget.div_ceil(2));
+    let mut after = cell_count
+        .saturating_sub(selected_index + 1)
+        .min(summary_budget.saturating_sub(before));
+    let unused = summary_budget.saturating_sub(before + after);
+    before = before.saturating_add(selected_index.saturating_sub(before).min(unused));
+    after = after.saturating_add(
+        cell_count
+            .saturating_sub(selected_index + after + 1)
+            .min(summary_budget.saturating_sub(before + after)),
+    );
+
+    (
+        selected_index.saturating_sub(before),
+        selected_index + after + 1,
+    )
+}
+
+/// Calculate the height needed to render one inline notebook cell.
+fn notebook_cell_render_height(
+    cell: &NotebookCell,
+    composer_max_rows: usize,
+    output_preview_rows: usize,
+) -> usize {
+    let composer = cell
+        .editor
+        .textarea
+        .lines()
+        .len()
+        .clamp(1, composer_max_rows)
+        .saturating_add(3);
+    let error = usize::from(cell.failure.is_some()).saturating_mul(2);
+    let output = cell
+        .output
+        .as_ref()
+        .filter(|_| !cell.output_collapsed)
+        .map_or(0, |output| {
+            if output.grid.headers.is_empty() {
+                1
+            } else {
+                output
+                    .grid
+                    .rows
+                    .len()
+                    .min(output_preview_rows)
+                    .max(1)
+                    .saturating_add(2)
+            }
+        });
+    composer
+        .saturating_add(error)
+        .saturating_add(output)
+        .saturating_add(1)
 }
 
 /// Calculate the scroll offset needed to keep cursor visible in the editor viewport.
@@ -11354,6 +13675,1112 @@ mod tests {
     }
 
     // ========== Grid Mouse Tests ==========
+
+    fn notebook_test_app(runtime: &tokio::runtime::Runtime) -> App {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut app = App::new(GridModel::empty(), runtime.handle().clone(), tx, rx, None);
+        app.connection_picker = None;
+        app.connection_manager = None;
+        app.switch_workspace(WorkspaceMode::Notebook);
+        app
+    }
+
+    fn notebook_test_output(rows: usize) -> NotebookOutput {
+        NotebookOutput {
+            grid: GridModel::new(
+                vec!["value".to_string()],
+                (1..=rows).map(|row| vec![row.to_string()]).collect(),
+            ),
+            grid_state: GridState::default(),
+            command_tag: Some(format!("SELECT {rows}")),
+            elapsed: Duration::from_millis(4),
+            error: None,
+            refinement: RefinementAvailability::Unavailable(
+                RefinementUnavailableReason::ResultIncomplete,
+            ),
+            retained: None,
+            executed_revision: 0,
+            truncated: rows > 12,
+        }
+    }
+
+    fn install_notebook_test_snapshot(
+        app: &mut App,
+        cell_index: usize,
+        execution: u64,
+        handle: u64,
+    ) -> ResultVersion {
+        let cell_id = app.notebook.cells[cell_index].id;
+        let version = ResultVersion {
+            source_cell: cell_id,
+            source_execution: ExecutionId(execution),
+            source_revision: app.notebook.cells[cell_index].revision,
+        };
+        let handle = RetainedResultHandle(handle);
+        let retained = super::super::refinement::RetainedResult {
+            provider: super::super::refinement::RefinementProviderId::PostgresTemp,
+            handle,
+            version,
+            rows: 1,
+            retained_bytes: 16,
+            connection_generation: app.connect_generation,
+        };
+        let mut output = notebook_test_output(1);
+        output.refinement = RefinementAvailability::Available(retained.clone());
+        output.retained = Some(retained);
+        app.notebook.cells[cell_index].output = Some(output);
+        app.retained_versions.insert(version, handle);
+        app.pg_snapshots.insert(
+            handle,
+            PgTempSnapshot {
+                physical_name: format!("snapshot_{execution}"),
+                public_columns: vec!["value".to_string()],
+                relation_oid: execution as u32,
+                connection_generation: app.connect_generation,
+                backend_pid: 1,
+                row_count: 1,
+                byte_size: 16,
+            },
+        );
+        app.pg_snapshot_order.push_back(handle);
+        version
+    }
+
+    fn notebook_buffer(app: &mut App, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let mut terminal =
+            Terminal::new(ratatui::backend::TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| app.render_notebook_workspace(frame, frame.area()))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buffer: &ratatui::buffer::Buffer) -> String {
+        let mut text = String::new();
+        for y in buffer.area.y..buffer.area.bottom() {
+            for x in buffer.area.x..buffer.area.right() {
+                text.push_str(buffer.cell((x, y)).unwrap().symbol());
+            }
+            text.push('\n');
+        }
+        text
+    }
+
+    #[test]
+    fn notebook_cell_colon_opens_command_prompt() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+
+        app.on_key(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE));
+
+        assert!(app.command.active);
+        assert_eq!(app.notebook.focus, NotebookFocus::Cell);
+    }
+
+    #[test]
+    fn notebook_cell_command_can_switch_back_to_classic() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.on_key(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE));
+
+        for character in "mode classic".chars() {
+            app.on_key(KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert_eq!(app.workspace_mode, WorkspaceMode::Classic);
+        assert_eq!(app.focus, Focus::Query);
+    }
+
+    #[test]
+    fn notebook_meta_command_switches_to_visible_classic_results_without_losing_cells() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 1".to_string());
+
+        app.execute_command("\\dt");
+
+        assert_eq!(app.workspace_mode, WorkspaceMode::Classic);
+        assert_eq!(app.notebook.cells[0].source(), "SELECT 1");
+    }
+
+    #[test]
+    fn notebook_sidebar_escape_returns_to_cell_focus_without_quit_prompt() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.sidebar_visible = true;
+        app.focus = Focus::Sidebar(SidebarSection::Schema);
+
+        app.on_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(app.focus, Focus::Notebook);
+        assert_eq!(app.notebook.focus, NotebookFocus::Cell);
+        assert!(app.confirm_prompt.is_none());
+    }
+
+    #[test]
+    fn notebook_tab_reaches_sidebar_and_status_reports_schema_focus() {
+        use ratatui::widgets::Widget;
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.sidebar_visible = true;
+
+        app.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+
+        assert_eq!(app.focus, Focus::Sidebar(SidebarSection::Schema));
+        let area = Rect::new(0, 0, 160, 1);
+        let mut buffer = ratatui::buffer::Buffer::empty(area);
+        app.status_line(area.width).render(area, &mut buffer);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("SCHEMA"));
+        assert!(text.contains("Esc notebook"));
+    }
+
+    #[test]
+    fn notebook_execute_and_advance_stays_on_cell_when_execution_is_rejected() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 1".to_string());
+        app.notebook.ensure_trailing_draft();
+        let selected = app.notebook.selected;
+
+        app.on_key(KeyEvent::new(KeyCode::Char('E'), KeyModifiers::SHIFT));
+
+        assert_eq!(app.notebook.selected, selected);
+        assert!(!app.db.running);
+    }
+
+    #[test]
+    fn notebook_mouse_click_targets_composer_and_result() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].output = Some(notebook_test_output(5));
+        app.notebook.ensure_trailing_draft();
+        notebook_buffer(&mut app, 100, 30);
+
+        let first = app.render_notebook_cells[0];
+        let result = first.output.unwrap();
+        app.handle_mouse_click(result.x + 1, result.y + 4);
+        assert_eq!(app.notebook.selected, first.cell_id);
+        assert_eq!(app.notebook.focus, NotebookFocus::Result);
+        assert_eq!(
+            app.notebook.cells[0]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid_state
+                .cursor_row,
+            2
+        );
+
+        let draft = app.render_notebook_cells[1];
+        app.handle_mouse_click(draft.composer.x + 1, draft.composer.y + 1);
+        assert_eq!(app.notebook.selected, draft.cell_id);
+        assert_eq!(app.notebook.focus, NotebookFocus::Editor);
+    }
+
+    #[test]
+    fn notebook_cell_h_l_collapse_output_while_result_h_l_move_columns() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT left_value, right_value".to_string());
+        let mut output = notebook_test_output(1);
+        output.grid = GridModel::new(
+            vec!["left_value".to_string(), "right_value".to_string()],
+            vec![vec!["left".to_string(), "right".to_string()]],
+        );
+        output.grid_state.cursor_col = 1;
+        app.notebook.cells[0].output = Some(output);
+
+        app.on_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+        assert!(app.notebook.cells[0].output_collapsed);
+        assert_eq!(app.notebook.focus, NotebookFocus::Cell);
+
+        app.on_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE));
+        assert!(!app.notebook.cells[0].output_collapsed);
+        assert_eq!(app.notebook.focus, NotebookFocus::Cell);
+
+        app.notebook.focus = NotebookFocus::Result;
+        app.on_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+        assert_eq!(
+            app.notebook.cells[0]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid_state
+                .cursor_col,
+            0
+        );
+        assert!(!app.notebook.cells[0].output_collapsed);
+
+        app.on_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE));
+        assert_eq!(
+            app.notebook.cells[0]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid_state
+                .cursor_col,
+            1
+        );
+        assert!(!app.notebook.cells[0].output_collapsed);
+    }
+
+    #[test]
+    fn notebook_output_chevron_stays_visible_and_click_toggles_cell_output() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source(
+            "SELECT a_very_long_column_name, another_very_long_column_name FROM example"
+                .to_string(),
+        );
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].output = Some(notebook_test_output(5));
+        let buffer = notebook_buffer(&mut app, 52, 20);
+        let toggle = app.render_notebook_cells[0].output_toggle.unwrap();
+
+        assert_eq!(buffer.cell((toggle.x, toggle.y)).unwrap().symbol(), "▾");
+        app.handle_mouse_click(toggle.x, toggle.y);
+        assert!(app.notebook.cells[0].output_collapsed);
+        assert_eq!(app.notebook.focus, NotebookFocus::Cell);
+
+        let buffer = notebook_buffer(&mut app, 52, 20);
+        let toggle = app.render_notebook_cells[0].output_toggle.unwrap();
+        assert_eq!(buffer.cell((toggle.x, toggle.y)).unwrap().symbol(), "▸");
+        assert!(app.render_notebook_cells[0].output.is_none());
+        app.handle_mouse_click(toggle.x, toggle.y);
+        assert!(!app.notebook.cells[0].output_collapsed);
+        assert_eq!(app.notebook.focus, NotebookFocus::Cell);
+    }
+
+    #[test]
+    fn notebook_clear_execution_recurses_through_bound_and_restored_dependents() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1 AS value".to_string());
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        let root_older = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let root_latest = install_notebook_test_snapshot(&mut app, 0, 2, 2);
+
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT value FROM @result_1".to_string());
+        app.notebook.selected_cell_mut().dependency = Some(root_older);
+        app.notebook.selected_cell_mut().execution = CellExecutionState::Succeeded;
+        let child = install_notebook_test_snapshot(&mut app, 1, 3, 3);
+
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT value FROM @result_2".to_string());
+        app.notebook.selected_cell_mut().dependency = Some(child);
+        app.notebook.selected_cell_mut().execution = CellExecutionState::Failed;
+        app.notebook.selected_cell_mut().failure = Some("old execution error".to_string());
+        app.notebook.selected_cell_mut().bound_connection_generation = Some(42);
+        app.notebook.selected_cell_mut().output_collapsed = true;
+        let grandchild = install_notebook_test_snapshot(&mut app, 2, 4, 4);
+
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT value FROM @result_3".to_string());
+        app.notebook.selected_cell_mut().execution = CellExecutionState::Failed;
+        app.notebook.selected_cell_mut().failure = Some("restored execution error".to_string());
+
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 99 AS unrelated".to_string());
+        app.notebook.selected_cell_mut().execution = CellExecutionState::Succeeded;
+        let unrelated = install_notebook_test_snapshot(&mut app, 4, 5, 5);
+
+        let sources = app
+            .notebook
+            .cells
+            .iter()
+            .map(|cell| cell.source())
+            .collect::<Vec<_>>();
+        let dependencies = app
+            .notebook
+            .cells
+            .iter()
+            .map(|cell| cell.dependency)
+            .collect::<Vec<_>>();
+        app.notebook.selected = CellId(1);
+        app.notebook.focus = NotebookFocus::Cell;
+
+        app.on_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        assert!(matches!(
+            app.confirm_prompt.as_ref().map(ConfirmPrompt::context),
+            Some(ConfirmContext::ClearNotebookCellExecution { cell_id: 1 })
+        ));
+        app.on_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(app.confirm_prompt.is_none());
+        assert!(app.notebook.cells[0].output.is_some());
+        assert!(app.pg_snapshots.contains_key(&RetainedResultHandle(1)));
+
+        app.on_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        app.on_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        assert!(app.confirm_prompt.is_none());
+        assert_eq!(
+            app.notebook
+                .cells
+                .iter()
+                .map(|cell| cell.source())
+                .collect::<Vec<_>>(),
+            sources
+        );
+        assert_eq!(
+            app.notebook
+                .cells
+                .iter()
+                .map(|cell| cell.dependency)
+                .collect::<Vec<_>>(),
+            dependencies
+        );
+        for cell in &app.notebook.cells[..4] {
+            assert!(cell.output.is_none());
+            assert!(cell.failure.is_none());
+            assert_eq!(cell.execution, CellExecutionState::NeverRun);
+            assert_eq!(cell.bound_connection_generation, None);
+            assert!(!cell.output_collapsed);
+        }
+        assert!(app.notebook.cells[4].output.is_some());
+        assert_eq!(
+            app.notebook.cells[4].execution,
+            CellExecutionState::Succeeded
+        );
+        for version in [root_older, root_latest, child, grandchild] {
+            assert!(!app.retained_versions.contains_key(&version));
+        }
+        assert!(app.retained_versions.contains_key(&unrelated));
+        for handle in 1..=4 {
+            assert!(!app.pg_snapshots.contains_key(&RetainedResultHandle(handle)));
+            assert!(!app
+                .pg_snapshot_order
+                .contains(&RetainedResultHandle(handle)));
+        }
+        assert!(app.pg_snapshots.contains_key(&RetainedResultHandle(5)));
+        assert!(app.pg_snapshot_order.contains(&RetainedResultHandle(5)));
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Cleared cell 1 and 3 dependent execution(s)")
+        );
+    }
+
+    #[test]
+    fn notebook_clear_execution_ignores_empty_cells_and_rejects_running_queries() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+
+        app.on_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        assert!(app.confirm_prompt.is_none());
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Selected cell has no execution to clear")
+        );
+
+        app.notebook.cells[0].output = Some(notebook_test_output(1));
+        app.db.running = true;
+        app.on_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        assert!(app.confirm_prompt.is_none());
+        assert!(app.notebook.cells[0].output.is_some());
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Wait for the running query before clearing cells")
+        );
+    }
+
+    #[test]
+    fn notebook_result_focus_renders_cursor_and_scrolls_beyond_preview() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].output = Some(notebook_test_output(40));
+        app.notebook.focus = NotebookFocus::Result;
+
+        for _ in 0..20 {
+            app.handle_notebook_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        }
+        let text = buffer_text(&notebook_buffer(&mut app, 100, 24));
+
+        assert!(
+            text.contains("21 >  21"),
+            "focused row should be visible: {text}"
+        );
+        assert!(
+            text.contains("#    value"),
+            "grid header is missing: {text}"
+        );
+        assert!(
+            text.contains("PREVIEW · NO SNAPSHOT · ≥41 rows · 4ms"),
+            "result metadata is missing from the active header: {text}"
+        );
+        assert!(
+            app.notebook.cells[0]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid_state
+                .row_offset
+                > 0
+        );
+    }
+
+    #[test]
+    fn notebook_focused_result_expands_table_and_compacts_nearby_cells() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT previous_value".to_string());
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].output = Some(notebook_test_output(40));
+        app.notebook.cells[0]
+            .output
+            .as_mut()
+            .unwrap()
+            .executed_revision = app.notebook.cells[0].revision;
+        app.notebook.cells[0].output_collapsed = true;
+        app.notebook.select_or_create_draft();
+        app.notebook.selected_cell_mut().replace_source(
+            "SELECT value\nFROM example\nWHERE enabled\nORDER BY value".to_string(),
+        );
+        app.notebook.selected_cell_mut().execution = CellExecutionState::Succeeded;
+        app.notebook.selected_cell_mut().output = Some(notebook_test_output(60));
+        app.notebook
+            .selected_cell_mut()
+            .output
+            .as_mut()
+            .unwrap()
+            .executed_revision = app.notebook.selected_cell().revision;
+        app.notebook.ensure_trailing_draft();
+        app.notebook.focus = NotebookFocus::Result;
+
+        let text = buffer_text(&notebook_buffer(&mut app, 120, 24));
+        let areas = &app.render_notebook_cells;
+        let previous = areas.iter().find(|area| area.cell_id == CellId(1)).unwrap();
+        let active = areas.iter().find(|area| area.cell_id == CellId(2)).unwrap();
+        let draft = areas.iter().find(|area| area.cell_id == CellId(3)).unwrap();
+
+        assert!(previous.compact);
+        assert_eq!(previous.composer.height, 1);
+        assert!(draft.compact);
+        assert_eq!(draft.composer.height, 1);
+        assert!(!active.compact);
+        assert_eq!(active.composer.height, 2);
+        assert!(active.grid.unwrap().height > 13);
+        assert!(
+            text.contains("SELECT value FROM example WHERE enabled ORDER BY value"),
+            "active SQL should be summarized on one line: {text}"
+        );
+        assert!(text.contains("▸ CELL 1 · SQL · SUCCEEDED"), "{text}");
+        assert!(text.contains("▸ CELL 3 · SQL · DRAFT"), "{text}");
+        assert!(!text.contains("h/j/k/l table"), "{text}");
+        assert!(app.notebook.cells[0].output_collapsed);
+    }
+
+    #[test]
+    fn notebook_compact_result_summary_click_switches_and_restores_its_table() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT previous_value".to_string());
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].output = Some(notebook_test_output(30));
+        app.notebook.cells[0]
+            .output
+            .as_mut()
+            .unwrap()
+            .grid_state
+            .cursor_row = 7;
+        app.notebook.cells[0].output_collapsed = true;
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT active_value".to_string());
+        app.notebook.selected_cell_mut().execution = CellExecutionState::Succeeded;
+        app.notebook.selected_cell_mut().output = Some(notebook_test_output(30));
+        app.notebook.focus = NotebookFocus::Result;
+        notebook_buffer(&mut app, 100, 24);
+        let previous = app
+            .render_notebook_cells
+            .iter()
+            .find(|area| area.cell_id == CellId(1))
+            .copied()
+            .unwrap();
+
+        app.handle_mouse_click(previous.composer.x + 1, previous.composer.y);
+        notebook_buffer(&mut app, 100, 24);
+
+        assert_eq!(app.notebook.selected, CellId(1));
+        assert_eq!(app.notebook.focus, NotebookFocus::Result);
+        assert!(!app.notebook.cells[0].output_collapsed);
+        assert_eq!(
+            app.notebook.cells[0]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid_state
+                .cursor_row,
+            7
+        );
+        let active = app
+            .render_notebook_cells
+            .iter()
+            .find(|area| area.cell_id == CellId(1))
+            .unwrap();
+        assert!(!active.compact);
+        assert!(active.grid.unwrap().height > 13);
+    }
+
+    #[test]
+    fn notebook_result_escape_restores_the_full_notebook_flow() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT previous_value".to_string());
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].output = Some(notebook_test_output(2));
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT active_value".to_string());
+        app.notebook.selected_cell_mut().execution = CellExecutionState::Succeeded;
+        app.notebook.selected_cell_mut().output = Some(notebook_test_output(2));
+        app.notebook.focus = NotebookFocus::Result;
+        notebook_buffer(&mut app, 100, 30);
+        assert!(app.render_notebook_cells[0].compact);
+
+        app.on_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        notebook_buffer(&mut app, 100, 30);
+
+        assert_eq!(app.notebook.focus, NotebookFocus::Cell);
+        assert!(app.render_notebook_cells.iter().all(|area| !area.compact));
+        assert!(app.render_notebook_cells[0].grid.is_some());
+        assert!(app.render_notebook_cells[1].grid.is_some());
+    }
+
+    #[test]
+    fn notebook_result_layout_stays_expanded_when_sidebar_has_focus() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT previous_value".to_string());
+        app.notebook.cells[0].output = Some(notebook_test_output(2));
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT active_value".to_string());
+        app.notebook.selected_cell_mut().output = Some(notebook_test_output(2));
+        app.notebook.focus = NotebookFocus::Result;
+        app.focus = Focus::Sidebar(SidebarSection::Schema);
+
+        notebook_buffer(&mut app, 100, 30);
+
+        assert!(app.render_notebook_cells.iter().all(|area| !area.compact));
+        assert!(app.render_notebook_cells[0].grid.is_some());
+    }
+
+    #[test]
+    fn notebook_focused_window_reserves_nearby_summaries_without_starving_table() {
+        assert_eq!(notebook_focused_cell_window(3, 1, 23), (0, 3));
+        assert_eq!(notebook_focused_cell_window(20, 10, 23), (7, 14));
+        assert_eq!(notebook_focused_cell_window(20, 0, 23), (0, 7));
+        assert_eq!(notebook_focused_cell_window(20, 19, 23), (13, 20));
+        assert_eq!(notebook_focused_cell_window(3, 1, 4), (1, 2));
+        assert_eq!(notebook_focused_cell_window(3, 1, 2), (1, 2));
+    }
+
+    #[test]
+    fn notebook_result_mouse_click_selects_exact_row_and_column() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT left_value, right_value".to_string());
+        let mut output = notebook_test_output(3);
+        output.grid = GridModel::new(
+            vec!["left_value".to_string(), "right_value".to_string()],
+            vec![
+                vec!["left-1".to_string(), "right-1".to_string()],
+                vec!["left-2".to_string(), "right-2".to_string()],
+                vec!["left-3".to_string(), "right-3".to_string()],
+            ],
+        );
+        app.notebook.cells[0].output = Some(output);
+        notebook_buffer(&mut app, 100, 30);
+
+        let grid = app.render_notebook_cells[0].grid.unwrap();
+        let widths = app.notebook.cells[0]
+            .output
+            .as_ref()
+            .unwrap()
+            .grid
+            .col_widths
+            .clone();
+        let marker_width = 5;
+        let second_column_x = grid.x + marker_width + widths[0] + 1;
+        app.handle_mouse_click(second_column_x, grid.y);
+        assert_eq!(
+            app.notebook.cells[0]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid_state
+                .cursor_col,
+            1
+        );
+
+        app.handle_mouse_click(second_column_x, grid.y + 3);
+        let state = &app.notebook.cells[0].output.as_ref().unwrap().grid_state;
+        assert_eq!(app.notebook.focus, NotebookFocus::Result);
+        assert_eq!((state.cursor_row, state.cursor_col), (2, 1));
+    }
+
+    #[test]
+    fn notebook_result_uses_grid_keymap_and_keeps_cell_navigation_state() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT left_value, right_value".to_string());
+        let mut output = notebook_test_output(20);
+        output.grid = GridModel::new(
+            vec!["left_value".to_string(), "right_value".to_string()],
+            (1..=20)
+                .map(|row| vec![format!("left-{row}"), format!("right-{row}")])
+                .collect(),
+        );
+        app.notebook.cells[0].output = Some(output);
+        app.notebook.focus = NotebookFocus::Result;
+        app.grid_keymap.bind(
+            KeyBinding::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            Action::MoveRight,
+        );
+
+        app.handle_notebook_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        app.handle_notebook_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL));
+        app.handle_notebook_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        let state = &app.notebook.cells[0].output.as_ref().unwrap().grid_state;
+        assert_eq!((state.cursor_row, state.cursor_col), (6, 1));
+        assert!(state.selected_rows.contains(&5));
+
+        app.notebook.select_or_create_draft();
+        app.notebook.focus = NotebookFocus::Cell;
+        app.notebook.select_previous();
+        app.notebook.focus = NotebookFocus::Result;
+        let state = &app.notebook.cells[0].output.as_ref().unwrap().grid_state;
+        assert_eq!((state.cursor_row, state.cursor_col), (6, 1));
+        assert!(state.selected_rows.contains(&5));
+    }
+
+    #[test]
+    fn notebook_inspect_expands_output_and_row_detail_stays_read_only() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        app.notebook.cells[0].output = Some(notebook_test_output(2));
+        app.notebook.cells[0].output_collapsed = true;
+
+        app.handle_notebook_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
+        assert_eq!(app.notebook.focus, NotebookFocus::Result);
+        assert!(!app.notebook.cells[0].output_collapsed);
+
+        app.handle_notebook_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
+        assert!(app.row_detail.is_some());
+        app.handle_row_detail_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE));
+        assert!(app.row_detail.is_some());
+        assert!(!app.cell_editor.active);
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Notebook results are read-only")
+        );
+    }
+
+    #[test]
+    fn notebook_result_status_reports_row_and_column() {
+        use ratatui::widgets::Widget;
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        let mut output = notebook_test_output(3);
+        output.grid = GridModel::new(
+            vec!["left_value".to_string(), "right_value".to_string()],
+            vec![
+                vec!["left-1".to_string(), "right-1".to_string()],
+                vec!["left-2".to_string(), "right-2".to_string()],
+                vec!["left-3".to_string(), "right-3".to_string()],
+            ],
+        );
+        output.grid_state.cursor_row = 1;
+        output.grid_state.cursor_col = 1;
+        app.notebook.cells[0].output = Some(output);
+        app.notebook.focus = NotebookFocus::Result;
+        let area = Rect::new(0, 0, 200, 1);
+        let mut buffer = ratatui::buffer::Buffer::empty(area);
+
+        app.status_line(area.width).render(area, &mut buffer);
+        let text = buffer_text(&buffer);
+
+        assert!(text.contains("Row 2/3 · Col 2/2 · 1 cells"), "{text}");
+        assert!(
+            text.contains("h/j/k/l table · / search · yy copy · Esc restore cells"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn notebook_latest_reference_rebinds_to_latest_published_result_each_run() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        let older = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 2".to_string());
+        let latest = install_notebook_test_snapshot(&mut app, 1, 2, 2);
+
+        let orphan = ResultVersion {
+            source_cell: CellId(99),
+            source_execution: ExecutionId(3),
+            source_revision: 1,
+        };
+        let orphan_handle = RetainedResultHandle(3);
+        app.retained_versions.insert(orphan, orphan_handle);
+        app.pg_snapshots.insert(
+            orphan_handle,
+            PgTempSnapshot {
+                physical_name: "orphan".to_string(),
+                public_columns: vec!["value".to_string()],
+                relation_oid: 3,
+                connection_generation: app.connect_generation,
+                backend_pid: 1,
+                row_count: 1,
+                byte_size: 16,
+            },
+        );
+        app.pg_snapshot_order.push_back(orphan_handle);
+
+        let (version, snapshot) = app
+            .resolve_notebook_result_dependency("SELECT * FROM @result", Some(older))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(version, latest);
+        assert_eq!(snapshot.physical_name, "snapshot_2");
+    }
+
+    #[test]
+    fn notebook_numbered_reference_rebinds_restored_or_unbound_cell() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        let latest = install_notebook_test_snapshot(&mut app, 0, 2, 2);
+        let restored = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(1),
+            source_revision: 1,
+        };
+
+        for dependency in [None, Some(restored)] {
+            let (version, snapshot) = app
+                .resolve_notebook_result_dependency("SELECT * FROM @result_1", dependency)
+                .unwrap()
+                .unwrap();
+            assert_eq!(version, latest);
+            assert_eq!(snapshot.physical_name, "snapshot_2");
+        }
+    }
+
+    #[test]
+    fn notebook_numbered_reference_keeps_a_live_immutable_binding() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        let older = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let _latest = install_notebook_test_snapshot(&mut app, 0, 2, 2);
+
+        let (version, snapshot) = app
+            .resolve_notebook_result_dependency("SELECT * FROM @result_1", Some(older))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(version, older);
+        assert_eq!(snapshot.physical_name, "snapshot_1");
+    }
+
+    #[test]
+    fn notebook_missing_result_reference_reports_which_source_to_run() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let app = notebook_test_app(&runtime);
+
+        assert_eq!(
+            app.resolve_notebook_result_dependency("SELECT * FROM @result", None)
+                .unwrap_err(),
+            "No retained result is available for @result. Run a source cell first"
+        );
+        assert_eq!(
+            app.resolve_notebook_result_dependency("SELECT * FROM @result_1", None)
+                .unwrap_err(),
+            "Result for cell 1 is unavailable. Run cell 1 first"
+        );
+    }
+
+    #[test]
+    fn notebook_result_wheel_moves_rows_without_switching_cells() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        app.notebook.cells[0].output = Some(notebook_test_output(40));
+        app.notebook.ensure_trailing_draft();
+        app.notebook.focus = NotebookFocus::Result;
+        let selected = app.notebook.selected;
+
+        app.handle_mouse_scroll(3);
+
+        assert_eq!(app.notebook.selected, selected);
+        assert_eq!(app.notebook.focus, NotebookFocus::Result);
+        assert_eq!(
+            app.notebook.cells[0]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid_state
+                .cursor_row,
+            3
+        );
+    }
+
+    #[test]
+    fn notebook_long_editor_keeps_active_line_and_rail_visible() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.config.notebook.composer_max_rows = 8;
+        let source = (1..=14)
+            .map(|line| format!("SELECT {line} AS line_{line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        app.notebook.cells[0].replace_source(source);
+        app.notebook.cells[0]
+            .editor
+            .textarea
+            .move_cursor(CursorMove::Bottom);
+        app.notebook.focus = NotebookFocus::Editor;
+
+        let buffer = notebook_buffer(&mut app, 100, 24);
+        let text = buffer_text(&buffer);
+        let area = app.render_notebook_cells[0].composer;
+
+        assert!(
+            text.contains("SELECT 14 AS line_14"),
+            "active line is clipped: {text}"
+        );
+        assert!(!text.contains("SELECT 1 AS line_1 "));
+        assert_eq!(
+            (area.y..area.bottom())
+                .filter(|row| buffer.cell((area.x, *row)).unwrap().symbol() == "┃")
+                .count(),
+            area.height as usize
+        );
+    }
+
+    #[test]
+    fn notebook_selected_cell_stays_visible_after_tall_output() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].output = Some(notebook_test_output(40));
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 42 AS final_value".to_string());
+        app.notebook.selected_cell_mut().execution = CellExecutionState::Succeeded;
+        app.notebook.selected_cell_mut().output = Some(notebook_test_output(1));
+        let selected = app.notebook.selected;
+
+        let text = buffer_text(&notebook_buffer(&mut app, 60, 16));
+
+        assert!(
+            text.contains("SELECT 42 AS final_value"),
+            "selected cell vanished: {text}"
+        );
+        assert!(app
+            .render_notebook_cells
+            .iter()
+            .any(|area| area.cell_id == selected));
+    }
+
+    #[test]
+    fn notebook_failed_rerun_keeps_stale_output_visible() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        app.notebook.cells[0].execution = CellExecutionState::Failed;
+        app.notebook.cells[0].failure = Some("relation does not exist".to_string());
+        app.notebook.cells[0].output = Some(notebook_test_output(1));
+
+        let text = buffer_text(&notebook_buffer(&mut app, 100, 24));
+
+        assert!(text.contains("ERROR · relation does not exist"));
+        assert!(text.contains("STALE OUTPUT"));
+    }
+
+    #[test]
+    fn notebook_cell_ids_match_refinement_headers_after_insertion() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        app.notebook.ensure_trailing_draft();
+        app.notebook
+            .insert_refinement(super::super::refinement::ResultVersion {
+                source_cell: CellId(1),
+                source_execution: ExecutionId(1),
+                source_revision: 1,
+            });
+
+        let text = buffer_text(&notebook_buffer(&mut app, 100, 30));
+
+        assert!(text.contains("CELL 3 · SQL · SOURCE UNAVAILABLE · from cell 1/run 1"));
+        assert!(text.contains("CELL 2 · SQL · DRAFT"));
+    }
+
+    #[test]
+    fn notebook_restored_reference_renders_runnable_after_source_is_rerun() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        app.notebook.ensure_trailing_draft();
+        app.notebook.insert_refinement(ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(1),
+            source_revision: 1,
+        });
+
+        let unavailable = buffer_text(&notebook_buffer(&mut app, 100, 30));
+        assert!(unavailable.contains("CELL 3 · SQL · SOURCE UNAVAILABLE · from cell 1/run 1"));
+
+        let _latest = install_notebook_test_snapshot(&mut app, 0, 2, 2);
+        let runnable = buffer_text(&notebook_buffer(&mut app, 100, 30));
+        assert!(runnable.contains("CELL 3 · SQL · NEEDS RUN · from cell 1/run 1"));
+    }
+
+    #[test]
+    fn notebook_status_does_not_leak_classic_result_timing_or_selection() {
+        use ratatui::widgets::Widget;
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.grid = GridModel::new(vec!["classic".to_string()], vec![vec!["42".to_string()]]);
+        app.grid_state.selected_rows.insert(0);
+        app.db.last_command_tag = Some("CLASSIC SELECT 1".to_string());
+        app.db.last_elapsed = Some(Duration::from_secs(9));
+        let area = Rect::new(0, 0, 160, 1);
+        let mut buffer = ratatui::buffer::Buffer::empty(area);
+
+        app.status_line(area.width).render(area, &mut buffer);
+        let text = buffer_text(&buffer);
+
+        assert!(!text.contains("CLASSIC SELECT 1"));
+        assert!(!text.contains("9000ms"));
+        assert!(!text.contains("1 sel"));
+    }
 
     #[test]
     fn test_grid_mouse_target_selects_column_from_header_and_body() {

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -45,15 +45,16 @@ use crate::history::{History, HistoryEntry};
 use crate::session::SessionState;
 use crate::ui::{
     create_sql_highlighter, determine_context, escape_sql_value, get_word_before_cursor, is_inside,
-    quote_identifier, AiQueryModal, AiQueryModalAction, ColumnInfo, CommandPrompt, CompletionKind,
-    CompletionPopup, ConfirmContext, ConfirmPrompt, ConfirmResult, ConnectionFormAction,
-    ConnectionFormModal, ConnectionInfo, ConnectionManagerAction, ConnectionManagerModal,
-    CursorShape, DataGrid, FuzzyPicker, GridKeyResult, GridModel, GridState, HelpAction, HelpPopup,
-    HighlightedTextArea, JsonEditorAction, JsonEditorModal, KeyHintPopup, KeySequenceAction,
-    KeySequenceCompletion, KeySequenceHandlerWithContext, KeySequenceResult, PasswordPrompt,
-    PasswordPromptResult, PendingKey, PickerAction, Priority, QueryEditor, ResizeAction,
-    RowDetailAction, RowDetailModal, SchemaCache, SearchPrompt, Sidebar, SidebarAction,
-    StatusLineBuilder, StatusSegment, TableInfo, YankFormat,
+    load_theme, quote_identifier, zone_block, zone_inner, zone_label, zone_scrollbar_area,
+    AiQueryModal, AiQueryModalAction, ColumnInfo, CommandPrompt, CompletionKind, CompletionPopup,
+    ConfirmContext, ConfirmPrompt, ConfirmResult, ConnectionFormAction, ConnectionFormModal,
+    ConnectionInfo, ConnectionManagerAction, ConnectionManagerModal, CursorShape, DataGrid,
+    FuzzyPicker, GridKeyResult, GridModel, GridState, HelpAction, HelpPopup, HighlightedTextArea,
+    JsonEditorAction, JsonEditorModal, KeyHintPopup, KeySequenceAction, KeySequenceCompletion,
+    KeySequenceHandlerWithContext, KeySequenceResult, PasswordPrompt, PasswordPromptResult,
+    PendingKey, PickerAction, Priority, QueryEditor, ResizeAction, RowDetailAction, RowDetailModal,
+    SchemaCache, SearchPrompt, Sidebar, SidebarAction, StatusLineBuilder, StatusSegment, TableInfo,
+    UiTheme, YankFormat,
 };
 use crate::update::{
     apply_update, check_for_update, current_target_triple, detect_current_install_method,
@@ -798,7 +799,7 @@ const MAX_DEFAULT_QUERY_HEIGHT: u16 = 12;
 const DEFAULT_QUERY_HEIGHT_RATIO_DENOM: u16 = 4; // 25%
 const STATUS_HEIGHT: u16 = 1;
 const MIN_GRID_HEIGHT: u16 = 3;
-const QUERY_BORDER_ROWS: u16 = 2;
+const QUERY_CHROME_ROWS: u16 = 1;
 const QUERY_EXPANDED_MAX_RATIO_DENOM: u16 = 2; // 50%
 
 /// Check if a query is suitable for cursor-based paging.
@@ -869,7 +870,7 @@ fn compute_query_panel_height(
     let maximized_height = ratio_cap.max(regular_height);
 
     if mode == Mode::Insert {
-        let desired_content_height = (editor_line_count as u16).saturating_add(QUERY_BORDER_ROWS);
+        let desired_content_height = (editor_line_count as u16).saturating_add(QUERY_CHROME_ROWS);
         let desired_height = desired_content_height.max(regular_height);
         return desired_height.min(maximized_height);
     }
@@ -2433,6 +2434,12 @@ pub struct App {
     /// Application configuration
     pub config: Config,
 
+    /// Resolved theme for UI chrome.
+    pub ui_theme: UiTheme,
+
+    /// Diagnostics produced while constructing the application.
+    startup_warnings: Vec<String>,
+
     /// Keymap for grid navigation
     pub grid_keymap: Keymap,
     /// Keymap for editor in normal mode
@@ -2660,6 +2667,8 @@ impl App {
         config: Config,
     ) -> Self {
         let editor = QueryEditor::new();
+        let (syntax_theme, theme_warning) = load_theme(&config.display.theme);
+        let ui_theme = UiTheme::from_theme(&syntax_theme);
 
         // Load history
         let history = History::load(config.editor.max_history).unwrap_or_else(|e| {
@@ -2685,6 +2694,8 @@ impl App {
             mode: Mode::Normal,
 
             config,
+            ui_theme,
+            startup_warnings: theme_warning.into_iter().collect(),
 
             grid_keymap,
             editor_normal_keymap,
@@ -2694,7 +2705,7 @@ impl App {
             connection_form_keymap,
 
             editor,
-            highlighter: create_sql_highlighter(),
+            highlighter: create_sql_highlighter(syntax_theme),
             search: SearchPrompt::new(),
             search_target: SearchTarget::Editor,
             command: CommandPrompt::new(),
@@ -2801,6 +2812,11 @@ impl App {
         // This allows main.rs to first check session state for auto-reconnect.
 
         app
+    }
+
+    /// Take diagnostics collected while constructing the application.
+    pub fn take_startup_warnings(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.startup_warnings)
     }
 
     /// Capture current session state for persistence.
@@ -3038,6 +3054,7 @@ impl App {
                         None, // No error handling yet
                         self.sidebar_focus,
                         has_focus,
+                        &self.ui_theme,
                     );
                 } else {
                     self.render_sidebar_area = None;
@@ -3068,36 +3085,31 @@ impl App {
                 self.render_grid_area = Some(grid_area);
 
                 // Query editor with syntax highlighting
-                let query_border = match (self.focus, self.mode) {
-                    (Focus::Query, Mode::Normal) => Style::default().fg(Color::Cyan),
-                    (Focus::Query, Mode::Insert) => Style::default().fg(Color::Green),
-                    (Focus::Query, Mode::Visual) => Style::default().fg(Color::Yellow),
-                    (Focus::Grid, _) | (Focus::Sidebar(_), _) => {
-                        Style::default().fg(Color::DarkGray)
-                    }
-                };
-
-                // Build query title with [+] indicator if modified
-                let modified_indicator = if self.editor.is_modified() {
-                    " [+]"
-                } else {
-                    ""
-                };
-                let query_title = if self.focus == Focus::Query {
-                    format!(" ● Query [{}]{} ", self.mode.label(), modified_indicator)
-                } else {
-                    format!(" Query{} ", modified_indicator)
-                };
-
-                let query_block = Block::default()
-                    .borders(Borders::ALL)
-                    .title(query_title.as_str())
-                    .title_style(if self.focus == Focus::Query {
-                        query_border.add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(Color::DarkGray)
-                    })
-                    .border_style(query_border);
+                let query_focused = self.focus == Focus::Query;
+                let query_accent = self.ui_theme.mode_accent(self.mode);
+                let mut query_details = Vec::with_capacity(2);
+                if query_focused {
+                    query_details.push(Span::styled(
+                        format!(" [{}]", self.mode.label()),
+                        self.ui_theme.label_focused.fg(query_accent),
+                    ));
+                }
+                if self.editor.is_modified() {
+                    query_details.push(Span::styled(" [+]", self.ui_theme.warning));
+                }
+                let query_block = zone_block(
+                    zone_label(
+                        "QUERY",
+                        query_details,
+                        query_focused,
+                        query_accent,
+                        &self.ui_theme,
+                    ),
+                    self.ui_theme.bg_elevated,
+                    self.ui_theme.text,
+                    query_focused,
+                    query_accent,
+                );
 
                 // Choose cursor shape based on vim mode
                 let cursor_shape = match self.mode {
@@ -3109,6 +3121,8 @@ impl App {
                 let highlighted_editor =
                     HighlightedTextArea::new(&self.editor.textarea, highlighted_lines.clone())
                         .block(query_block.clone())
+                        .cursor_style(self.ui_theme.editor_cursor)
+                        .selection_style(self.ui_theme.editor_selection)
                         .scroll(self.editor_scroll)
                         .show_cursor(is_editor_focused)
                         .cursor_shape(cursor_shape);
@@ -3126,9 +3140,9 @@ impl App {
                 }
 
                 // Update editor scroll based on cursor position
-                // The inner area height is query_area.height - 2 (for borders)
-                let inner_height = query_area.height.saturating_sub(2) as usize;
-                let inner_width = query_area.width.saturating_sub(2) as usize;
+                let query_inner = query_block.inner(query_area);
+                let inner_height = query_inner.height as usize;
+                let inner_width = query_inner.width as usize;
                 let (cursor_row, cursor_col) = self.editor.textarea.cursor();
                 self.editor_scroll = calculate_editor_scroll(
                     cursor_row,
@@ -3141,13 +3155,7 @@ impl App {
                 // Render scrollbar for query editor if content exceeds visible area
                 let total_lines = self.editor.textarea.lines().len();
                 if total_lines > inner_height && inner_height > 0 {
-                    let inner_area = query_block.inner(query_area);
-                    let scrollbar_area = Rect {
-                        x: inner_area.x + inner_area.width.saturating_sub(1),
-                        y: inner_area.y,
-                        width: 1,
-                        height: inner_area.height,
-                    };
+                    let scrollbar_area = zone_scrollbar_area(query_area);
 
                     let scrollbar = if scrollbar_area.height >= 7 {
                         Scrollbar::new(ScrollbarOrientation::VerticalRight)
@@ -3155,12 +3163,14 @@ impl App {
                             .end_symbol(Some("▼"))
                             .thumb_symbol("█")
                             .track_symbol(Some("░"))
+                            .style(self.ui_theme.scrollbar)
                     } else {
                         Scrollbar::new(ScrollbarOrientation::VerticalRight)
                             .begin_symbol(None)
                             .end_symbol(None)
                             .thumb_symbol("█")
                             .track_symbol(Some("│"))
+                            .style(self.ui_theme.scrollbar)
                     };
 
                     let mut scrollbar_state =
@@ -3170,13 +3180,12 @@ impl App {
                 }
 
                 // Calculate grid viewport dimensions for scroll handling
-                // Inner area: grid_area minus borders (2 for borders)
+                // Inner area: shared tonal-zone content rectangle
                 // Body area: inner minus header row (1)
                 // Data width: inner width minus marker column (3)
-                let inner_height = grid_area.height.saturating_sub(2);
-                let body_height = inner_height.saturating_sub(1); // minus header
-                let inner_width = grid_area.width.saturating_sub(2);
-                let data_width = inner_width.saturating_sub(3); // minus marker column
+                let grid_inner = zone_inner(grid_area);
+                let body_height = grid_inner.height.saturating_sub(1); // minus header
+                let data_width = grid_inner.width.saturating_sub(3); // minus marker column
 
                 // Update grid state scroll position based on viewport
                 self.grid_state.ensure_cursor_visible(
@@ -3191,10 +3200,35 @@ impl App {
                 self.last_grid_viewport = Some((body_height as usize, data_width));
 
                 // Results grid.
+                let grid_focused = self.focus == Focus::Grid;
+                let mut grid_details = vec![Span::styled(
+                    format!(" · {} rows", self.grid.rows.len()),
+                    self.ui_theme.text_muted,
+                )];
+                if let Some(elapsed) = self.db.last_elapsed {
+                    grid_details.push(Span::styled(
+                        format!(" · {}ms", elapsed.as_millis()),
+                        self.ui_theme.text_muted,
+                    ));
+                }
+                if let Some(search_info) = self.grid_state.search.match_info() {
+                    grid_details.push(Span::styled(
+                        format!(" · {search_info}"),
+                        self.ui_theme.warning,
+                    ));
+                }
                 let grid_widget = DataGrid {
                     model: &self.grid,
                     state: &self.grid_state,
-                    focused: self.focus == Focus::Grid,
+                    label: zone_label(
+                        "RESULTS",
+                        grid_details,
+                        grid_focused,
+                        self.ui_theme.accent,
+                        &self.ui_theme,
+                    ),
+                    theme: &self.ui_theme,
+                    focused: grid_focused,
                     show_row_numbers: self.config.display.show_row_numbers,
                     show_scrollbar: true,
                 };
@@ -3341,10 +3375,9 @@ impl App {
                     if !visible.is_empty() {
                         // Position popup near the cursor
                         let (cursor_row, cursor_col) = self.editor.textarea.cursor();
-                        // Estimate position (query_area starts at y=0, each line is 1 row)
-                        let popup_y = query_area.y + 1 + cursor_row as u16;
-                        let popup_x = query_area.x
-                            + 1
+                        let query_inner = zone_inner(query_area);
+                        let popup_y = query_inner.y + cursor_row as u16;
+                        let popup_x = query_inner.x
                             + cursor_col.saturating_sub(self.completion.prefix.len()) as u16;
 
                         let popup_height = (visible.len() + 2) as u16; // +2 for borders
@@ -10732,12 +10765,11 @@ impl App {
             self.grid_state.cursor_row.saturating_add(1)
         };
 
-        // Mode indicator with color
-        let (mode_text, mode_style) = match self.mode {
-            Mode::Normal => ("NORMAL", Style::default().fg(Color::Cyan)),
-            Mode::Insert => ("INSERT", Style::default().fg(Color::Green)),
-            Mode::Visual => ("VISUAL", Style::default().fg(Color::Yellow)),
-        };
+        let mode_text = format!(" {} ", self.mode.label());
+        let mode_style = Style::default()
+            .fg(self.ui_theme.pill_fg)
+            .bg(self.ui_theme.mode_accent(self.mode))
+            .add_modifier(Modifier::BOLD);
 
         // Connection info
         let conn_segment = if self.db.status == DbStatus::Connected {
@@ -10762,10 +10794,10 @@ impl App {
         };
 
         let conn_style = match self.db.status {
-            DbStatus::Connected => Style::default().fg(Color::Green),
-            DbStatus::Connecting => Style::default().fg(Color::Yellow),
-            DbStatus::Error => Style::default().fg(Color::Red),
-            DbStatus::Disconnected => Style::default().fg(Color::DarkGray),
+            DbStatus::Connected => Style::default().fg(self.ui_theme.success),
+            DbStatus::Connecting => Style::default().fg(self.ui_theme.warning),
+            DbStatus::Error => Style::default().fg(self.ui_theme.error),
+            DbStatus::Disconnected => Style::default().fg(self.ui_theme.text_muted),
         };
 
         // Row info
@@ -10803,12 +10835,12 @@ impl App {
         // Status message (right-aligned)
         let status = self.last_status.as_deref().unwrap_or("Ready").to_string();
         let status_style = if self.last_error.is_some() {
-            Style::default().fg(Color::Red)
+            Style::default().fg(self.ui_theme.error)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(self.ui_theme.text_muted)
         };
         let focus_style = Style::default()
-            .fg(Color::Cyan)
+            .fg(self.ui_theme.accent)
             .add_modifier(Modifier::BOLD);
         let navigation_hint = if self.focus == Focus::Query && self.mode != Mode::Normal {
             "Alt-hjkl move · Esc then Tab/S-Tab cycle"
@@ -10818,6 +10850,7 @@ impl App {
 
         // Build status line with priority-based segments
         let line = StatusLineBuilder::new()
+            .separator_style(Style::default().fg(self.ui_theme.text_muted))
             // Critical: Mode (always shown)
             .segment(StatusSegment::new(mode_text, Priority::Critical).style(mode_style))
             // Critical: active pane (always shown)
@@ -10837,7 +10870,7 @@ impl App {
                 StatusSegment::new(running_indicator.unwrap_or_default(), Priority::Critical)
                     .style(
                         Style::default()
-                            .fg(Color::Yellow)
+                            .fg(self.ui_theme.warning)
                             .add_modifier(Modifier::BOLD),
                     ),
             )
@@ -10845,7 +10878,7 @@ impl App {
             .segment_if(
                 self.db.in_transaction,
                 StatusSegment::new("TXN", Priority::High)
-                    .style(Style::default().fg(Color::Magenta)),
+                    .style(Style::default().fg(self.ui_theme.accent_visual)),
             )
             // Medium: Row info
             .segment(StatusSegment::new(row_info, Priority::Medium).min_width(50))
@@ -10853,20 +10886,20 @@ impl App {
             .segment_if(
                 selection_info.is_some(),
                 StatusSegment::new(selection_info.unwrap_or_default(), Priority::Medium)
-                    .style(Style::default().fg(Color::Cyan))
+                    .style(Style::default().fg(self.ui_theme.accent))
                     .min_width(60),
             )
             // Low: Query timing
             .segment_if(
                 timing_info.is_some(),
                 StatusSegment::new(timing_info.unwrap_or_default(), Priority::Low)
-                    .style(Style::default().fg(Color::DarkGray))
+                    .style(Style::default().fg(self.ui_theme.text_muted))
                     .min_width(80),
             )
             // Low: navigation reminder on wider terminals.
             .segment(
                 StatusSegment::new(navigation_hint, Priority::Low)
-                    .style(Style::default().fg(Color::DarkGray))
+                    .style(Style::default().fg(self.ui_theme.text_muted))
                     .min_width(105),
             )
             // Right-aligned: Status message
@@ -10877,7 +10910,11 @@ impl App {
             )
             .build(width);
 
-        Paragraph::new(line)
+        Paragraph::new(line).style(
+            Style::default()
+                .fg(self.ui_theme.text)
+                .bg(self.ui_theme.bg_status),
+        )
     }
 
     /// Open the history fuzzy picker.
@@ -11047,17 +11084,7 @@ fn grid_mouse_target(
     col_offset: usize,
     col_widths: &[u16],
 ) -> Option<GridMouseTarget> {
-    // Convert from block area (with borders) to inner grid content area.
-    if grid_area.width < 2 || grid_area.height < 2 {
-        return None;
-    }
-
-    let inner = Rect {
-        x: grid_area.x.saturating_add(1),
-        y: grid_area.y.saturating_add(1),
-        width: grid_area.width.saturating_sub(2),
-        height: grid_area.height.saturating_sub(2),
-    };
+    let inner = zone_inner(grid_area);
 
     if inner.width == 0 || inner.height == 0 {
         return None;
@@ -11238,6 +11265,76 @@ mod tests {
         }
     }
 
+    #[test]
+    #[serial]
+    fn theme_warning_does_not_overwrite_runtime_status() {
+        let _guard = ConfigDirGuard::new();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut config = Config::default();
+        config.display.theme = "../invalid".to_string();
+        let mut app = App::with_config(
+            GridModel::empty(),
+            runtime.handle().clone(),
+            tx,
+            rx,
+            None,
+            config,
+        );
+        app.last_status = Some("runtime status".to_string());
+        app.last_error = Some("runtime error".to_string());
+
+        let warnings = app.take_startup_warnings();
+
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("../invalid"));
+        assert_eq!(app.last_status.as_deref(), Some("runtime status"));
+        assert_eq!(app.last_error.as_deref(), Some("runtime error"));
+    }
+
+    #[test]
+    #[serial]
+    fn status_line_paints_complete_built_in_theme_backgrounds() {
+        use ratatui::buffer::Buffer;
+        use ratatui::widgets::Widget;
+
+        let _guard = ConfigDirGuard::new();
+        for theme_name in ["one_dark", "github_light"] {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let (tx, rx) = mpsc::unbounded_channel();
+            let mut config = Config::default();
+            config.display.theme = theme_name.to_string();
+            let app = App::with_config(
+                GridModel::empty(),
+                runtime.handle().clone(),
+                tx,
+                rx,
+                None,
+                config,
+            );
+            let area = Rect::new(0, 0, 100, 1);
+            let mut buffer = Buffer::empty(area);
+
+            app.status_line(area.width).render(area, &mut buffer);
+
+            assert!(buffer.content.iter().all(|cell| {
+                cell.bg == app.ui_theme.bg_status || cell.bg == app.ui_theme.accent
+            }));
+            assert_eq!(buffer.cell((1, 0)).unwrap().bg, app.ui_theme.accent);
+            for cell in &buffer.content {
+                if !cell.symbol().trim().is_empty() {
+                    assert_ne!(cell.fg, Color::Reset);
+                }
+            }
+        }
+    }
+
     // ========== Grid Mouse Tests ==========
 
     #[test]
@@ -11252,7 +11349,7 @@ mod tests {
         let col_widths = vec![5, 5, 5];
 
         // Header row is at y=1 (inner.y = 1).
-        // With no row numbers, marker_w = 3 and data_x = 1 + 3 = 4.
+        // With no row numbers, marker_w = 3 and data_x = 2 + 3 = 5.
         let header = grid_mouse_target(11, 1, grid_area, false, 10, 0, 0, &col_widths);
         assert_eq!(header, Some(GridMouseTarget::Header { col: Some(1) }));
 
@@ -11281,7 +11378,7 @@ mod tests {
         };
 
         let col_widths = vec![5, 5, 5];
-        // row_count=120 => digits=3, row_number_width=4, marker_w=7, data_x=1+7=8.
+        // row_count=120 => digits=3, row_number_width=4, marker_w=7, data_x=2+7=9.
         let cell = grid_mouse_target(9, 2, grid_area, true, 120, 0, 0, &col_widths);
         assert_eq!(
             cell,
@@ -11719,6 +11816,11 @@ mod tests {
         let low_content =
             compute_query_panel_height(40, Mode::Insert, QueryHeightMode::Minimized, 2);
         assert_eq!(low_content, 10);
+
+        // Tonal chrome reserves one label row above the editor content.
+        let content_driven =
+            compute_query_panel_height(40, Mode::Insert, QueryHeightMode::Minimized, 10);
+        assert_eq!(content_driven, 11);
 
         // High content expands, capped at 50% of main area.
         let high_content =

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -2512,6 +2512,7 @@ pub enum DbEvent {
         row: usize,
         col: usize,
         value: String,
+        is_null: bool,
     },
     /// Result of a connection test (from connection form).
     TestConnectionResult {
@@ -6590,14 +6591,13 @@ impl App {
             .col_types
             .get(col)
             .and_then(|t| (!t.is_empty()).then_some(t.as_str()));
-        set_doc.insert(
-            field_name,
-            parse_grid_cell_to_bson(&new_value, field_type_hint, true),
-        );
+        let bson_value = parse_grid_cell_to_bson(&new_value, field_type_hint, true);
+        let is_null = matches!(&bson_value, Bson::Null);
+        set_doc.insert(field_name, bson_value);
         let mut update = Document::new();
         update.insert("$set", Bson::Document(set_doc));
 
-        self.execute_mongo_cell_update(collection, filter, update, row, col, new_value);
+        self.execute_mongo_cell_update(collection, filter, update, row, col, (new_value, is_null));
     }
 
     fn build_mongo_update_filter(
@@ -6654,7 +6654,7 @@ impl App {
         update: Document,
         row: usize,
         col: usize,
-        new_value: String,
+        updated_value: (String, bool),
     ) {
         let Some(client) = self.db.mongo_client.clone() else {
             self.last_error = Some("Not connected".to_string());
@@ -6674,6 +6674,7 @@ impl App {
         self.last_status = Some("Updating...".to_string());
         self.query_ui.start();
 
+        let (new_value, is_null) = updated_value;
         let tx = self.db_events_tx.clone();
         self.rt.spawn(async move {
             let db = client.database(&db_name);
@@ -6685,6 +6686,7 @@ impl App {
                             row,
                             col,
                             value: new_value,
+                            is_null,
                         });
                     } else if res.matched_count == 0 {
                         let _ = tx.send(DbEvent::QueryError {
@@ -6729,6 +6731,7 @@ impl App {
         // Store row/col/value for updating grid on success
         let update_row = row;
         let update_col = col;
+        let update_is_null = new_value.is_empty() || new_value.eq_ignore_ascii_case("null");
         let update_value = new_value;
 
         self.rt.spawn(async move {
@@ -6750,6 +6753,7 @@ impl App {
                             row: update_row,
                             col: update_col,
                             value: update_value,
+                            is_null: update_is_null,
                         });
                     } else if affected == 0 {
                         let _ = tx.send(DbEvent::QueryError {
@@ -8316,6 +8320,20 @@ impl App {
 
         let expanded_path = expand_user_path(path);
         if notebook && !exporting_selection {
+            if retained.is_none()
+                && self
+                    .notebook
+                    .selected_cell()
+                    .output
+                    .as_ref()
+                    .is_some_and(|output| output.truncated)
+            {
+                self.last_error = Some(
+                    "Notebook result is truncated and no retained session snapshot is available for full export"
+                        .to_string(),
+                );
+                return;
+            }
             if let Some(retained) = retained {
                 let loaded = grid.rows.len();
                 if loaded < retained.rows
@@ -10935,7 +10953,7 @@ impl App {
                 .notebook
                 .cells
                 .iter()
-                .any(|cell| cell.is_dirty() || cell.editor.is_modified())
+                .any(|cell| cell.editor.is_modified())
     }
 
     fn handle_notebook_key(&mut self, key: KeyEvent) {
@@ -14858,13 +14876,23 @@ impl App {
                 self.last_status = Some("Schema refresh failed (see error)".to_string());
                 self.last_error = Some(error);
             }
-            DbEvent::CellUpdated { row, col, value } => {
+            DbEvent::CellUpdated {
+                row,
+                col,
+                value,
+                is_null,
+            } => {
                 self.db.running = false;
                 self.query_ui.clear();
                 // Update the grid cell
                 if let Some(grid_row) = self.grid.rows.get_mut(row) {
                     if let Some(cell) = grid_row.get_mut(col) {
                         *cell = value;
+                    }
+                }
+                if let Some(null_row) = self.grid.null_cells.get_mut(row) {
+                    if let Some(null_cell) = null_row.get_mut(col) {
+                        *null_cell = is_null;
                     }
                 }
                 self.last_status = Some("Cell updated successfully".to_string());
@@ -19421,6 +19449,47 @@ mod tests {
     }
 
     #[test]
+    fn notebook_full_export_refuses_truncated_output_without_retention_but_allows_selection() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        let mut output = notebook_test_output(2);
+        output.truncated = true;
+        output.refinement =
+            RefinementAvailability::Unavailable(RefinementUnavailableReason::SnapshotDisabled);
+        app.notebook.cells[0].output = Some(output);
+        let dir = tempfile::tempdir().unwrap();
+        let full_path = dir.path().join("partial.csv");
+        let selected_path = dir.path().join("selected.csv");
+
+        app.handle_export_command(&format!("csv {}", full_path.display()));
+
+        assert!(app
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("truncated") && error.contains("snapshot")));
+        assert!(!full_path.exists());
+
+        app.last_error = None;
+        app.notebook.cells[0]
+            .output
+            .as_mut()
+            .unwrap()
+            .grid_state
+            .selected_rows
+            .insert(1);
+        app.handle_export_command(&format!("csv {}", selected_path.display()));
+
+        assert_eq!(std::fs::read_to_string(selected_path).unwrap(), "value\n2");
+        assert!(app
+            .last_status
+            .as_deref()
+            .is_some_and(|status| status.contains("Exported 1 selected row")));
+    }
+
+    #[test]
     fn notebook_action_palette_opens_filters_switches_workspace_and_esc_closes() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -20171,6 +20240,32 @@ mod tests {
 
         app.notebook.cells[0].replace_source("SELECT 2".to_string());
         assert!(app.workspace_has_unsaved_changes());
+    }
+
+    #[test]
+    fn saved_notebook_with_stale_output_is_not_reported_as_unsaved() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].output = Some(notebook_test_output(1));
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].replace_source("SELECT 2".to_string());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("saved.json");
+
+        assert!(app.notebook.cells[0].is_dirty());
+        assert!(app.workspace_has_unsaved_changes());
+        assert!(!app.execute_command(&format!("save-notebook {}", path.display())));
+
+        assert!(!app.notebook.cells[0].editor.is_modified());
+        assert!(app.notebook.cells[0].is_dirty());
+        assert!(app.notebook.cells[0].output_is_stale());
+        assert!(!app.notebook_has_unsaved_changes());
+        assert!(!app.workspace_has_unsaved_changes());
+        assert!(!app.execute_command(&format!("open-notebook {}", path.display())));
+        assert!(app.confirm_prompt.is_none());
     }
 
     #[test]
@@ -22565,6 +22660,50 @@ mod tests {
     }
 
     #[test]
+    fn cell_update_refreshes_null_identity_for_filters_and_exports() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+        app.grid = GridModel::new(
+            vec!["left".to_string(), "right".to_string()],
+            vec![vec!["NULL".to_string(), "before".to_string()]],
+        )
+        .with_null_cells(vec![vec![true, false]]);
+
+        app.apply_db_event(DbEvent::CellUpdated {
+            row: 0,
+            col: 0,
+            value: "after".to_string(),
+            is_null: false,
+        });
+        app.apply_db_event(DbEvent::CellUpdated {
+            row: 0,
+            col: 1,
+            value: "NULL".to_string(),
+            is_null: true,
+        });
+
+        assert_eq!(app.grid.rows[0], ["after", "NULL"]);
+        assert_eq!(app.grid.null_cells[0], [false, true]);
+        app.grid_state.cursor_col = 0;
+        assert_eq!(
+            app.current_classic_filter_value(),
+            Some(FilterValue::Text("after".to_string()))
+        );
+        app.grid_state.cursor_col = 1;
+        assert_eq!(app.current_classic_filter_value(), Some(FilterValue::Null));
+        let json: serde_json::Value = serde_json::from_str(&app.grid.rows_as_json(&[0])).unwrap();
+        assert_eq!(json[0]["left"], "after");
+        assert!(json[0]["right"].is_null());
+        assert_eq!(
+            app.grid.rows_as_sql_inserts(&[0], "result"),
+            "INSERT INTO result (left, right) VALUES ('after', NULL);"
+        );
+    }
+
+    #[test]
     fn test_cell_editor_open_sets_cursor_at_end() {
         let mut editor = CellEditor::new();
         editor.open(0, 0, "hello".to_string());
@@ -24015,6 +24154,11 @@ mod tests {
             matches!(oid_like, Bson::String(ref s) if s == "507f1f77bcf86cd799439011"),
             "string-typed cells should not be coerced to ObjectId"
         );
+
+        let literal_null = parse_grid_cell_to_bson("NULL", Some("string"), true);
+        assert!(matches!(literal_null, Bson::String(ref s) if s == "NULL"));
+        let actual_null = parse_grid_cell_to_bson("NULL", Some("null"), true);
+        assert!(matches!(actual_null, Bson::Null));
     }
 
     #[test]

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -10925,15 +10925,17 @@ impl App {
     fn workspace_has_unsaved_changes(&self) -> bool {
         match self.workspace_mode {
             WorkspaceMode::Classic => self.editor.is_modified(),
-            WorkspaceMode::Notebook => {
-                self.notebook_document_dirty
-                    || self
-                        .notebook
-                        .cells
-                        .iter()
-                        .any(|cell| cell.is_dirty() || cell.editor.is_modified())
-            }
+            WorkspaceMode::Notebook => self.notebook_has_unsaved_changes(),
         }
+    }
+
+    fn notebook_has_unsaved_changes(&self) -> bool {
+        self.notebook_document_dirty
+            || self
+                .notebook
+                .cells
+                .iter()
+                .any(|cell| cell.is_dirty() || cell.editor.is_modified())
     }
 
     fn handle_notebook_key(&mut self, key: KeyEvent) {
@@ -11702,7 +11704,7 @@ impl App {
             return;
         }
         let path = expand_user_path(args);
-        if self.workspace_has_unsaved_changes() {
+        if self.workspace_has_unsaved_changes() || self.notebook_has_unsaved_changes() {
             self.confirm_prompt = Some(ConfirmPrompt::new(
                 format!(
                     "You have unsaved changes. Open notebook '{}' anyway?",
@@ -19345,6 +19347,56 @@ mod tests {
     }
 
     #[test]
+    fn notebook_json_export_preserves_loaded_and_selected_sql_nulls() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].output = Some(NotebookOutput {
+            grid: GridModel::new(
+                vec![
+                    "actual_null".to_string(),
+                    "literal_null".to_string(),
+                    "empty".to_string(),
+                ],
+                vec![
+                    vec!["value".to_string(), "NULL".to_string(), String::new()],
+                    vec!["NULL".to_string(), "NULL".to_string(), String::new()],
+                ],
+            )
+            .with_null_cells(vec![vec![false, false, false], vec![true, false, false]]),
+            ..notebook_test_output(2)
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let full_path = dir.path().join("full.json");
+        let selected_path = dir.path().join("selected.json");
+
+        app.handle_export_command(&format!("json {}", full_path.display()));
+        let full: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(full_path).unwrap()).unwrap();
+        assert_eq!(full[0]["actual_null"], "value");
+        assert!(full[1]["actual_null"].is_null());
+        assert_eq!(full[1]["literal_null"], "NULL");
+        assert_eq!(full[1]["empty"], "");
+
+        app.notebook.cells[0]
+            .output
+            .as_mut()
+            .unwrap()
+            .grid_state
+            .selected_rows
+            .insert(1);
+        app.handle_export_command(&format!("json {}", selected_path.display()));
+        let selected: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(selected_path).unwrap()).unwrap();
+        assert_eq!(selected.as_array().unwrap().len(), 1);
+        assert!(selected[0]["actual_null"].is_null());
+        assert_eq!(selected[0]["literal_null"], "NULL");
+        assert_eq!(selected[0]["empty"], "");
+    }
+
+    #[test]
     fn notebook_export_requires_live_snapshot_when_loaded_output_is_truncated() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -19917,6 +19969,46 @@ mod tests {
 
         assert_eq!(app.notebook.cells[0].source(), "SELECT 'keep me'");
         assert_eq!(app.last_status.as_deref(), Some("Notebook open cancelled"));
+    }
+
+    #[test]
+    fn opening_notebook_from_classic_prompts_for_unsaved_notebook_changes() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("other.json");
+        save_notebook_to_path(
+            &NotebookSession {
+                cells: vec![NotebookCellSession {
+                    cell_id: Some(1),
+                    source: "SELECT 'other'".to_string(),
+                    ..NotebookCellSession::default()
+                }],
+                selected_index: 0,
+            },
+            &path,
+        )
+        .unwrap();
+
+        for document_dirty in [false, true] {
+            let mut app = notebook_test_app(&runtime);
+            if document_dirty {
+                app.notebook_document_dirty = true;
+            } else {
+                app.notebook.cells[0].replace_source("SELECT 'keep me'".to_string());
+            }
+            app.switch_workspace(WorkspaceMode::Classic);
+
+            assert!(!app.workspace_has_unsaved_changes());
+            assert!(app.notebook_has_unsaved_changes());
+            assert!(!app.execute_command(&format!("open-notebook {}", path.display())));
+            assert!(matches!(
+                app.confirm_prompt.as_ref().map(ConfirmPrompt::context),
+                Some(ConfirmContext::OpenNotebook { path: pending }) if pending == &path
+            ));
+        }
     }
 
     fn notebook_buffer(app: &mut App, width: u16, height: u16) -> ratatui::buffer::Buffer {

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{self, Stdout};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -32,7 +33,8 @@ use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use tokio_postgres::{CancelToken, Client, NoTls, SimpleQueryMessage};
 use tokio_postgres_rustls_improved::MakeRustlsConnect;
-use tui_textarea::{CursorMove, Input};
+use tui_textarea::{CursorMove, Input, TextArea};
+use unicode_width::UnicodeWidthStr;
 use webpki_roots::TLS_SERVER_ROOTS;
 
 use super::execution::{
@@ -42,11 +44,21 @@ use super::execution::{
 use super::notebook::{
     CellExecutionState, NotebookCell, NotebookFocus, NotebookOutput, NotebookState,
 };
+use super::notebook_export::{self, NotebookExportFormat};
+use super::notebook_run::{
+    notebook_run_plan_with_names, notebook_run_plan_without_references, NotebookRunScope,
+};
 use super::pg_snapshot::{self, PgSnapshotRequest, PgTempSnapshot};
 use super::refinement::{
-    compile_logical_reference, logical_result_reference, LogicalResultReference,
-    RefinementAvailability, RefinementUnavailableReason, ResultVersion, RetainedResultHandle,
+    compile_logical_references_mapped, logical_result_reference, logical_result_references,
+    normalize_result_name, LogicalResultReference, RefinementAvailability,
+    RefinementUnavailableReason, ResultVersion, RetainedResultHandle, SqlSourceMap,
 };
+use super::result_transform::{
+    compile_result_transform, parse_filter_value, FilterOp, FilterValue, OrderDirection,
+    ResultFilter, ResultTransform,
+};
+use super::sql_lexer::{code_words, single_statement};
 use super::state::{
     DbStatus, Focus, Mode, PanelDirection, SearchTarget, SidebarSection, WorkspaceMode,
 };
@@ -55,30 +67,31 @@ use crate::config::{
     load_connections, save_connections, Action, ClipboardBackend, Config, ConnectionEntry,
     ConnectionsFile, DbKind, KeyBinding, Keymap, SnapshotMode, SslMode, UpdateMode,
 };
-use crate::history::{History, HistoryEntry};
+use crate::history::{History, HistoryEntry, SavedQuerySnippet};
 use crate::session::{
-    NotebookCellSession, NotebookDependencySession, NotebookSession, SessionState,
+    load_notebook_from_path, save_notebook_to_path, NotebookCellSession, NotebookDependencySession,
+    NotebookRunRecord, NotebookRunStatus, NotebookSession, SessionState,
 };
 use crate::ui::{
-    create_sql_highlighter, determine_context, escape_sql_value, get_word_before_cursor, is_inside,
-    load_theme, overlay_block, quote_identifier, zone_block, zone_inner, zone_label,
-    zone_scrollbar_area, AiQueryModal, AiQueryModalAction, ColumnInfo, CommandPrompt,
-    CompletionKind, CompletionPopup, ConfirmContext, ConfirmPrompt, ConfirmResult,
-    ConnectionFormAction, ConnectionFormModal, ConnectionInfo, ConnectionManagerAction,
-    ConnectionManagerModal, CursorShape, DataGrid, FuzzyPicker, GridKeyResult, GridModel,
-    GridState, GridViewport, HelpAction, HelpPopup, HighlightedTextArea, JsonEditorAction,
-    JsonEditorModal, KeyHintPopup, KeySequenceAction, KeySequenceCompletion,
-    KeySequenceHandlerWithContext, KeySequenceResult, PasswordPrompt, PasswordPromptResult,
-    PendingKey, PickerAction, Priority, QueryEditor, ResizeAction, RowDetailAction, RowDetailModal,
-    SchemaCache, SearchPrompt, Sidebar, SidebarAction, StatusLineBuilder, StatusSegment, TableInfo,
-    UiTheme, YankFormat,
+    action_entries, create_sql_highlighter, determine_context, escape_sql_value,
+    get_word_before_cursor, is_inside, load_theme, overlay_block, quote_identifier, zone_block,
+    zone_inner, zone_label, zone_scrollbar_area, ActionContext, ActionEntry, AiQueryModal,
+    AiQueryModalAction, ColumnInfo, CommandPrompt, CompletionKind, CompletionPopup, ConfirmContext,
+    ConfirmPrompt, ConfirmResult, ConnectionFormAction, ConnectionFormModal, ConnectionInfo,
+    ConnectionManagerAction, ConnectionManagerModal, CursorShape, DataGrid, FuzzyPicker,
+    GridKeyResult, GridModel, GridState, GridViewport, HelpAction, HelpPopup, HighlightedTextArea,
+    JsonEditorAction, JsonEditorModal, KeyHintPopup, KeySequenceAction, KeySequenceCompletion,
+    KeySequenceHandlerWithContext, KeySequenceResult, PaletteAction, PasswordPrompt,
+    PasswordPromptResult, PendingKey, PickerAction, Priority, QueryEditor, ResizeAction,
+    RowDetailAction, RowDetailModal, SchemaCache, SearchPrompt, Sidebar, SidebarAction,
+    StatusLineBuilder, StatusSegment, TableInfo, UiTheme, YankFormat,
 };
 use crate::update::{
     apply_update, check_for_update, current_target_triple, detect_current_install_method,
     upgrade_hint, ApplyResult, GitHubReleasesProvider, InstallMethod, UpdateCheckOutcome,
     UpdateInfo, UpdateState,
 };
-use crate::util::format_pg_error;
+use crate::util::{format_pg_error, format_pg_error_with_position, pg_error_cursor_position};
 use crate::util::{is_json_column_type, should_use_multiline_editor};
 use throbber_widgets_tui::{Throbber, ThrobberState, BRAILLE_SIX};
 use tui_syntax::Highlighter;
@@ -748,6 +761,8 @@ async fn fetch_column_types(
 pub struct QueryResult {
     pub headers: Vec<String>,
     pub rows: Vec<Vec<String>>,
+    /// Per-cell SQL NULL identity captured before values are rendered as text.
+    pub null_cells: Vec<Vec<bool>>,
     pub command_tag: Option<String>,
     pub truncated: bool,
     pub elapsed: Duration,
@@ -860,6 +875,214 @@ fn is_row_returning_query(query: &str) -> bool {
         || first.eq_ignore_ascii_case("table")
         || first.eq_ignore_ascii_case("show")
         || first.eq_ignore_ascii_case("explain")
+}
+
+fn cursor_fetch_query(page_size: usize, timeout_secs: u32, read_only: bool) -> String {
+    let fetch = format!("FETCH FORWARD {page_size} FROM tsql_cursor");
+    if timeout_secs == 0 && !read_only {
+        fetch
+    } else {
+        let begin = if read_only {
+            "BEGIN READ ONLY"
+        } else {
+            "BEGIN"
+        };
+        format!(
+            "{begin}; SET LOCAL statement_timeout = {}; {fetch}; COMMIT",
+            timeout_secs.saturating_mul(1_000)
+        )
+    }
+}
+
+async fn cursor_simple_query(
+    client: &Client,
+    query: &str,
+    timeout_secs: u32,
+    connected_with_tls: bool,
+) -> Result<Vec<SimpleQueryMessage>, String> {
+    if timeout_secs == 0 {
+        return client
+            .simple_query(query)
+            .await
+            .map_err(|error| format_pg_error(&error));
+    }
+    let token = client.cancel_token();
+    match tokio::time::timeout(
+        Duration::from_secs(u64::from(timeout_secs)),
+        client.simple_query(query),
+    )
+    .await
+    {
+        Ok(Ok(messages)) => Ok(messages),
+        Ok(Err(error)) => Err(format_pg_error(&error)),
+        Err(_) => {
+            if connected_with_tls {
+                let _ = token.cancel_query(make_rustls_connect_insecure()).await;
+            } else {
+                let _ = token.cancel_query(NoTls).await;
+            }
+            Err(format!("statement timeout after {timeout_secs}s"))
+        }
+    }
+}
+
+/// Adds a server-side preview boundary for a single, read-only notebook query.
+/// This keeps the simple-query path bounded even when snapshot retention is off.
+fn bounded_notebook_preview_query(query: &str, max_rows: usize) -> Option<String> {
+    if !pg_snapshot::is_snapshot_candidate(query) {
+        return None;
+    }
+    let source = super::sql_lexer::single_statement(query).ok()?;
+    let leading = &query[..query.len() - query.trim_start().len()];
+    Some(format!(
+        "SELECT * FROM (\n{leading}{source}\n) AS __tsql_notebook_preview LIMIT {}",
+        max_rows.saturating_add(1)
+    ))
+}
+
+struct StreamedSimpleQuery {
+    headers: Vec<String>,
+    rows: Vec<Vec<String>>,
+    null_cells: Vec<Vec<bool>>,
+    command_tag: Option<String>,
+    truncated: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct NotebookPageLoad {
+    cell_id: CellId,
+    version: ResultVersion,
+    handle: RetainedResultHandle,
+    connection_generation: u64,
+}
+
+const MAX_NOTEBOOK_DISPLAY_BYTES: usize = 8 * 1024 * 1024;
+
+fn notebook_display_byte_budget(snapshot_max_bytes: u64) -> usize {
+    usize::try_from(snapshot_max_bytes)
+        .unwrap_or(usize::MAX)
+        .min(MAX_NOTEBOOK_DISPLAY_BYTES)
+}
+
+fn bounded_cell_text(value: &str, max_bytes: usize) -> (String, bool) {
+    if value.len() <= max_bytes {
+        return (value.to_string(), false);
+    }
+    if max_bytes == 0 {
+        return (String::new(), true);
+    }
+    let suffix = "…";
+    let mut end = value.len().min(max_bytes.saturating_sub(suffix.len()));
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    if suffix.len() > max_bytes {
+        (value[..end].to_string(), true)
+    } else {
+        (format!("{}{suffix}", &value[..end]), true)
+    }
+}
+
+/// Streams simple-protocol messages with backpressure and retains only the
+/// configured row prefix. Unlike `simple_query`, this never buffers the full
+/// server response in the TUI process.
+async fn stream_simple_query(
+    client: &Client,
+    query: &str,
+    max_rows: usize,
+    max_bytes: usize,
+) -> Result<StreamedSimpleQuery, tokio_postgres::Error> {
+    let stream = client.simple_query_raw(query).await?;
+    tokio::pin!(stream);
+    let mut current_headers: Option<Vec<String>> = None;
+    let mut current_rows = Vec::new();
+    let mut current_null_cells = Vec::new();
+    let mut headers = Vec::new();
+    let mut rows = Vec::new();
+    let mut null_cells = Vec::new();
+    let mut command_tag = None;
+    let mut truncated = false;
+    let mut current_bytes = 0usize;
+
+    while let Some(message) = stream.try_next().await? {
+        match message {
+            SimpleQueryMessage::RowDescription(columns) => {
+                current_headers = Some(
+                    columns
+                        .iter()
+                        .map(|column| column.name().to_string())
+                        .collect(),
+                );
+                current_bytes = current_headers
+                    .as_ref()
+                    .map_or(0, |headers| headers.iter().map(String::len).sum());
+            }
+            SimpleQueryMessage::Row(row) => {
+                if current_headers.is_none() {
+                    current_headers = Some(
+                        row.columns()
+                            .iter()
+                            .map(|column| column.name().to_string())
+                            .collect(),
+                    );
+                    current_bytes = current_headers
+                        .as_ref()
+                        .map_or(0, |headers| headers.iter().map(String::len).sum());
+                }
+                if current_rows.len() < max_rows && current_bytes < max_bytes {
+                    let mut limited = false;
+                    let mut out_row = Vec::with_capacity(row.len());
+                    let mut null_row = Vec::with_capacity(row.len());
+                    for index in 0..row.len() {
+                        let remaining = max_bytes.saturating_sub(current_bytes);
+                        let cell = row.get(index);
+                        null_row.push(cell.is_none());
+                        let (value, was_limited) =
+                            bounded_cell_text(cell.unwrap_or("NULL"), remaining);
+                        current_bytes = current_bytes.saturating_add(value.len());
+                        limited |= was_limited;
+                        out_row.push(value);
+                    }
+                    current_rows.push(out_row);
+                    current_null_cells.push(null_row);
+                    truncated |= limited;
+                } else {
+                    truncated = true;
+                }
+            }
+            SimpleQueryMessage::CommandComplete(rows_affected) => {
+                let reported_rows = if current_headers.is_some() && rows_affected == 0 {
+                    current_rows.len() as u64
+                } else {
+                    rows_affected
+                };
+                command_tag = Some(format!("{reported_rows} rows"));
+                if let Some(current_headers) = current_headers.take() {
+                    headers = current_headers;
+                    rows = std::mem::take(&mut current_rows);
+                    null_cells = std::mem::take(&mut current_null_cells);
+                } else {
+                    current_rows.clear();
+                    current_null_cells.clear();
+                }
+                current_bytes = 0;
+            }
+            _ => {}
+        }
+    }
+    if let Some(current_headers) = current_headers.take() {
+        headers = current_headers;
+        rows = current_rows;
+        null_cells = current_null_cells;
+    }
+
+    Ok(StreamedSimpleQuery {
+        headers,
+        rows,
+        null_cells,
+        command_tag,
+        truncated,
+    })
 }
 
 /// Compute the query panel height from the main-column content height.
@@ -1301,6 +1524,12 @@ enum MongoQuery {
         collection: String,
         filter: Document,
     },
+}
+
+struct MongoQueryLimits {
+    max_rows: usize,
+    max_bytes: usize,
+    timeout_secs: u32,
 }
 
 fn json_value_to_bson(value: &serde_json::Value) -> std::result::Result<Bson, String> {
@@ -2098,6 +2327,7 @@ fn mongo_result_from_documents(
 ) -> QueryResult {
     if docs.is_empty() {
         return QueryResult {
+            null_cells: Vec::new(),
             headers: vec!["status".to_string()],
             rows: vec![vec!["No documents".to_string()]],
             command_tag: Some("0 rows".to_string()),
@@ -2120,13 +2350,18 @@ fn mongo_result_from_documents(
     }
 
     let mut rows = Vec::with_capacity(docs.len());
+    let mut null_cells = Vec::with_capacity(docs.len());
     for doc in &docs {
         let mut row = Vec::with_capacity(headers.len());
+        let mut null_row = Vec::with_capacity(headers.len());
         for header in &headers {
-            let value = doc.get(header).map(bson_to_grid_cell).unwrap_or_default();
+            let cell = doc.get(header);
+            null_row.push(cell.is_none_or(|value| matches!(value, Bson::Null)));
+            let value = cell.map(bson_to_grid_cell).unwrap_or_default();
             row.push(value);
         }
         rows.push(row);
+        null_cells.push(null_row);
     }
 
     let mut type_map: HashMap<String, String> = HashMap::new();
@@ -2150,6 +2385,7 @@ fn mongo_result_from_documents(
     };
 
     QueryResult {
+        null_cells,
         command_tag: Some(format!("{} rows", rows.len())),
         headers,
         rows,
@@ -2159,6 +2395,26 @@ fn mongo_result_from_documents(
         primary_keys,
         col_types,
     }
+}
+
+fn push_bounded_mongo_document(
+    documents: &mut Vec<Document>,
+    document: Document,
+    used_bytes: &mut usize,
+    max_rows: usize,
+    max_bytes: usize,
+) -> bool {
+    if documents.len() >= max_rows {
+        return false;
+    }
+    let document_bytes = bson::to_vec(&document).map_or(usize::MAX, |bytes| bytes.len());
+    let next = used_bytes.saturating_add(document_bytes);
+    if next > max_bytes {
+        return false;
+    }
+    *used_bytes = next;
+    documents.push(document);
+    true
 }
 
 pub type SharedClient = Arc<Mutex<Client>>;
@@ -2200,7 +2456,49 @@ pub enum DbEvent {
         context: ExecutionContext,
         error: String,
     },
-    QueryCancelled,
+    /// Additional rows fetched from a retained notebook result.
+    NotebookRowsAppended {
+        cell_id: CellId,
+        version: ResultVersion,
+        handle: RetainedResultHandle,
+        connection_generation: u64,
+        offset: usize,
+        rows: Vec<Vec<String>>,
+        null_cells: Vec<Vec<bool>>,
+        truncated_by_bytes: bool,
+    },
+    NotebookRowsError {
+        cell_id: CellId,
+        version: ResultVersion,
+        handle: RetainedResultHandle,
+        connection_generation: u64,
+        error: String,
+    },
+    NotebookExportFinished {
+        cell_id: CellId,
+        version: ResultVersion,
+        handle: RetainedResultHandle,
+        connection_generation: u64,
+        rows: usize,
+        path: std::path::PathBuf,
+        format: String,
+    },
+    NotebookExportError {
+        cell_id: CellId,
+        version: ResultVersion,
+        handle: RetainedResultHandle,
+        connection_generation: u64,
+        error: String,
+    },
+    /// A Classic execution event tagged with its immutable execution identity.
+    ClassicExecution {
+        context: ExecutionContext,
+        event: Box<DbEvent>,
+    },
+    QueryCancelled {
+        context: Option<ExecutionContext>,
+        connection_generation: u64,
+    },
     SchemaLoaded {
         tables: Vec<TableInfo>,
         source_database: Option<String>,
@@ -2224,6 +2522,8 @@ pub enum DbEvent {
     RowsAppended {
         /// The new rows to append.
         rows: Vec<Vec<String>>,
+        /// The SQL NULL identity for the appended rows.
+        null_cells: Vec<Vec<bool>>,
         /// Whether this is the final batch (no more rows available).
         done: bool,
         /// Whether fetching was truncated due to max_rows limit.
@@ -2513,6 +2813,9 @@ pub struct App {
     /// Diagnostics produced while constructing the application.
     startup_warnings: Vec<String>,
 
+    /// Use simple disclosure and rail glyphs for ASCII-only terminals.
+    notebook_ascii: bool,
+
     /// Keymap for grid navigation
     pub grid_keymap: Keymap,
     /// Keymap for Notebook Cell focus.
@@ -2552,14 +2855,38 @@ pub struct App {
     pub paged_query: Option<PagedQueryState>,
     /// Last editor query dispatched on the current database connection.
     last_executed_query: Option<String>,
+    /// Original Classic query used as the stable source for result transformations.
+    classic_result_base_query: Option<String>,
+    /// Column names from the untransformed Classic result.
+    classic_result_base_headers: Vec<String>,
+    /// Database-side operations applied to the current Classic result.
+    classic_result_transform: ResultTransform,
+    /// Operations that produced the rows currently displayed in the Classic grid.
+    classic_result_applied_transform: ResultTransform,
     /// How the active editor query was started, used when applying its result.
     active_query_kind: Option<QueryExecutionKind>,
     active_execution: Option<ActiveExecution>,
+    active_classic_execution: Option<ExecutionContext>,
+    active_notebook_sql: Option<String>,
+    active_notebook_cancelled: Option<Arc<AtomicBool>>,
     next_execution_id: u64,
     next_retained_handle: u64,
     pg_snapshots: HashMap<RetainedResultHandle, PgTempSnapshot>,
     retained_versions: HashMap<super::refinement::ResultVersion, RetainedResultHandle>,
     pg_snapshot_order: VecDeque<RetainedResultHandle>,
+    pg_snapshot_lru: VecDeque<RetainedResultHandle>,
+    evicted_versions: HashSet<ResultVersion>,
+    notebook_page_loading: Option<NotebookPageLoad>,
+    notebook_page_to_end: bool,
+    notebook_page_cancelled: Option<Arc<AtomicBool>>,
+    notebook_export_loading: Option<NotebookPageLoad>,
+    notebook_export_cancelled: Option<Arc<AtomicBool>>,
+    notebook_run_queue: VecDeque<CellId>,
+    notebook_run_total: usize,
+    notebook_run_rebind_sources: HashSet<CellId>,
+    notebook_document_path: Option<std::path::PathBuf>,
+    notebook_document_dirty: bool,
+    notebook_activity: VecDeque<NotebookActivity>,
 
     pub grid: GridModel,
     pub grid_state: GridState,
@@ -2594,6 +2921,11 @@ pub struct App {
     pub history_picker: Option<FuzzyPicker<HistoryEntry>>,
     /// When true, the history picker shows only pinned entries.
     history_picker_pinned_only: bool,
+    pub snippet_picker: Option<FuzzyPicker<SavedQuerySnippet>>,
+    pub cell_history_picker: Option<FuzzyPicker<NotebookRunRecord>>,
+    pub action_palette: Option<FuzzyPicker<ActionEntry>>,
+    result_columns_picker: Option<FuzzyPicker<ResultColumnEntry>>,
+    result_columns_draft: Vec<usize>,
 
     /// Last rendered area for query editor (for mouse click handling).
     render_query_area: Option<Rect>,
@@ -2677,6 +3009,27 @@ struct GridCellClick {
     col: usize,
 }
 
+#[derive(Clone, Debug)]
+struct ResultColumnEntry {
+    ordinal: usize,
+    name: String,
+    selected_position: Option<usize>,
+}
+
+impl ResultColumnEntry {
+    fn display(&self) -> String {
+        let marker = self.selected_position.map_or_else(
+            || "[ ]".to_string(),
+            |position| format!("[{}]", position.saturating_add(1)),
+        );
+        format!(
+            "{marker} #{}  {}",
+            self.ordinal.saturating_add(1),
+            self.name
+        )
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 struct NotebookCellRenderArea {
     cell_id: CellId,
@@ -2685,6 +3038,12 @@ struct NotebookCellRenderArea {
     output: Option<Rect>,
     grid: Option<Rect>,
     compact: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct NotebookActivity {
+    cell_id: CellId,
+    failed: bool,
 }
 
 /// Local enum to track cursor style changes (SetCursorStyle doesn't implement PartialEq).
@@ -2698,6 +3057,7 @@ enum CachedCursorStyle {
 struct WorkspaceLayoutSnapshot {
     focus: Focus,
     mode: Mode,
+    notebook_focus: NotebookFocus,
     sidebar_visible: bool,
     sidebar_focus: SidebarSection,
 }
@@ -2788,6 +3148,7 @@ impl App {
             config,
             ui_theme,
             startup_warnings: theme_warning.into_iter().collect(),
+            notebook_ascii: notebook_ascii_fallback(),
 
             grid_keymap,
             notebook_keymap,
@@ -2816,13 +3177,33 @@ impl App {
             db: DbSession::new(),
             paged_query: None,
             last_executed_query: None,
+            classic_result_base_query: None,
+            classic_result_base_headers: Vec::new(),
+            classic_result_transform: ResultTransform::default(),
+            classic_result_applied_transform: ResultTransform::default(),
             active_query_kind: None,
             active_execution: None,
+            active_classic_execution: None,
+            active_notebook_sql: None,
+            active_notebook_cancelled: None,
             next_execution_id: 1,
             next_retained_handle: 1,
             pg_snapshots: HashMap::new(),
             retained_versions: HashMap::new(),
             pg_snapshot_order: VecDeque::new(),
+            pg_snapshot_lru: VecDeque::new(),
+            evicted_versions: HashSet::new(),
+            notebook_page_loading: None,
+            notebook_page_to_end: false,
+            notebook_page_cancelled: None,
+            notebook_export_loading: None,
+            notebook_export_cancelled: None,
+            notebook_run_queue: VecDeque::new(),
+            notebook_run_total: 0,
+            notebook_run_rebind_sources: HashSet::new(),
+            notebook_document_path: None,
+            notebook_document_dirty: false,
+            notebook_activity: VecDeque::new(),
 
             grid,
             grid_state: GridState::default(),
@@ -2843,6 +3224,11 @@ impl App {
             history,
             history_picker: None,
             history_picker_pinned_only: false,
+            snippet_picker: None,
+            cell_history_picker: None,
+            action_palette: None,
+            result_columns_picker: None,
+            result_columns_draft: Vec::new(),
 
             render_query_area: None,
             render_grid_area: None,
@@ -2950,13 +3336,25 @@ impl App {
                     .iter()
                     .map(|cell| NotebookCellSession {
                         cell_id: Some(cell.id.0),
+                        result_name: cell.result_name.clone(),
                         source: cell.source(),
+                        source_collapsed: cell.source_collapsed,
                         output_collapsed: cell.output_collapsed,
                         dependency: cell.dependency.map(|version| NotebookDependencySession {
                             source_cell_id: version.source_cell.0,
                             source_execution_id: version.source_execution.0,
                             source_revision: version.source_revision,
                         }),
+                        additional_dependencies: cell
+                            .additional_dependencies
+                            .iter()
+                            .map(|version| NotebookDependencySession {
+                                source_cell_id: version.source_cell.0,
+                                source_execution_id: version.source_execution.0,
+                                source_revision: version.source_revision,
+                            })
+                            .collect(),
+                        execution_history: cell.execution_history.clone(),
                     })
                     .collect(),
                 selected_index: self.notebook.selected_index(),
@@ -2980,7 +3378,7 @@ impl App {
 
         // Restore sidebar visibility
         self.sidebar_visible = state.sidebar_visible;
-        self.notebook = NotebookState::from_sources_with_ids(
+        self.notebook = NotebookState::from_sources_with_dependencies(
             state
                 .notebook
                 .cells
@@ -2988,7 +3386,9 @@ impl App {
                 .map(|cell| {
                     (
                         cell.cell_id.map(super::execution::CellId),
+                        cell.result_name,
                         cell.source,
+                        cell.source_collapsed,
                         cell.output_collapsed,
                         cell.dependency
                             .map(|dependency| super::refinement::ResultVersion {
@@ -2998,11 +3398,23 @@ impl App {
                                 ),
                                 source_revision: dependency.source_revision,
                             }),
+                        cell.additional_dependencies
+                            .into_iter()
+                            .map(|dependency| super::refinement::ResultVersion {
+                                source_cell: super::execution::CellId(dependency.source_cell_id),
+                                source_execution: super::execution::ExecutionId(
+                                    dependency.source_execution_id,
+                                ),
+                                source_revision: dependency.source_revision,
+                            })
+                            .collect(),
+                        cell.execution_history,
                     )
                 })
                 .collect(),
             state.notebook.selected_index,
         );
+        self.notebook_document_dirty = false;
         if state.workspace == "notebook" {
             self.workspace_mode = WorkspaceMode::Notebook;
             self.focus = Focus::Notebook;
@@ -3147,18 +3559,20 @@ impl App {
                 self.maybe_start_scheduled_update_check();
             }
 
-            // Pre-compute highlighted lines before the draw closure
-            let query_text = self.editor.text();
-            let highlighted_lines = self
-                .highlighter
-                .highlight("sql", &query_text)
-                .unwrap_or_else(|_| {
-                    // Fallback to plain text if highlighting fails
-                    query_text
-                        .lines()
-                        .map(|s| Line::from(s.to_string()))
-                        .collect()
-                });
+            // The Classic editor can be very large; do not highlight it behind Notebook mode.
+            let highlighted_lines = if self.workspace_mode == WorkspaceMode::Classic {
+                let query_text = self.editor.text();
+                self.highlighter
+                    .highlight("sql", &query_text)
+                    .unwrap_or_else(|_| {
+                        query_text
+                            .lines()
+                            .map(|line| Line::from(line.to_string()))
+                            .collect()
+                    })
+            } else {
+                Vec::new()
+            };
 
             // Compute hint visibility once per tick to avoid time-based state
             // flipping between calls during the same render cycle.
@@ -3186,15 +3600,16 @@ impl App {
                 let size = frame.area();
                 let results_maximized = self.maximized_results_restore.is_some();
                 let sidebar_visible = self.sidebar_visible && !results_maximized;
-                let query_height = if results_maximized {
-                    0
-                } else {
-                    compute_query_panel_height(
-                        size.height.saturating_sub(STATUS_HEIGHT),
-                        self.mode,
-                        self.editor.textarea.lines().len(),
-                    )
-                };
+                let query_height =
+                    if results_maximized || self.workspace_mode == WorkspaceMode::Notebook {
+                        0
+                    } else {
+                        compute_query_panel_height(
+                            size.height.saturating_sub(STATUS_HEIGHT),
+                            self.mode,
+                            self.editor.textarea.lines().len(),
+                        )
+                    };
                 let areas = compute_workspace_areas(
                     size,
                     if sidebar_visible {
@@ -3234,6 +3649,7 @@ impl App {
                         &self.connections,
                         self.current_connection_name.as_deref(),
                         &schema_items,
+                        self.db.status == DbStatus::Connected,
                         !self.schema_cache.loaded && self.db.status == DbStatus::Connected,
                         None, // No error handling yet
                         self.sidebar_focus,
@@ -3244,228 +3660,243 @@ impl App {
                     self.render_sidebar_area = None;
                 }
 
-                // Store rendered areas for mouse click handling
-                self.render_query_area = (!results_maximized).then_some(areas.query);
-                self.render_grid_area = Some(areas.grid);
+                if self.workspace_mode == WorkspaceMode::Classic {
+                    // Store rendered areas for mouse click handling.
+                    self.render_query_area = (!results_maximized).then_some(areas.query);
+                    self.render_grid_area = Some(areas.grid);
 
-                // Query editor with syntax highlighting
-                let query_focused = self.focus == Focus::Query;
-                let query_accent = self.ui_theme.mode_accent(self.mode);
-                let mut query_details = Vec::with_capacity(2);
-                if query_focused {
-                    query_details.push(Span::styled(
-                        format!(" [{}]", self.mode.label()),
-                        self.ui_theme.label_focused.fg(query_accent),
-                    ));
-                }
-                if self.workspace_has_unsaved_changes() {
-                    query_details.push(Span::styled(" [+]", self.ui_theme.warning));
-                }
-                let query_block = zone_block(
-                    zone_label(
-                        "QUERY",
-                        query_details,
+                    // Query editor with syntax highlighting
+                    let query_focused = self.focus == Focus::Query;
+                    let query_accent = self.ui_theme.mode_accent(self.mode);
+                    let mut query_details = Vec::with_capacity(2);
+                    if query_focused {
+                        query_details.push(Span::styled(
+                            format!(" [{}]", self.mode.label()),
+                            self.ui_theme.label_focused.fg(query_accent),
+                        ));
+                    }
+                    if self.workspace_has_unsaved_changes() {
+                        query_details.push(Span::styled(" [+]", self.ui_theme.warning));
+                    }
+                    let query_block = zone_block(
+                        zone_label(
+                            "QUERY",
+                            query_details,
+                            query_focused,
+                            query_accent,
+                            &self.ui_theme,
+                        ),
+                        self.ui_theme.bg_elevated,
+                        self.ui_theme.text,
                         query_focused,
                         query_accent,
-                        &self.ui_theme,
-                    ),
-                    self.ui_theme.bg_elevated,
-                    self.ui_theme.text,
-                    query_focused,
-                    query_accent,
-                );
-
-                // Choose cursor shape based on vim mode
-                let cursor_shape = match self.mode {
-                    Mode::Normal | Mode::Visual => CursorShape::Block,
-                    Mode::Insert => CursorShape::Bar,
-                };
-
-                let is_editor_focused = matches!(self.focus, Focus::Query);
-                let highlighted_editor =
-                    HighlightedTextArea::new(&self.editor.textarea, highlighted_lines.clone())
-                        .block(query_block.clone())
-                        .cursor_style(self.ui_theme.editor_cursor)
-                        .selection_style(self.ui_theme.editor_selection)
-                        .scroll(self.editor_scroll)
-                        .show_cursor(is_editor_focused)
-                        .cursor_shape(cursor_shape);
-
-                // Get cursor screen position before rendering (for Bar/Underline cursors)
-                let cursor_pos = (!results_maximized)
-                    .then(|| highlighted_editor.cursor_screen_position(areas.query))
-                    .flatten();
-
-                if !results_maximized {
-                    frame.render_widget(highlighted_editor, areas.query);
-                }
-
-                // For Bar/Underline cursor shapes, use the terminal's native cursor
-                if !results_maximized && is_editor_focused && cursor_shape != CursorShape::Block {
-                    if let Some(pos) = cursor_pos {
-                        frame.set_cursor_position(pos);
-                    }
-                }
-
-                // Update editor scroll based on cursor position
-                let query_inner = query_block.inner(areas.query);
-                let inner_height = query_inner.height as usize;
-                let inner_width = query_inner.width as usize;
-                let (cursor_row, cursor_col) = self.editor.textarea.cursor();
-                if !results_maximized {
-                    self.editor_scroll = calculate_editor_scroll(
-                        cursor_row,
-                        cursor_col,
-                        self.editor_scroll,
-                        inner_height,
-                        inner_width,
                     );
-                }
 
-                // Render scrollbar for query editor if content exceeds visible area
-                let total_lines = self.editor.textarea.lines().len();
-                if !results_maximized && total_lines > inner_height && inner_height > 0 {
-                    let scrollbar_area = zone_scrollbar_area(areas.query);
-
-                    let scrollbar = if scrollbar_area.height >= 7 {
-                        Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                            .begin_symbol(Some("▲"))
-                            .end_symbol(Some("▼"))
-                            .thumb_symbol("█")
-                            .track_symbol(Some("░"))
-                            .style(self.ui_theme.scrollbar)
-                    } else {
-                        Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                            .begin_symbol(None)
-                            .end_symbol(None)
-                            .thumb_symbol("█")
-                            .track_symbol(Some("│"))
-                            .style(self.ui_theme.scrollbar)
+                    // Choose cursor shape based on vim mode
+                    let cursor_shape = match self.mode {
+                        Mode::Normal | Mode::Visual => CursorShape::Block,
+                        Mode::Insert => CursorShape::Bar,
                     };
 
-                    let mut scrollbar_state =
-                        ScrollbarState::new(total_lines).position(self.editor_scroll.0 as usize);
+                    let is_editor_focused = matches!(self.focus, Focus::Query);
+                    let highlighted_editor =
+                        HighlightedTextArea::new(&self.editor.textarea, highlighted_lines.clone())
+                            .block(query_block.clone())
+                            .cursor_style(self.ui_theme.editor_cursor)
+                            .selection_style(self.ui_theme.editor_selection)
+                            .scroll(self.editor_scroll)
+                            .show_cursor(is_editor_focused)
+                            .cursor_shape(cursor_shape);
 
-                    frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
-                }
+                    // Get cursor screen position before rendering (for Bar/Underline cursors)
+                    let cursor_pos = (!results_maximized)
+                        .then(|| highlighted_editor.cursor_screen_position(areas.query))
+                        .flatten();
 
-                // Calculate grid viewport dimensions for scroll handling
-                // Inner area: shared tonal-zone content rectangle
-                // Body area: inner minus header row (1)
-                // Data width: inner width minus marker column (3)
-                let grid_inner = zone_inner(areas.grid);
-                let body_height = grid_inner.height.saturating_sub(1); // minus header
-                let data_width = grid_inner.width.saturating_sub(3); // minus marker column
+                    if !results_maximized {
+                        frame.render_widget(highlighted_editor, areas.query);
+                    }
 
-                // Update grid state scroll position based on viewport
-                self.grid_state.ensure_cursor_visible(
-                    body_height as usize,
-                    self.grid.rows.len(),
-                    self.grid.headers.len(),
-                    &self.grid.col_widths,
-                    data_width,
-                );
+                    // For Bar/Underline cursor shapes, use the terminal's native cursor
+                    if !results_maximized && is_editor_focused && cursor_shape != CursorShape::Block
+                    {
+                        if let Some(pos) = cursor_pos {
+                            frame.set_cursor_position(pos);
+                        }
+                    }
 
-                // Store viewport dimensions for potential future use
-                self.last_grid_viewport = Some((body_height as usize, data_width));
+                    // Update editor scroll based on cursor position
+                    let query_inner = query_block.inner(areas.query);
+                    let inner_height = query_inner.height as usize;
+                    let inner_width = query_inner.width as usize;
+                    let (cursor_row, cursor_col) = self.editor.textarea.cursor();
+                    if !results_maximized {
+                        self.editor_scroll = calculate_editor_scroll(
+                            cursor_row,
+                            cursor_col,
+                            self.editor_scroll,
+                            inner_height,
+                            inner_width,
+                        );
+                    }
 
-                // Results grid.
-                let grid_focused = self.focus == Focus::Grid;
-                let mut grid_details = vec![Span::styled(
-                    format!(" · {} rows", self.grid.rows.len()),
-                    self.ui_theme.text_muted,
-                )];
-                if let Some(elapsed) = self.db.last_elapsed {
-                    grid_details.push(Span::styled(
-                        format!(" · {}ms", elapsed.as_millis()),
+                    // Render scrollbar for query editor if content exceeds visible area
+                    let total_lines = self.editor.textarea.lines().len();
+                    if !results_maximized && total_lines > inner_height && inner_height > 0 {
+                        let scrollbar_area = zone_scrollbar_area(areas.query);
+
+                        let scrollbar = if scrollbar_area.height >= 7 {
+                            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                                .begin_symbol(Some("▲"))
+                                .end_symbol(Some("▼"))
+                                .thumb_symbol("█")
+                                .track_symbol(Some("░"))
+                                .style(self.ui_theme.scrollbar)
+                        } else {
+                            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                                .begin_symbol(None)
+                                .end_symbol(None)
+                                .thumb_symbol("█")
+                                .track_symbol(Some("│"))
+                                .style(self.ui_theme.scrollbar)
+                        };
+
+                        let mut scrollbar_state = ScrollbarState::new(total_lines)
+                            .position(self.editor_scroll.0 as usize);
+
+                        frame.render_stateful_widget(
+                            scrollbar,
+                            scrollbar_area,
+                            &mut scrollbar_state,
+                        );
+                    }
+
+                    // Calculate grid viewport dimensions for scroll handling
+                    // Inner area: shared tonal-zone content rectangle
+                    // Body area: inner minus header row (1)
+                    // Data width: inner width minus marker column (3)
+                    let grid_inner = zone_inner(areas.grid);
+                    let body_height = grid_inner.height.saturating_sub(1); // minus header
+                    let data_width = grid_inner.width.saturating_sub(3); // minus marker column
+
+                    // Update grid state scroll position based on viewport
+                    self.grid_state.ensure_cursor_visible(
+                        body_height as usize,
+                        self.grid.rows.len(),
+                        self.grid.headers.len(),
+                        &self.grid.col_widths,
+                        data_width,
+                    );
+
+                    // Store viewport dimensions for potential future use
+                    self.last_grid_viewport = Some((body_height as usize, data_width));
+
+                    // Results grid.
+                    let grid_focused = self.focus == Focus::Grid;
+                    let mut grid_details = vec![Span::styled(
+                        format!(" · {} rows", self.grid.rows.len()),
                         self.ui_theme.text_muted,
-                    ));
-                }
-                if let Some(search_info) = self.grid_state.search.match_info() {
-                    grid_details.push(Span::styled(
-                        format!(" · {search_info}"),
-                        self.ui_theme.warning,
-                    ));
-                }
-                let grid_widget = DataGrid {
-                    model: &self.grid,
-                    state: &self.grid_state,
-                    label: zone_label(
-                        "RESULTS",
-                        grid_details,
-                        grid_focused,
-                        self.ui_theme.accent,
-                        &self.ui_theme,
-                    ),
-                    theme: &self.ui_theme,
-                    focused: grid_focused,
-                    show_row_numbers: self.config.display.show_row_numbers,
-                    show_scrollbar: true,
-                };
-                frame.render_widget(grid_widget, areas.grid);
-
-                // Loading overlay when query is running (only if grid area is large enough)
-                if self.db.running && areas.grid.width >= 20 && areas.grid.height >= 5 {
-                    // Calculate centered overlay area (40% width, minimum 20 chars, 5 lines height)
-                    let overlay_width = (areas.grid.width * 40 / 100).max(20).min(areas.grid.width);
-                    let overlay_height = 5u16.min(areas.grid.height);
-                    let overlay_x =
-                        areas.grid.x + (areas.grid.width.saturating_sub(overlay_width)) / 2;
-                    let overlay_y =
-                        areas.grid.y + (areas.grid.height.saturating_sub(overlay_height)) / 2;
-                    let overlay_area = Rect {
-                        x: overlay_x,
-                        y: overlay_y,
-                        width: overlay_width,
-                        height: overlay_height,
-                    };
-
-                    // Clear the overlay area
-                    frame.render_widget(Clear, overlay_area);
-
-                    let block = overlay_block("", &self.ui_theme);
-
-                    let inner = block.inner(overlay_area);
-                    frame.render_widget(block, overlay_area);
-
-                    // Layout for spinner and elapsed time
-                    let chunks = Layout::default()
-                        .direction(Direction::Vertical)
-                        .constraints([
-                            Constraint::Length(1), // Spinner with label
-                            Constraint::Length(1), // Elapsed time
-                        ])
-                        .split(inner);
-
-                    // Render spinner with label
-                    let throbber = Throbber::default()
-                        .label(" Executing...")
-                        .style(Style::default().fg(self.ui_theme.text))
-                        .throbber_style(
-                            Style::default()
-                                .fg(self.ui_theme.accent)
-                                .add_modifier(Modifier::BOLD),
-                        )
-                        .throbber_set(BRAILLE_SIX);
-
-                    frame.render_stateful_widget(
-                        throbber,
-                        chunks[0],
-                        &mut self.query_ui.throbber_state,
-                    );
-
-                    // Render elapsed time
-                    if let Some(start_time) = self.query_ui.start_time {
-                        let elapsed = start_time.elapsed();
-                        let elapsed_text = format!("{:.1}s elapsed", elapsed.as_secs_f64());
-                        let elapsed_widget = Paragraph::new(elapsed_text)
-                            .style(Style::default().fg(self.ui_theme.text_muted))
-                            .alignment(Alignment::Center);
-                        frame.render_widget(elapsed_widget, chunks[1]);
+                    )];
+                    if let Some(elapsed) = self.db.last_elapsed {
+                        grid_details.push(Span::styled(
+                            format!(" · {}ms", elapsed.as_millis()),
+                            self.ui_theme.text_muted,
+                        ));
                     }
-                }
+                    if let Some(search_info) = self.grid_state.search.match_info() {
+                        grid_details.push(Span::styled(
+                            format!(" · {search_info}"),
+                            self.ui_theme.warning,
+                        ));
+                    }
+                    if !self.classic_result_applied_transform.is_empty() {
+                        let summary = self
+                            .classic_result_applied_transform
+                            .summary(&self.classic_result_base_headers);
+                        if !summary.is_empty() {
+                            grid_details
+                                .push(Span::styled(format!(" · {summary}"), self.ui_theme.warning));
+                        }
+                    }
+                    let grid_widget = DataGrid {
+                        model: &self.grid,
+                        state: &self.grid_state,
+                        label: zone_label(
+                            "RESULTS",
+                            grid_details,
+                            grid_focused,
+                            self.ui_theme.accent,
+                            &self.ui_theme,
+                        ),
+                        theme: &self.ui_theme,
+                        focused: grid_focused,
+                        show_row_numbers: self.config.display.show_row_numbers,
+                        show_scrollbar: true,
+                    };
+                    frame.render_widget(grid_widget, areas.grid);
 
-                if self.workspace_mode == WorkspaceMode::Notebook {
+                    // Loading overlay when query is running (only if grid area is large enough)
+                    if self.db.running && areas.grid.width >= 20 && areas.grid.height >= 5 {
+                        // Calculate centered overlay area (40% width, minimum 20 chars, 5 lines height)
+                        let overlay_width =
+                            (areas.grid.width * 40 / 100).max(20).min(areas.grid.width);
+                        let overlay_height = 5u16.min(areas.grid.height);
+                        let overlay_x =
+                            areas.grid.x + (areas.grid.width.saturating_sub(overlay_width)) / 2;
+                        let overlay_y =
+                            areas.grid.y + (areas.grid.height.saturating_sub(overlay_height)) / 2;
+                        let overlay_area = Rect {
+                            x: overlay_x,
+                            y: overlay_y,
+                            width: overlay_width,
+                            height: overlay_height,
+                        };
+
+                        // Clear the overlay area
+                        frame.render_widget(Clear, overlay_area);
+
+                        let block = overlay_block("", &self.ui_theme);
+
+                        let inner = block.inner(overlay_area);
+                        frame.render_widget(block, overlay_area);
+
+                        // Layout for spinner and elapsed time
+                        let chunks = Layout::default()
+                            .direction(Direction::Vertical)
+                            .constraints([
+                                Constraint::Length(1), // Spinner with label
+                                Constraint::Length(1), // Elapsed time
+                            ])
+                            .split(inner);
+
+                        // Render spinner with label
+                        let throbber = Throbber::default()
+                            .label(" Executing...")
+                            .style(Style::default().fg(self.ui_theme.text))
+                            .throbber_style(
+                                Style::default()
+                                    .fg(self.ui_theme.accent)
+                                    .add_modifier(Modifier::BOLD),
+                            )
+                            .throbber_set(BRAILLE_SIX);
+
+                        frame.render_stateful_widget(
+                            throbber,
+                            chunks[0],
+                            &mut self.query_ui.throbber_state,
+                        );
+
+                        // Render elapsed time
+                        if let Some(start_time) = self.query_ui.start_time {
+                            let elapsed = start_time.elapsed();
+                            let elapsed_text = format!("{:.1}s elapsed", elapsed.as_secs_f64());
+                            let elapsed_widget = Paragraph::new(elapsed_text)
+                                .style(Style::default().fg(self.ui_theme.text_muted))
+                                .alignment(Alignment::Center);
+                            frame.render_widget(elapsed_widget, chunks[1]);
+                        }
+                    }
+                } else {
                     self.render_notebook_workspace(frame, main_area);
                 }
 
@@ -3478,6 +3909,22 @@ impl App {
 
                 // Render history picker if open
                 if let Some(ref mut picker) = self.history_picker {
+                    picker.render(frame, size, &self.ui_theme);
+                }
+
+                if let Some(ref mut picker) = self.snippet_picker {
+                    picker.render(frame, size, &self.ui_theme);
+                }
+
+                if let Some(ref mut picker) = self.cell_history_picker {
+                    picker.render(frame, size, &self.ui_theme);
+                }
+
+                if let Some(ref mut picker) = self.action_palette {
+                    picker.render(frame, size, &self.ui_theme);
+                }
+
+                if let Some(ref mut picker) = self.result_columns_picker {
                     picker.render(frame, size, &self.ui_theme);
                 }
 
@@ -3545,16 +3992,47 @@ impl App {
 
                     if !visible.is_empty() {
                         // Position popup near the cursor
-                        let (cursor_row, cursor_col) = self.editor.textarea.cursor();
-                        let query_inner = zone_inner(areas.query);
-                        let popup_y = query_inner.y + cursor_row as u16;
-                        let popup_x = query_inner.x
+                        let (cursor_row, cursor_col, editor_area) =
+                            if self.workspace_mode == WorkspaceMode::Notebook {
+                                let cell = self.notebook.selected_cell();
+                                let (row, col) = cell.editor.textarea.cursor();
+                                let area = self
+                                    .render_notebook_cells
+                                    .iter()
+                                    .find(|area| area.cell_id == cell.id)
+                                    .map_or(areas.query, |area| area.composer);
+                                (row, col, area)
+                            } else {
+                                let (row, col) = self.editor.textarea.cursor();
+                                (row, col, zone_inner(areas.query))
+                            };
+                        let popup_y = editor_area
+                            .y
+                            .saturating_add(cursor_row as u16)
+                            .saturating_add(u16::from(
+                                self.workspace_mode == WorkspaceMode::Notebook,
+                            ));
+                        let popup_x = editor_area.x
                             + cursor_col.saturating_sub(self.completion.prefix.len()) as u16;
 
                         let popup_height = (visible.len() + 2) as u16; // +2 for borders
-                        let base_width = 40u16;
-                        let popup_width = (base_width + if needs_scrollbar { 1 } else { 0 })
-                            .min(size.width.saturating_sub(popup_x));
+                        let content_width = visible
+                            .iter()
+                            .map(|(_, item)| {
+                                2 + item.label.width()
+                                    + item
+                                        .detail
+                                        .as_deref()
+                                        .map_or(0, |detail| 2 + detail.width())
+                            })
+                            .max()
+                            .unwrap_or(0)
+                            .max("Completions (Tab select, Esc cancel)".width());
+                        let popup_width = u16::try_from(content_width.saturating_add(2))
+                            .unwrap_or(u16::MAX)
+                            .saturating_add(u16::from(needs_scrollbar))
+                            .clamp(40, 100)
+                            .min(size.width);
 
                         // Make sure popup fits on screen
                         let popup_y = if popup_y + popup_height > size.height {
@@ -3579,6 +4057,7 @@ impl App {
                                     CompletionKind::Keyword => "K",
                                     CompletionKind::Table => "T",
                                     CompletionKind::Column => "C",
+                                    CompletionKind::Result => "R",
                                     CompletionKind::Schema => "S",
                                     CompletionKind::Function => "F",
                                 };
@@ -3593,6 +4072,12 @@ impl App {
                                         Style::default().fg(self.ui_theme.text_muted),
                                     ),
                                     Span::styled(&item.label, style),
+                                    Span::styled(
+                                        item.detail.as_deref().map_or_else(String::new, |detail| {
+                                            format!("  {detail}")
+                                        }),
+                                        Style::default().fg(self.ui_theme.text_muted),
+                                    ),
                                 ])
                             })
                             .collect();
@@ -3808,6 +4293,10 @@ impl App {
                         || self.cell_editor.active
                         || self.ai_modal.is_some()
                         || self.history_picker.is_some()
+                        || self.snippet_picker.is_some()
+                        || self.cell_history_picker.is_some()
+                        || self.action_palette.is_some()
+                        || self.result_columns_picker.is_some()
                         || self.connection_picker.is_some()
                         || self.json_editor.is_some()
                         || self.row_detail.is_some()
@@ -3818,7 +4307,14 @@ impl App {
                     if !has_other_modal && size.width >= 20 && size.height >= 5 {
                         let popup_width = (size.width.saturating_mul(70) / 100)
                             .clamp(40, size.width.saturating_sub(4));
-                        let desired_height = (err.lines().count() as u16).saturating_add(4);
+                        let content_width = usize::from(popup_width.saturating_sub(2).max(1));
+                        let wrapped_lines = err
+                            .lines()
+                            .map(|line| line.width().max(1).div_ceil(content_width))
+                            .sum::<usize>();
+                        let desired_height = u16::try_from(wrapped_lines)
+                            .unwrap_or(u16::MAX)
+                            .saturating_add(4);
                         let popup_height = desired_height
                             .clamp(5, 12)
                             .min(size.height.saturating_sub(2));
@@ -3834,7 +4330,7 @@ impl App {
                         // exception to the calm overlay recipe.
                         let block = overlay_block("", &self.ui_theme)
                             .title_top(Line::from(Span::styled(
-                                " Error (Enter/Esc dismiss) ",
+                                " Error (y copy · Enter/Esc dismiss) ",
                                 Style::default()
                                     .fg(self.ui_theme.error)
                                     .add_modifier(Modifier::BOLD),
@@ -3867,8 +4363,9 @@ impl App {
             }
 
             // Use faster polling when query is running or loading more rows
-            let is_loading =
-                self.db.running || self.paged_query.as_ref().is_some_and(|p| p.loading);
+            let is_loading = self.db.running
+                || self.paged_query.as_ref().is_some_and(|p| p.loading)
+                || self.notebook_export_loading.is_some();
             let poll_duration = if is_loading {
                 Duration::from_millis(16) // ~60 FPS when loading
             } else {
@@ -3889,6 +4386,7 @@ impl App {
                     Event::Mouse(mouse) if self.on_mouse(mouse) => {
                         break;
                     }
+                    Event::Paste(text) => self.on_paste(&text),
                     _ => {}
                 }
             }
@@ -3985,7 +4483,9 @@ impl App {
         // Ctrl-c: cancel running query.
         if key.code == KeyCode::Char('c')
             && key.modifiers == KeyModifiers::CONTROL
-            && self.db.running
+            && (self.db.running
+                || self.notebook_page_loading.is_some()
+                || self.notebook_export_loading.is_some())
         {
             self.cancel_query();
             return false;
@@ -3998,6 +4498,11 @@ impl App {
                 && !self.search.active
                 && !self.command.active
                 && !self.completion.active
+                && self.history_picker.is_none()
+                && self.snippet_picker.is_none()
+                && self.cell_history_picker.is_none()
+                && self.action_palette.is_none()
+                && self.result_columns_picker.is_none()
                 && self.last_error.is_none()
             {
                 self.set_focus(Focus::Notebook);
@@ -4009,6 +4514,11 @@ impl App {
                 && !self.search.active
                 && !self.command.active
                 && !self.completion.active
+                && self.history_picker.is_none()
+                && self.snippet_picker.is_none()
+                && self.cell_history_picker.is_none()
+                && self.action_palette.is_none()
+                && self.result_columns_picker.is_none()
                 && self.last_error.is_none();
             if notebook_can_handle_escape {
                 match self.notebook.focus {
@@ -4024,7 +4534,7 @@ impl App {
                         self.notebook.focus = NotebookFocus::Cell;
                         return false;
                     }
-                    NotebookFocus::Cell => {}
+                    NotebookFocus::Cell => return false,
                 }
             }
             if self.db.running {
@@ -4040,6 +4550,10 @@ impl App {
                 || self.cell_editor.active
                 || self.ai_modal.is_some()
                 || self.history_picker.is_some()
+                || self.snippet_picker.is_some()
+                || self.cell_history_picker.is_some()
+                || self.action_palette.is_some()
+                || self.result_columns_picker.is_some()
                 || self.connection_picker.is_some()
                 || self.pending_key.is_some()
                 || self.last_error.is_some()
@@ -4059,6 +4573,11 @@ impl App {
                 self.ai_pending_request_id = None;
                 self.history_picker = None;
                 self.history_picker_pinned_only = false;
+                self.snippet_picker = None;
+                self.cell_history_picker = None;
+                self.action_palette = None;
+                self.result_columns_picker = None;
+                self.result_columns_draft.clear();
                 self.connection_picker = None;
                 self.pending_key = None;
                 self.last_error = None;
@@ -4094,6 +4613,22 @@ impl App {
             return self.handle_history_picker_key(key);
         }
 
+        if self.snippet_picker.is_some() {
+            return self.handle_snippet_picker_key(key);
+        }
+
+        if self.cell_history_picker.is_some() {
+            return self.handle_cell_history_picker_key(key);
+        }
+
+        if self.result_columns_picker.is_some() {
+            return self.handle_result_columns_picker_key(key);
+        }
+
+        if self.action_palette.is_some() {
+            return self.handle_action_palette_key(key);
+        }
+
         // Handle connection picker when open (takes priority over error dismissal)
         if self.connection_picker.is_some() {
             // Clear any error when interacting with the picker
@@ -4103,6 +4638,13 @@ impl App {
 
         // If error is showing, Enter dismisses it.
         if self.last_error.is_some() {
+            if key.code == KeyCode::Char('y') && key.modifiers == KeyModifiers::NONE {
+                let error = self.last_error.clone().unwrap_or_default();
+                if self.copy_to_clipboard(&error) {
+                    self.last_status = Some("Error copied to clipboard".to_string());
+                }
+                return false;
+            }
             if key.code == KeyCode::Enter && key.modifiers == KeyModifiers::NONE {
                 self.last_error = None;
                 return false;
@@ -4118,6 +4660,16 @@ impl App {
             } else {
                 self.execute_query();
             }
+            return false;
+        }
+
+        let open_actions = matches!(key.code, KeyCode::Char('p' | 'P'))
+            && key.modifiers.contains(KeyModifiers::CONTROL)
+            && key.modifiers.contains(KeyModifiers::SHIFT)
+            || matches!(key.code, KeyCode::Char('k' | 'K'))
+                && key.modifiers.contains(KeyModifiers::SUPER);
+        if open_actions {
+            self.open_action_palette();
             return false;
         }
 
@@ -4475,6 +5027,66 @@ impl App {
         false
     }
 
+    fn on_paste(&mut self, text: &str) {
+        if text.is_empty() || self.confirm_prompt.is_some() || self.row_detail.is_some() {
+            return;
+        }
+        let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+        if let Some(editor) = self.json_editor.as_mut() {
+            editor.paste_text(&normalized);
+            return;
+        }
+        if self.password_prompt.is_some()
+            || self.connection_form.is_some()
+            || self.connection_manager.is_some()
+            || self.ai_modal.is_some()
+            || self.history_picker.is_some()
+            || self.connection_picker.is_some()
+            || self.snippet_picker.is_some()
+            || self.cell_history_picker.is_some()
+            || self.action_palette.is_some()
+            || self.result_columns_picker.is_some()
+        {
+            for character in normalized.replace('\n', " ").chars() {
+                self.on_key(KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE));
+            }
+            return;
+        }
+        if self.command.active {
+            self.command
+                .textarea
+                .insert_str(normalized.replace('\n', " "));
+            return;
+        }
+        if self.search.active {
+            self.search
+                .textarea
+                .insert_str(normalized.replace('\n', " "));
+            return;
+        }
+        if self.cell_editor.active {
+            for character in normalized.replace('\n', " ").chars() {
+                self.cell_editor.insert_char(character);
+            }
+            return;
+        }
+        if self.workspace_mode == WorkspaceMode::Notebook
+            && self.focus == Focus::Notebook
+            && self.notebook.focus == NotebookFocus::Editor
+        {
+            self.completion.close();
+            let cell = self.notebook.selected_cell_mut();
+            cell.editor.textarea.insert_str(&normalized);
+            cell.mark_edited();
+            self.notebook_document_dirty = true;
+            return;
+        }
+        if self.focus == Focus::Query {
+            self.completion.close();
+            self.editor.textarea.insert_str(&normalized);
+        }
+    }
+
     fn focus_navigation_action(&self, key: &KeyEvent) -> Option<Action> {
         let action = match self.focus {
             Focus::Query => match self.mode {
@@ -4521,7 +5133,14 @@ impl App {
     }
 
     fn set_focus(&mut self, focus: Focus) {
-        if self.maximized_results_restore.is_some() && focus != Focus::Grid {
+        if self.maximized_results_restore.is_some()
+            && focus
+                != if self.workspace_mode == WorkspaceMode::Notebook {
+                    Focus::Notebook
+                } else {
+                    Focus::Grid
+                }
+        {
             return;
         }
 
@@ -4848,6 +5467,59 @@ impl App {
             return false;
         }
 
+        if let Some(ref mut picker) = self.action_palette {
+            match picker.handle_mouse(mouse) {
+                PickerAction::Continue => {}
+                PickerAction::Cancelled => self.action_palette = None,
+                PickerAction::Selected(entry) => {
+                    self.action_palette = None;
+                    self.run_palette_action(entry.action);
+                }
+            }
+            return false;
+        }
+
+        if let Some(ref mut picker) = self.result_columns_picker {
+            match picker.handle_mouse(mouse) {
+                PickerAction::Continue => {}
+                PickerAction::Cancelled => {
+                    self.result_columns_picker = None;
+                    self.result_columns_draft.clear();
+                }
+                PickerAction::Selected(entry) => {
+                    let selected = picker.selected();
+                    let query = picker.query().to_string();
+                    self.toggle_result_column(entry.ordinal);
+                    self.rebuild_result_columns_picker(query, selected);
+                }
+            }
+            return false;
+        }
+
+        if let Some(ref mut picker) = self.snippet_picker {
+            match picker.handle_mouse(mouse) {
+                PickerAction::Continue => {}
+                PickerAction::Cancelled => self.snippet_picker = None,
+                PickerAction::Selected(snippet) => {
+                    self.snippet_picker = None;
+                    self.load_snippet(snippet);
+                }
+            }
+            return false;
+        }
+
+        if let Some(ref mut picker) = self.cell_history_picker {
+            match picker.handle_mouse(mouse) {
+                PickerAction::Continue => {}
+                PickerAction::Cancelled => self.cell_history_picker = None,
+                PickerAction::Selected(record) => {
+                    self.cell_history_picker = None;
+                    self.restore_notebook_run(record.execution_id);
+                }
+            }
+            return false;
+        }
+
         // Error popup is modal: any click dismisses it.
         if self.last_error.is_some() {
             if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
@@ -4877,7 +5549,6 @@ impl App {
                     if self.workspace_mode == WorkspaceMode::Notebook {
                         let cell = self.notebook.selected_cell_mut();
                         cell.replace_source(entry.query);
-                        cell.editor.mark_saved();
                         self.notebook.focus = NotebookFocus::Editor;
                         self.set_focus(Focus::Notebook);
                     } else {
@@ -4999,6 +5670,7 @@ impl App {
             {
                 let cell = self.notebook.selected_cell_mut();
                 cell.output_collapsed = !cell.output_collapsed;
+                self.notebook_document_dirty = true;
                 self.notebook.focus = NotebookFocus::Cell;
             } else if target.output.is_some_and(|output| is_inside(x, y, output)) {
                 self.notebook.focus = NotebookFocus::Result;
@@ -5046,6 +5718,10 @@ impl App {
                     self.notebook.focus = NotebookFocus::Cell;
                 }
             } else {
+                if self.notebook.selected_cell().source_collapsed {
+                    self.notebook.selected_cell_mut().source_collapsed = false;
+                    self.notebook_document_dirty = true;
+                }
                 self.notebook.focus = NotebookFocus::Editor;
             }
             return;
@@ -5235,6 +5911,9 @@ impl App {
         if self.sidebar_visible {
             self.sidebar_visible = false;
             match self.focus {
+                Focus::Sidebar(_) if self.workspace_mode == WorkspaceMode::Notebook => {
+                    self.set_focus(Focus::Notebook);
+                }
                 Focus::Sidebar(SidebarSection::Connections) => self.set_focus(Focus::Query),
                 Focus::Sidebar(SidebarSection::Schema) => self.set_focus(Focus::Grid),
                 Focus::Query | Focus::Grid | Focus::Notebook => {}
@@ -5248,6 +5927,7 @@ impl App {
         if let Some(state) = self.maximized_results_restore.take() {
             self.focus = state.focus;
             self.mode = state.mode;
+            self.notebook.focus = state.notebook_focus;
             self.sidebar_visible = state.sidebar_visible;
             self.sidebar_focus = state.sidebar_focus;
             self.last_status = Some("Workspace restored".to_string());
@@ -5257,10 +5937,21 @@ impl App {
         self.maximized_results_restore = Some(WorkspaceLayoutSnapshot {
             focus: self.focus,
             mode: self.mode,
+            notebook_focus: self.notebook.focus,
             sidebar_visible: self.sidebar_visible,
             sidebar_focus: self.sidebar_focus,
         });
-        self.focus = Focus::Grid;
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            self.focus = Focus::Notebook;
+            if self.notebook.selected_cell().output.is_some() {
+                self.notebook.selected_cell_mut().output_collapsed = false;
+                self.notebook.focus = NotebookFocus::Result;
+            } else {
+                self.notebook.focus = NotebookFocus::Cell;
+            }
+        } else {
+            self.focus = Focus::Grid;
+        }
         self.mode = Mode::Normal;
         self.sidebar_visible = false;
         self.last_status = Some("Results maximized".to_string());
@@ -5559,6 +6250,10 @@ impl App {
                 self.clear_notebook_cell_execution(super::execution::CellId(cell_id));
                 false
             }
+            ConfirmContext::OpenNotebook { path } => {
+                self.replace_notebook_document(path);
+                false
+            }
             ConfirmContext::CloseConnectionForm => {
                 // Close the connection form without saving
                 self.pending_duplicate_donor = None;
@@ -5615,6 +6310,9 @@ impl App {
             }
             ConfirmContext::ClearNotebookCellExecution { .. } => {
                 self.last_status = Some("Cell execution clear cancelled".to_string());
+            }
+            ConfirmContext::OpenNotebook { .. } => {
+                self.last_status = Some("Notebook open cancelled".to_string());
             }
             ConfirmContext::CloseConnectionForm => {
                 // Keep the form open
@@ -6213,6 +6911,17 @@ impl App {
                 self.last_status = Some("Grid search cleared".to_string());
                 return;
             }
+            if let RefinementAvailability::Available(retained) = &output.refinement {
+                let loaded = output.grid.rows.len();
+                if loaded < retained.rows || output.truncated {
+                    self.search.close();
+                    self.last_status = Some(format!(
+                        "Grid search covers only {} of {} retained rows; focus the result and press G to load more",
+                        loaded, retained.rows
+                    ));
+                    return;
+                }
+            }
 
             output.grid_state.apply_search(&pattern, &output.grid);
             let match_count = output.grid_state.search.match_count();
@@ -6328,6 +7037,10 @@ impl App {
                 self.db.running = false;
                 self.db.transaction_state = TransactionState::Unknown;
                 self.last_executed_query = None;
+                self.classic_result_base_query = None;
+                self.classic_result_base_headers.clear();
+                self.classic_result_transform.reset();
+                self.classic_result_applied_transform.reset();
                 self.active_query_kind = None;
                 self.current_connection_name = None;
                 self.active_connection_name = None;
@@ -6344,10 +7057,186 @@ impl App {
                     .bound_connection_generation = None;
                 self.last_status = Some("Cell will bind to the active connection on run".into());
             }
+            "detach" if self.workspace_mode == WorkspaceMode::Notebook => {
+                let cell = self.notebook.selected_cell_mut();
+                cell.dependency = None;
+                cell.additional_dependencies.clear();
+                self.notebook_document_dirty = true;
+                self.last_status = Some("Cell detached from its previous result source".into());
+            }
+            "name" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.name_selected_notebook_cell(args);
+            }
+            "cell" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.goto_notebook_cell(args);
+            }
+            "outline" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.show_notebook_outline();
+            }
+            "activity" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.goto_latest_notebook_activity();
+            }
+            "cell-history" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.open_cell_history_picker();
+            }
+            "cell-run" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.inspect_notebook_run(args);
+            }
+            "error-jump" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.jump_to_notebook_error();
+            }
+            "error" if self.workspace_mode == WorkspaceMode::Notebook => {
+                let cell = self.notebook.selected_cell();
+                if let Some(error) = cell
+                    .failure
+                    .clone()
+                    .or_else(|| cell.output.as_ref().and_then(|output| output.error.clone()))
+                {
+                    self.last_error = Some(format!("Cell {} error\n{error}", cell.id.0));
+                } else {
+                    self.last_status = Some("Selected notebook cell has no error".to_string());
+                }
+            }
+            "copy-error" if self.workspace_mode == WorkspaceMode::Notebook => {
+                let cell = self.notebook.selected_cell();
+                let cell_id = cell.id;
+                let error = cell
+                    .failure
+                    .clone()
+                    .or_else(|| cell.output.as_ref().and_then(|output| output.error.clone()));
+                if let Some(error) = error {
+                    if self.copy_to_clipboard(&error) {
+                        self.last_status =
+                            Some(format!("Copied error from notebook cell {}", cell_id.0));
+                    }
+                } else {
+                    self.last_status = Some("Selected notebook cell has no error".to_string());
+                }
+            }
+            "explain-cell" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.explain_selected_notebook_cell();
+            }
+            "collapse-source" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.notebook.selected_cell_mut().source_collapsed = true;
+                self.notebook_document_dirty = true;
+                self.notebook.focus = NotebookFocus::Cell;
+                self.mode = Mode::Normal;
+                self.last_status = Some("Collapsed notebook cell source".to_string());
+            }
+            "expand-source" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.notebook.selected_cell_mut().source_collapsed = false;
+                self.notebook_document_dirty = true;
+                self.last_status = Some("Expanded notebook cell source".to_string());
+            }
+            "toggle-source" if self.workspace_mode == WorkspaceMode::Notebook => {
+                let cell = self.notebook.selected_cell_mut();
+                cell.source_collapsed = !cell.source_collapsed;
+                let collapsed = cell.source_collapsed;
+                self.notebook_document_dirty = true;
+                if collapsed {
+                    self.notebook.focus = NotebookFocus::Cell;
+                    self.mode = Mode::Normal;
+                }
+                self.last_status = Some(
+                    if collapsed {
+                        "Collapsed notebook cell source"
+                    } else {
+                        "Expanded notebook cell source"
+                    }
+                    .to_string(),
+                );
+            }
             "run-without-snapshot" if self.workspace_mode == WorkspaceMode::Notebook => {
                 self.execute_notebook_cell_with_snapshot(false);
             }
-            "rebase" | "rebind" | "run-without-snapshot" => {
+            "run-all" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.queue_notebook_run(NotebookRunScope::All);
+            }
+            "run-above" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.queue_notebook_run(NotebookRunScope::Above);
+            }
+            "run-below" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.queue_notebook_run(NotebookRunScope::Below);
+            }
+            "run-dependents" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.queue_notebook_run(NotebookRunScope::Dependents);
+            }
+            "save-notebook" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.save_notebook_document(args);
+            }
+            "open-notebook" => self.open_notebook_document(args),
+            "insert-above" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.notebook.insert_cell(false);
+                self.notebook_document_dirty = true;
+                self.mode = Mode::Insert;
+                self.last_status = Some("Inserted notebook cell above".to_string());
+            }
+            "insert-below" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.notebook.insert_cell(true);
+                self.notebook_document_dirty = true;
+                self.mode = Mode::Insert;
+                self.last_status = Some("Inserted notebook cell below".to_string());
+            }
+            "duplicate-cell" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.notebook.duplicate_selected();
+                self.notebook_document_dirty = true;
+                self.last_status = Some("Duplicated notebook cell".to_string());
+            }
+            "move-cell-up" if self.workspace_mode == WorkspaceMode::Notebook => {
+                let moved = self.notebook.move_selected(false);
+                self.notebook_document_dirty |= moved;
+                self.last_status = Some(
+                    if moved {
+                        "Moved notebook cell up"
+                    } else {
+                        "Notebook cell is already at the top"
+                    }
+                    .to_string(),
+                );
+            }
+            "move-cell-down" if self.workspace_mode == WorkspaceMode::Notebook => {
+                let moved = self.notebook.move_selected(true);
+                self.notebook_document_dirty |= moved;
+                self.last_status = Some(
+                    if moved {
+                        "Moved notebook cell down"
+                    } else {
+                        "Notebook cell is already at the bottom"
+                    }
+                    .to_string(),
+                );
+            }
+            "clear-cell" if self.workspace_mode == WorkspaceMode::Notebook => {
+                self.request_clear_notebook_cell_execution();
+            }
+            "rebase"
+            | "rebind"
+            | "detach"
+            | "name"
+            | "cell"
+            | "outline"
+            | "activity"
+            | "cell-history"
+            | "cell-run"
+            | "error"
+            | "error-jump"
+            | "copy-error"
+            | "explain-cell"
+            | "collapse-source"
+            | "expand-source"
+            | "toggle-source"
+            | "run-without-snapshot"
+            | "run-all"
+            | "run-above"
+            | "run-below"
+            | "run-dependents"
+            | "save-notebook"
+            | "insert-above"
+            | "insert-below"
+            | "duplicate-cell"
+            | "move-cell-up"
+            | "move-cell-down"
+            | "clear-cell" => {
                 self.last_status = Some("This command is only available in Notebook mode".into());
             }
             "mode" => match args {
@@ -6363,6 +7252,14 @@ impl App {
             "export" | "e" => {
                 self.handle_export_command(args);
             }
+            "sort" => self.handle_classic_sort_command(args),
+            "filter" => self.handle_classic_filter_command(args),
+            "columns" => self.handle_classic_columns_command(args),
+            "group-count" => self.handle_classic_group_count_command(args),
+            "clear-filters" => self.clear_classic_result_filters(),
+            "clear-sort" => self.clear_classic_result_sorting(),
+            "reset-result" => self.reset_classic_result_transform(),
+            "result-sql" => self.handle_result_sql_command(args),
             "gen" | "generate" => {
                 self.handle_gen_command(args);
             }
@@ -6405,6 +7302,10 @@ impl App {
                 } else {
                     self.db.mongo_database = Some(args.to_string());
                     self.last_executed_query = None;
+                    self.classic_result_base_query = None;
+                    self.classic_result_base_headers.clear();
+                    self.classic_result_transform.reset();
+                    self.classic_result_applied_transform.reset();
                     self.active_query_kind = None;
                     self.last_status = Some(format!("Switched to Mongo database '{}'", args));
                     self.load_schema();
@@ -6488,6 +7389,21 @@ impl App {
             }
             "history" => {
                 self.open_history_picker();
+            }
+            "actions" | "palette" => {
+                self.open_action_palette();
+            }
+            "snippets" => {
+                self.open_snippet_picker();
+            }
+            "snippet-save" => {
+                self.save_current_snippet(args);
+            }
+            "snippet-delete" => {
+                self.delete_snippet(args);
+            }
+            "snippet" => {
+                self.handle_snippet_command(args);
             }
             "refresh" => {
                 self.refresh_focused();
@@ -7118,6 +8034,7 @@ impl App {
 
                     let mut headers: Vec<String> = Vec::new();
                     let mut rows: Vec<Vec<String>> = Vec::new();
+                    let mut null_cells: Vec<Vec<bool>> = Vec::new();
 
                     for msg in messages {
                         match msg {
@@ -7130,10 +8047,14 @@ impl App {
                                         .collect();
                                 }
                                 let mut out_row = Vec::with_capacity(row.len());
+                                let mut null_row = Vec::with_capacity(row.len());
                                 for i in 0..row.len() {
-                                    out_row.push(row.get(i).unwrap_or("NULL").to_string());
+                                    let cell = row.get(i);
+                                    null_row.push(cell.is_none());
+                                    out_row.push(cell.unwrap_or("NULL").to_string());
                                 }
                                 rows.push(out_row);
+                                null_cells.push(null_row);
                             }
                             SimpleQueryMessage::CommandComplete(_) => {}
                             _ => {}
@@ -7143,6 +8064,7 @@ impl App {
                     let result = QueryResult {
                         headers,
                         rows,
+                        null_cells,
                         command_tag: None,
                         truncated: false,
                         elapsed,
@@ -7183,6 +8105,7 @@ impl App {
                 Ok(names) => {
                     let rows = names.into_iter().map(|n| vec![n]).collect::<Vec<_>>();
                     let result = QueryResult {
+                        null_cells: Vec::new(),
                         headers: vec!["name".to_string()],
                         rows,
                         command_tag: Some("show dbs".to_string()),
@@ -7230,6 +8153,7 @@ impl App {
                 Ok(names) => {
                     let rows = names.into_iter().map(|n| vec![n]).collect::<Vec<_>>();
                     let result = QueryResult {
+                        null_cells: Vec::new(),
                         headers: vec!["collection".to_string()],
                         rows,
                         command_tag: Some("show collections".to_string()),
@@ -7284,6 +8208,7 @@ impl App {
                         }
                     }
                     let result = QueryResult {
+                        null_cells: Vec::new(),
                         headers: vec!["field".to_string(), "type".to_string()],
                         rows,
                         command_tag: Some(format!("describe {}", collection_name)),
@@ -7305,7 +8230,20 @@ impl App {
     }
 
     fn handle_export_command(&mut self, args: &str) {
-        let grid = if self.workspace_mode == WorkspaceMode::Notebook {
+        let notebook = self.workspace_mode == WorkspaceMode::Notebook;
+        let selected_rows = if notebook {
+            self.notebook
+                .selected_cell()
+                .output
+                .as_ref()
+                .map_or_else(Vec::new, |output| {
+                    output.grid_state.selected_rows.iter().copied().collect()
+                })
+        } else {
+            self.grid_state.selected_rows.iter().copied().collect()
+        };
+        let exporting_selection = !selected_rows.is_empty();
+        let grid = if notebook {
             self.notebook
                 .selected_cell()
                 .output
@@ -7318,7 +8256,18 @@ impl App {
             self.last_error = Some("No data to export".to_string());
             return;
         };
-        if grid.rows.is_empty() {
+        let retained = notebook.then(|| {
+            self.notebook
+                .selected_cell()
+                .output
+                .as_ref()
+                .and_then(|output| match &output.refinement {
+                    RefinementAvailability::Available(retained) => Some(retained.clone()),
+                    RefinementAvailability::Unavailable(_) => None,
+                })
+        });
+        let retained = retained.flatten();
+        if grid.rows.is_empty() && retained.as_ref().is_none_or(|retained| retained.rows == 0) {
             self.last_error = Some("No data to export".to_string());
             return;
         }
@@ -7329,49 +8278,138 @@ impl App {
             return;
         }
 
-        let format = parts[0].to_lowercase();
+        let format_name = parts[0].to_lowercase();
         let path = parts.get(1).map(|s| s.trim()).unwrap_or("");
 
         if path.is_empty() {
-            self.last_status = Some(format!("Usage: :export {} <path>", format));
+            self.last_status = Some(format!("Usage: :export {} <path>", format_name));
             return;
         }
 
-        // Get all row indices
-        let indices: Vec<usize> = (0..grid.rows.len()).collect();
-
-        let content = match format.as_str() {
-            "csv" => grid.rows_as_csv(&indices, true),
-            "json" => grid.rows_as_json(&indices),
-            "tsv" => grid.rows_as_tsv(&indices, true),
+        let sql_table = grid
+            .source_table
+            .clone()
+            .unwrap_or_else(|| "result".to_string());
+        let format = match format_name.as_str() {
+            "csv" => NotebookExportFormat::Csv,
+            "json" => NotebookExportFormat::Json,
+            "tsv" => NotebookExportFormat::Tsv,
+            "sql" => NotebookExportFormat::Sql { table: sql_table },
+            token if token.starts_with("sql:") => {
+                let table = token.trim_start_matches("sql:").trim();
+                if table.is_empty() {
+                    self.last_error = Some("SQL export table name cannot be empty".to_string());
+                    return;
+                }
+                NotebookExportFormat::Sql {
+                    table: table.to_string(),
+                }
+            }
             _ => {
                 self.last_error = Some(format!(
-                    "Unknown format: {}. Use csv, json, or tsv.",
-                    format
+                    "Unknown format: {}. Use csv, json, tsv, sql, or sql:<table>.",
+                    format_name
                 ));
                 return;
             }
         };
 
-        // Expand ~ to home directory
-        let expanded_path = if let Some(stripped) = path.strip_prefix("~/") {
-            if let Some(home) = std::env::var_os("HOME") {
-                std::path::PathBuf::from(home).join(stripped)
-            } else {
-                std::path::PathBuf::from(path)
+        let expanded_path = expand_user_path(path);
+        if notebook && !exporting_selection {
+            if let Some(retained) = retained {
+                let loaded = grid.rows.len();
+                if loaded < retained.rows {
+                    if self.notebook_export_loading.is_some() {
+                        self.last_status = Some("A notebook export is already running".to_string());
+                        return;
+                    }
+                    let Some(snapshot) = self.pg_snapshots.get(&retained.handle).cloned() else {
+                        self.last_error =
+                            Some("Session snapshot is no longer available for export".to_string());
+                        return;
+                    };
+                    let Some(client) = self.db.client.clone() else {
+                        self.last_error = Some("Not connected; cannot export snapshot".to_string());
+                        return;
+                    };
+                    let cell_id = self.notebook.selected_cell().id;
+                    let version = retained.version;
+                    let handle = retained.handle;
+                    let connection_generation = retained.connection_generation;
+                    self.touch_pg_snapshot(handle);
+                    self.notebook_export_loading = Some(NotebookPageLoad {
+                        cell_id,
+                        version,
+                        handle,
+                        connection_generation,
+                    });
+                    let cancelled = Arc::new(AtomicBool::new(false));
+                    self.notebook_export_cancelled = Some(cancelled.clone());
+                    self.last_error = None;
+                    self.last_status = Some(format!(
+                        "Exporting {} retained rows as {}... (Ctrl+C cancels)",
+                        retained.rows,
+                        format.label()
+                    ));
+                    let tx = self.db_events_tx.clone();
+                    let path = expanded_path.clone();
+                    self.rt.spawn(async move {
+                        let guard = client.lock().await;
+                        match notebook_export::export_snapshot(
+                            &guard, &snapshot, version, &path, &format, &cancelled,
+                        )
+                        .await
+                        {
+                            Ok(rows) => {
+                                let _ = tx.send(DbEvent::NotebookExportFinished {
+                                    cell_id,
+                                    version,
+                                    handle,
+                                    connection_generation,
+                                    rows,
+                                    path,
+                                    format: format.label().to_string(),
+                                });
+                            }
+                            Err(error) => {
+                                let _ = tx.send(DbEvent::NotebookExportError {
+                                    cell_id,
+                                    version,
+                                    handle,
+                                    connection_generation,
+                                    error,
+                                });
+                            }
+                        }
+                    });
+                    return;
+                }
             }
+        }
+
+        let indices: Vec<usize> = if exporting_selection {
+            selected_rows
         } else {
-            std::path::PathBuf::from(path)
+            (0..grid.rows.len()).collect()
+        };
+
+        let content = match &format {
+            NotebookExportFormat::Csv => grid.rows_as_csv(&indices, true),
+            NotebookExportFormat::Json => grid.rows_as_json(&indices),
+            NotebookExportFormat::Tsv => grid.rows_as_tsv(&indices, true),
+            NotebookExportFormat::Sql { table } => grid.rows_as_sql_inserts(&indices, table),
         };
 
         match std::fs::write(&expanded_path, &content) {
             Ok(()) => {
                 let rows = indices.len();
                 self.last_status = Some(format!(
-                    "Exported {} rows to {} as {}",
+                    "Exported {}{} row{} to {} as {}",
                     rows,
+                    if exporting_selection { " selected" } else { "" },
+                    if rows == 1 { "" } else { "s" },
                     expanded_path.display(),
-                    format.to_uppercase()
+                    format.label()
                 ));
             }
             Err(e) => {
@@ -7431,7 +8469,20 @@ impl App {
     }
 
     fn handle_gen_command(&mut self, args: &str) {
-        if self.grid.rows.is_empty() {
+        let notebook = self.workspace_mode == WorkspaceMode::Notebook;
+        let Some((grid, grid_state)) = (if notebook {
+            self.notebook
+                .selected_cell()
+                .output
+                .as_ref()
+                .map(|output| (&output.grid, &output.grid_state))
+        } else {
+            Some((&self.grid, &self.grid_state))
+        }) else {
+            self.last_error = Some("No data to generate SQL from".to_string());
+            return;
+        };
+        if grid.rows.is_empty() {
             self.last_error = Some("No data to generate SQL from".to_string());
             return;
         }
@@ -7449,7 +8500,7 @@ impl App {
         // Use provided table or fall back to source_table from query
         let table: String = match parts.get(1) {
             Some(t) if !t.is_empty() => t.to_string(),
-            _ => match &self.grid.source_table {
+            _ => match &grid.source_table {
                 Some(t) => t.clone(),
                 None => {
                     self.last_error = Some(format!(
@@ -7470,10 +8521,10 @@ impl App {
         };
 
         // Get row indices: selected rows or current row
-        let row_indices: Vec<usize> = if self.grid_state.selected_rows.is_empty() {
-            vec![self.grid_state.cursor_row]
+        let row_indices: Vec<usize> = if grid_state.selected_rows.is_empty() {
+            vec![grid_state.cursor_row]
         } else {
-            self.grid_state.selected_rows.iter().copied().collect()
+            grid_state.selected_rows.iter().copied().collect()
         };
 
         // Determine which key columns to use:
@@ -7481,8 +8532,8 @@ impl App {
         // 2. Primary keys from grid (if available and valid)
         // 3. None (will use defaults in generate functions)
         let key_columns: Option<Vec<String>> = explicit_keys.or_else(|| {
-            if self.grid.has_valid_pk() {
-                Some(self.grid.primary_keys.clone())
+            if grid.has_valid_pk() {
+                Some(grid.primary_keys.clone())
             } else {
                 None
             }
@@ -7492,15 +8543,14 @@ impl App {
             let mut commands = Vec::new();
             let mut skipped_empty_updates = 0usize;
             for row_idx in &row_indices {
-                let Some(row_values) = self.grid.rows.get(*row_idx) else {
+                let Some(row_values) = grid.rows.get(*row_idx) else {
                     continue;
                 };
 
                 let mut full_doc = serde_json::Map::new();
-                for (i, header) in self.grid.headers.iter().enumerate() {
+                for (i, header) in grid.headers.iter().enumerate() {
                     let cell = row_values.get(i).cloned().unwrap_or_default();
-                    let type_hint = self
-                        .grid
+                    let type_hint = grid
                         .col_types
                         .get(i)
                         .and_then(|t| (!t.is_empty()).then_some(t.as_str()));
@@ -7516,13 +8566,13 @@ impl App {
                     .as_ref()
                     .cloned()
                     .or_else(|| {
-                        if self.grid.headers.iter().any(|h| h == "_id") {
+                        if grid.headers.iter().any(|h| h == "_id") {
                             Some(vec!["_id".to_string()])
                         } else {
                             None
                         }
                     })
-                    .unwrap_or_else(|| self.grid.headers.clone());
+                    .unwrap_or_else(|| grid.headers.clone());
 
                 let mut filter = serde_json::Map::new();
                 for key in &filter_keys {
@@ -7593,10 +8643,18 @@ impl App {
             }
             let generated = generated.into_iter().next().unwrap_or_default();
 
-            self.editor.textarea.select_all();
-            self.editor.textarea.cut();
-            self.editor.textarea.insert_str(&generated);
-            self.set_focus(Focus::Query);
+            if notebook {
+                self.notebook.insert_cell(true);
+                self.notebook.selected_cell_mut().replace_source(generated);
+                self.notebook.focus = NotebookFocus::Editor;
+                self.set_focus(Focus::Notebook);
+                self.notebook_document_dirty = true;
+            } else {
+                self.editor.textarea.select_all();
+                self.editor.textarea.cut();
+                self.editor.textarea.insert_str(&generated);
+                self.set_focus(Focus::Query);
+            }
             self.mode = Mode::Normal;
             self.last_status = Some(format!(
                 "Generated {} Mongo command statement{}{}",
@@ -7620,17 +8678,15 @@ impl App {
                 let keys: Option<Vec<&str>> = key_columns
                     .as_ref()
                     .map(|v| v.iter().map(|s| s.as_str()).collect());
-                self.grid
-                    .generate_update_sql(&table, &row_indices, keys.as_deref())
+                grid.generate_update_sql(&table, &row_indices, keys.as_deref())
             }
             "delete" | "d" => {
                 let keys: Option<Vec<&str>> = key_columns
                     .as_ref()
                     .map(|v| v.iter().map(|s| s.as_str()).collect());
-                self.grid
-                    .generate_delete_sql(&table, &row_indices, keys.as_deref())
+                grid.generate_delete_sql(&table, &row_indices, keys.as_deref())
             }
-            "insert" | "i" => self.grid.generate_insert_sql(&table, &row_indices),
+            "insert" | "i" => grid.generate_insert_sql(&table, &row_indices),
             _ => {
                 self.last_error = Some(format!(
                     "Unknown generate type: {}. Use update, delete, or insert.",
@@ -7641,12 +8697,18 @@ impl App {
         };
 
         // Put the generated SQL into the editor
-        self.editor.textarea.select_all();
-        self.editor.textarea.cut();
-        self.editor.textarea.insert_str(&sql);
-
-        // Move focus to the editor so user can review/edit
-        self.set_focus(Focus::Query);
+        if notebook {
+            self.notebook.insert_cell(true);
+            self.notebook.selected_cell_mut().replace_source(sql);
+            self.notebook.focus = NotebookFocus::Editor;
+            self.set_focus(Focus::Notebook);
+            self.notebook_document_dirty = true;
+        } else {
+            self.editor.textarea.select_all();
+            self.editor.textarea.cut();
+            self.editor.textarea.insert_str(&sql);
+            self.set_focus(Focus::Query);
+        }
         self.mode = Mode::Normal;
 
         let row_count = row_indices.len();
@@ -8561,6 +9623,10 @@ impl App {
         self.db.running = false;
         self.db.transaction_state = TransactionState::Unknown;
         self.last_executed_query = None;
+        self.classic_result_base_query = None;
+        self.classic_result_base_headers.clear();
+        self.classic_result_transform.reset();
+        self.classic_result_applied_transform.reset();
         self.active_query_kind = None;
         self.query_ui.clear();
         self.db.connected_with_tls = false;
@@ -9820,6 +10886,12 @@ impl App {
 
     pub fn switch_workspace(&mut self, workspace_mode: WorkspaceMode) {
         if self.workspace_mode == workspace_mode {
+            if workspace_mode == WorkspaceMode::Notebook
+                && matches!(self.focus, Focus::Query | Focus::Grid)
+            {
+                self.set_focus(Focus::Notebook);
+                self.mode = Mode::Normal;
+            }
             return;
         }
 
@@ -9846,10 +10918,14 @@ impl App {
     fn workspace_has_unsaved_changes(&self) -> bool {
         match self.workspace_mode {
             WorkspaceMode::Classic => self.editor.is_modified(),
-            WorkspaceMode::Notebook => self.notebook.cells.iter().any(|cell| {
-                !cell.is_empty()
-                    && (cell.output.is_none() || cell.is_dirty() || cell.editor.is_modified())
-            }),
+            WorkspaceMode::Notebook => {
+                self.notebook_document_dirty
+                    || self
+                        .notebook
+                        .cells
+                        .iter()
+                        .any(|cell| cell.is_dirty() || cell.editor.is_modified())
+            }
         }
     }
 
@@ -9886,6 +10962,10 @@ impl App {
                         }
                     }
                     Action::EnterCellEditor => {
+                        if self.notebook.selected_cell().source_collapsed {
+                            self.notebook.selected_cell_mut().source_collapsed = false;
+                            self.notebook_document_dirty = true;
+                        }
                         self.notebook.focus = NotebookFocus::Editor;
                         self.mode = Mode::Normal;
                     }
@@ -9893,6 +10973,7 @@ impl App {
                         if self.notebook.selected_cell().output.is_some() {
                             self.notebook.selected_cell_mut().output_collapsed = false;
                             self.notebook.focus = NotebookFocus::Result;
+                            self.maybe_fetch_notebook_result_rows(false);
                         } else {
                             self.last_status = Some("Cell has no result to inspect".to_string());
                         }
@@ -9904,12 +10985,15 @@ impl App {
                     Action::ToggleCellOutput => {
                         let cell = self.notebook.selected_cell_mut();
                         cell.output_collapsed = !cell.output_collapsed;
+                        self.notebook_document_dirty = true;
                     }
                     Action::CollapseCellOutput => {
                         self.notebook.selected_cell_mut().output_collapsed = true;
+                        self.notebook_document_dirty = true;
                     }
                     Action::ExpandCellOutput => {
                         self.notebook.selected_cell_mut().output_collapsed = false;
+                        self.notebook_document_dirty = true;
                     }
                     Action::ClearNotebookCellExecution => {
                         self.request_clear_notebook_cell_execution();
@@ -9940,15 +11024,59 @@ impl App {
                     return;
                 }
 
+                let action = match self.mode {
+                    Mode::Normal => self.editor_normal_keymap.get_action(&key),
+                    Mode::Insert => self.editor_insert_keymap.get_action(&key),
+                    Mode::Visual => self.editor_visual_keymap.get_action(&key),
+                };
+                match action {
+                    Some(Action::ExecuteQuery) => {
+                        self.execute_notebook_cell();
+                        return;
+                    }
+                    Some(Action::FocusGrid | Action::GotoResults) => {
+                        if self.notebook.selected_cell().output.is_some() {
+                            self.notebook.selected_cell_mut().output_collapsed = false;
+                            self.notebook.focus = NotebookFocus::Result;
+                            self.mode = Mode::Normal;
+                        } else {
+                            self.last_status = Some("Cell has no result to inspect".to_string());
+                        }
+                        return;
+                    }
+                    Some(Action::FocusQuery | Action::GotoEditor) => return,
+                    Some(Action::GotoConnections) => {
+                        self.set_focus(Focus::Sidebar(SidebarSection::Connections));
+                        return;
+                    }
+                    Some(Action::GotoTables) => {
+                        self.focus_schema();
+                        return;
+                    }
+                    Some(Action::ToggleSidebar) => {
+                        self.toggle_sidebar();
+                        return;
+                    }
+                    _ => {}
+                }
+
                 let index = self.notebook.selected_index();
-                let before = self.notebook.cells[index].source();
+                let before = (!notebook_editor_key_is_navigation_only(
+                    self.mode,
+                    key,
+                    action,
+                    self.pending_key,
+                ))
+                .then(|| self.notebook.cells[index].source());
                 let mut notebook_editor = std::mem::take(&mut self.notebook.cells[index].editor);
                 std::mem::swap(&mut self.editor, &mut notebook_editor);
                 self.handle_editor_key(key);
                 std::mem::swap(&mut self.editor, &mut notebook_editor);
                 self.notebook.cells[index].editor = notebook_editor;
-                if self.notebook.cells[index].source() != before {
-                    self.notebook.cells[index].mark_edited();
+                if let Some(before) = before {
+                    if self.notebook.cells[index].source() != before {
+                        self.notebook.cells[index].mark_edited();
+                    }
                 }
             }
             NotebookFocus::Result => {
@@ -9961,6 +11089,8 @@ impl App {
                 let action = (!pending_yank)
                     .then(|| self.grid_keymap.get_action(&key))
                     .flatten();
+                let fetch_to_end = matches!(action, Some(Action::MoveToBottom))
+                    || matches!(key.code, KeyCode::End | KeyCode::Char('G'));
                 let result = match action {
                     Some(Action::FocusQuery) => {
                         self.notebook.focus = NotebookFocus::Editor;
@@ -10012,6 +11142,7 @@ impl App {
                         .as_mut()
                         .map(|output| output.grid_state.handle_key(key, &output.grid)),
                 };
+                self.maybe_fetch_notebook_result_rows(fetch_to_end);
                 match result {
                     Some(GridKeyResult::OpenSearch) => {
                         self.search_target = SearchTarget::Grid;
@@ -10093,7 +11224,10 @@ impl App {
 
     fn refine_selected_cell(&mut self) {
         let output = self.notebook.selected_cell().output.as_ref();
-        let retained = output.and_then(|output| output.retained.clone());
+        let retained = output.and_then(|output| match &output.refinement {
+            RefinementAvailability::Available(retained) => Some(retained.clone()),
+            RefinementAvailability::Unavailable(_) => None,
+        });
         let Some(retained) = retained else {
             self.last_status = Some(
                 match output.map(|output| &output.refinement) {
@@ -10134,7 +11268,11 @@ impl App {
             self.last_status = Some("Session snapshot is no longer available".to_string());
             return;
         }
+        self.pg_snapshot_lru
+            .retain(|handle| *handle != retained.handle);
+        self.pg_snapshot_lru.push_back(retained.handle);
         self.notebook.insert_refinement(retained.version);
+        self.notebook_document_dirty = true;
         self.mode = Mode::Normal;
         self.last_status = Some(format!(
             "Refining cell {} run {}",
@@ -10143,27 +11281,477 @@ impl App {
     }
 
     fn rebase_selected_dependency(&mut self) {
-        let Some(current) = self.notebook.selected_cell().dependency else {
+        let cell = self.notebook.selected_cell();
+        let dependencies = cell
+            .dependency
+            .into_iter()
+            .chain(cell.additional_dependencies.iter().copied())
+            .collect::<Vec<_>>();
+        if dependencies.is_empty() {
             self.last_status = Some("Selected cell has no result dependency".to_string());
             return;
+        }
+        let mut replacements = Vec::with_capacity(dependencies.len());
+        for current in dependencies {
+            let Some(replacement) = self.latest_notebook_result_version(Some(current.source_cell))
+            else {
+                self.last_status = Some(format!(
+                    "Source cell {} has no current session snapshot",
+                    current.source_cell.0
+                ));
+                return;
+            };
+            self.evicted_versions.remove(&replacement);
+            replacements.push(replacement);
+        }
+        let primary = replacements.first().copied();
+        let labels = replacements
+            .iter()
+            .map(|version| {
+                format!(
+                    "cell {} run {}",
+                    version.source_cell.0, version.source_execution.0
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let cell = self.notebook.selected_cell_mut();
+        cell.dependency = primary;
+        cell.additional_dependencies = replacements.into_iter().skip(1).collect();
+        self.notebook_document_dirty = true;
+        self.last_status = Some(format!("Rebased to {labels}"));
+    }
+
+    fn name_selected_notebook_cell(&mut self, args: &str) {
+        let selected = self.notebook.selected;
+        if args.is_empty() {
+            self.last_status = Some(
+                self.notebook
+                    .selected_cell()
+                    .result_name
+                    .as_ref()
+                    .map_or_else(
+                        || "Usage: :name <identifier> or :name clear".to_string(),
+                        |name| format!("Cell {} is named @result_{name}", selected.0),
+                    ),
+            );
+            return;
+        }
+        if matches!(args, "clear" | "none") {
+            self.notebook.selected_cell_mut().result_name = None;
+            self.notebook_document_dirty = true;
+            self.last_status = Some(format!("Cleared result name for cell {}", selected.0));
+            return;
+        }
+        let Some(name) = normalize_result_name(args) else {
+            self.last_error = Some(
+                "Invalid result name. Use letters, numbers, and underscores, starting with a letter or underscore"
+                    .to_string(),
+            );
+            return;
         };
-        let replacement = self
+        if let Some(existing) =
+            self.notebook.cells.iter().find(|cell| {
+                cell.id != selected && cell.result_name.as_deref() == Some(name.as_str())
+            })
+        {
+            self.last_error = Some(format!(
+                "Result name '{name}' is already used by cell {}",
+                existing.id.0
+            ));
+            return;
+        }
+        self.notebook.selected_cell_mut().result_name = Some(name.clone());
+        self.notebook_document_dirty = true;
+        self.last_error = None;
+        self.last_status = Some(format!("Cell {} is now @result_{name}", selected.0));
+    }
+
+    fn explain_selected_notebook_cell(&mut self) {
+        if self.db.kind == Some(DbKind::Mongo) {
+            self.last_status = Some("Explain cell is only available for PostgreSQL".to_string());
+            return;
+        }
+        if self.db.running {
+            self.last_status = Some("A query is already running".to_string());
+            return;
+        }
+        if self.db.client.is_none() {
+            self.last_error =
+                Some("Not connected. Use :connect <url> or select a connection first.".into());
+            return;
+        }
+
+        let selected = self.notebook.selected_cell();
+        let source_cell = selected.id;
+        let source = selected.source();
+        let dependency = selected.dependency;
+        let additional_dependencies = selected.additional_dependencies.clone();
+        let source = match notebook_explain_source(&source) {
+            Ok(source) => source,
+            Err(error) => {
+                self.last_error = Some(error);
+                return;
+            }
+        };
+
+        let explain_cell = self.notebook.insert_cell(true);
+        let cell = self.notebook.selected_cell_mut();
+        cell.replace_source(source);
+        cell.dependency = dependency;
+        cell.additional_dependencies = additional_dependencies;
+        self.notebook.focus = NotebookFocus::Cell;
+        self.mode = Mode::Normal;
+        self.notebook_document_dirty = true;
+        self.last_status = Some(format!(
+            "Explaining cell {} in cell {}",
+            source_cell.0, explain_cell.0
+        ));
+        self.execute_notebook_cell_with_snapshot(false);
+    }
+
+    fn goto_notebook_cell(&mut self, args: &str) {
+        if args.is_empty() {
+            self.last_status = Some("Usage: :cell <id-or-result-name>".to_string());
+            return;
+        }
+        let requested_name = args
+            .strip_prefix("@result_")
+            .unwrap_or(args)
+            .to_ascii_lowercase();
+        let requested_id = args.parse::<u64>().ok().map(CellId);
+        let Some(cell_id) = self
             .notebook
             .cells
             .iter()
-            .find(|cell| cell.id == current.source_cell)
-            .and_then(|cell| cell.output.as_ref())
-            .and_then(|output| output.retained.as_ref())
-            .map(|retained| retained.version);
-        let Some(replacement) = replacement else {
-            self.last_status = Some("Source cell has no current session snapshot".to_string());
+            .find(|cell| {
+                requested_id == Some(cell.id)
+                    || cell.result_name.as_deref() == Some(requested_name.as_str())
+            })
+            .map(|cell| cell.id)
+        else {
+            self.last_error = Some(format!("Notebook cell '{args}' was not found"));
             return;
         };
-        self.notebook.selected_cell_mut().dependency = Some(replacement);
+        self.notebook.selected = cell_id;
+        self.notebook_activity
+            .retain(|activity| activity.cell_id != cell_id);
+        self.notebook.focus = NotebookFocus::Cell;
+        self.set_focus(Focus::Notebook);
+        self.mode = Mode::Normal;
+        self.last_error = None;
+        self.last_status = Some(format!("Focused notebook cell {}", cell_id.0));
+    }
+
+    fn goto_latest_notebook_activity(&mut self) {
+        let Some(activity) = self.notebook_activity.pop_back() else {
+            self.last_status = Some("No off-screen notebook activity".to_string());
+            return;
+        };
+        self.goto_notebook_cell(&activity.cell_id.0.to_string());
         self.last_status = Some(format!(
-            "Rebased to cell {} run {}",
-            replacement.source_cell.0, replacement.source_execution.0
+            "Focused cell {} ({})",
+            activity.cell_id.0,
+            if activity.failed {
+                "failed"
+            } else {
+                "finished"
+            }
         ));
+    }
+
+    fn note_notebook_activity(&mut self, cell_id: CellId, failed: bool) {
+        let visible = self.workspace_mode == WorkspaceMode::Notebook
+            && self
+                .render_notebook_cells
+                .iter()
+                .any(|area| area.cell_id == cell_id);
+        if visible {
+            return;
+        }
+        self.notebook_activity
+            .retain(|activity| activity.cell_id != cell_id);
+        self.notebook_activity
+            .push_back(NotebookActivity { cell_id, failed });
+        while self.notebook_activity.len() > 16 {
+            self.notebook_activity.pop_front();
+        }
+
+        let selected_index = self.notebook.selected_index();
+        let activity_index = self
+            .notebook
+            .cells
+            .iter()
+            .position(|cell| cell.id == cell_id)
+            .unwrap_or(selected_index);
+        let direction = if self.notebook_ascii {
+            if activity_index < selected_index {
+                "^"
+            } else {
+                "v"
+            }
+        } else if activity_index < selected_index {
+            "↑"
+        } else {
+            "↓"
+        };
+        self.last_status = Some(format!(
+            "{direction} Cell {} {} off-screen · :activity to jump",
+            cell_id.0,
+            if failed { "failed" } else { "finished" }
+        ));
+    }
+
+    fn jump_to_notebook_error(&mut self) {
+        let cell = self.notebook.selected_cell_mut();
+        let source = cell.source();
+        let error = cell.failure.as_deref().or_else(|| {
+            cell.output
+                .as_ref()
+                .and_then(|output| output.error.as_deref())
+        });
+        let Some((row, column)) = error.and_then(|error| pg_error_cursor_position(error, &source))
+        else {
+            self.last_status =
+                Some("Selected notebook cell has no navigable error position".to_string());
+            return;
+        };
+        cell.source_collapsed = false;
+        cell.editor.textarea.move_cursor(CursorMove::Jump(
+            u16::try_from(row).unwrap_or(u16::MAX),
+            u16::try_from(column).unwrap_or(u16::MAX),
+        ));
+        self.notebook.focus = NotebookFocus::Editor;
+        self.set_focus(Focus::Notebook);
+        self.mode = Mode::Normal;
+        self.last_error = None;
+        self.last_status = Some(format!("Error at line {}, column {}", row + 1, column + 1));
+    }
+
+    fn show_notebook_outline(&mut self) {
+        let cells = self
+            .notebook
+            .cells
+            .iter()
+            .filter(|cell| !cell.is_empty())
+            .map(|cell| {
+                cell.result_name.as_ref().map_or_else(
+                    || cell.id.0.to_string(),
+                    |name| format!("{}:@result_{name}", cell.id.0),
+                )
+            })
+            .collect::<Vec<_>>();
+        self.last_status = Some(if cells.is_empty() {
+            "Notebook outline is empty".to_string()
+        } else {
+            format!(
+                "Cells: {}. Use :cell <id-or-name> to jump",
+                cells.join(", ")
+            )
+        });
+    }
+
+    fn queue_notebook_run(&mut self, scope: NotebookRunScope) {
+        if self.db.running {
+            self.last_status = Some("A query is already running".to_string());
+            return;
+        }
+        let sources = self
+            .notebook
+            .cells
+            .iter()
+            .map(|cell| (cell.id, cell.source()))
+            .collect::<Vec<_>>();
+        let references = sources
+            .iter()
+            .map(|(id, source)| (*id, source.as_str()))
+            .collect::<Vec<_>>();
+        let named_sources = self
+            .notebook
+            .cells
+            .iter()
+            .filter_map(|cell| cell.result_name.clone().map(|name| (name, cell.id)))
+            .collect::<HashMap<_, _>>();
+        let planned = if self.db.kind == Some(DbKind::Mongo) {
+            notebook_run_plan_without_references(&references, self.notebook.selected, scope)
+        } else {
+            notebook_run_plan_with_names(&references, self.notebook.selected, scope, &named_sources)
+        };
+        let plan = match planned {
+            Ok(plan) => plan,
+            Err(error) => {
+                self.last_error = Some(error);
+                return;
+            }
+        };
+        if plan.is_empty() {
+            self.last_status = Some("No notebook cells to run".to_string());
+            return;
+        }
+        self.notebook_run_total = plan.len();
+        self.notebook_run_rebind_sources = plan.iter().copied().collect();
+        self.notebook_run_queue = plan.into();
+        self.run_next_notebook_cell();
+    }
+
+    fn run_next_notebook_cell(&mut self) {
+        if self.db.running {
+            return;
+        }
+        let Some(cell_id) = self.notebook_run_queue.pop_front() else {
+            if self.notebook_run_total > 0 {
+                self.last_status = Some(format!(
+                    "Notebook run complete ({} cell(s))",
+                    self.notebook_run_total
+                ));
+            }
+            self.notebook_run_total = 0;
+            self.notebook_run_rebind_sources.clear();
+            return;
+        };
+        self.notebook.selected = cell_id;
+        self.notebook.focus = NotebookFocus::Cell;
+        self.mode = Mode::Normal;
+        self.rebase_queued_notebook_cell(cell_id);
+        self.execute_notebook_cell();
+        if !self.db.running {
+            self.notebook_run_queue.clear();
+            self.notebook_run_total = 0;
+            self.notebook_run_rebind_sources.clear();
+            self.last_status = Some(format!("Notebook run stopped at cell {}", cell_id.0));
+            return;
+        }
+        let position = self
+            .notebook_run_total
+            .saturating_sub(self.notebook_run_queue.len());
+        self.last_status = Some(format!(
+            "Running notebook cell {} ({}/{})...",
+            cell_id.0, position, self.notebook_run_total
+        ));
+    }
+
+    fn rebase_queued_notebook_cell(&mut self, cell_id: CellId) {
+        let Some(cell) = self.notebook.cells.iter().find(|cell| cell.id == cell_id) else {
+            return;
+        };
+        let dependencies = cell
+            .dependency
+            .into_iter()
+            .chain(cell.additional_dependencies.iter().copied())
+            .collect::<Vec<_>>();
+        let replacements = dependencies
+            .into_iter()
+            .map(|dependency| {
+                if self
+                    .notebook_run_rebind_sources
+                    .contains(&dependency.source_cell)
+                {
+                    self.latest_notebook_result_version(Some(dependency.source_cell))
+                        .unwrap_or(dependency)
+                } else {
+                    dependency
+                }
+            })
+            .collect::<Vec<_>>();
+        let Some(cell) = self.notebook.cell_mut(cell_id) else {
+            return;
+        };
+        cell.dependency = replacements.first().copied();
+        cell.additional_dependencies = replacements.into_iter().skip(1).collect();
+    }
+
+    fn save_notebook_document(&mut self, args: &str) {
+        let path = if args.is_empty() {
+            self.notebook_document_path.clone()
+        } else {
+            Some(expand_user_path(args))
+        };
+        let Some(path) = path else {
+            self.last_status = Some("Usage: :save-notebook <path>".to_string());
+            return;
+        };
+        let notebook = self.capture_session_state().notebook;
+        match save_notebook_to_path(&notebook, &path) {
+            Ok(()) => {
+                for cell in &mut self.notebook.cells {
+                    cell.editor.mark_saved();
+                }
+                self.notebook_document_path = Some(path.clone());
+                self.notebook_document_dirty = false;
+                self.last_error = None;
+                self.last_status = Some(format!("Notebook saved to {}", path.display()));
+            }
+            Err(error) => self.last_error = Some(error.to_string()),
+        }
+    }
+
+    fn open_notebook_document(&mut self, args: &str) {
+        if args.is_empty() {
+            self.last_status = Some("Usage: :open-notebook <path>".to_string());
+            return;
+        }
+        if self.db.running {
+            self.last_status = Some("Cannot open a notebook while a query is running".to_string());
+            return;
+        }
+        let path = expand_user_path(args);
+        if self.workspace_has_unsaved_changes() {
+            self.confirm_prompt = Some(ConfirmPrompt::new(
+                format!(
+                    "You have unsaved changes. Open notebook '{}' anyway?",
+                    path.display()
+                ),
+                ConfirmContext::OpenNotebook { path },
+            ));
+            return;
+        }
+        self.replace_notebook_document(path);
+    }
+
+    fn replace_notebook_document(&mut self, path: std::path::PathBuf) {
+        let document = match load_notebook_from_path(&path) {
+            Ok(document) => document,
+            Err(error) => {
+                self.last_error = Some(error.to_string());
+                return;
+            }
+        };
+        self.invalidate_pg_snapshots(true);
+        self.notebook = NotebookState::from_sources_with_dependencies(
+            document
+                .cells
+                .into_iter()
+                .map(|cell| {
+                    (
+                        cell.cell_id.map(CellId),
+                        cell.result_name,
+                        cell.source,
+                        cell.source_collapsed,
+                        cell.output_collapsed,
+                        cell.dependency.map(|dependency| ResultVersion {
+                            source_cell: CellId(dependency.source_cell_id),
+                            source_execution: ExecutionId(dependency.source_execution_id),
+                            source_revision: dependency.source_revision,
+                        }),
+                        cell.additional_dependencies
+                            .into_iter()
+                            .map(|dependency| ResultVersion {
+                                source_cell: CellId(dependency.source_cell_id),
+                                source_execution: ExecutionId(dependency.source_execution_id),
+                                source_revision: dependency.source_revision,
+                            })
+                            .collect(),
+                        cell.execution_history,
+                    )
+                })
+                .collect(),
+            document.selected_index,
+        );
+        self.notebook_document_path = Some(path.clone());
+        self.notebook_document_dirty = false;
+        self.switch_workspace(WorkspaceMode::Notebook);
+        self.last_error = None;
+        self.last_status = Some(format!("Notebook opened from {}", path.display()));
     }
 
     fn request_delete_notebook_cell(&mut self) {
@@ -10171,23 +11759,17 @@ impl App {
         let needs_confirmation = !cell.is_empty()
             || cell.output.is_some()
             || cell.dependency.is_some()
+            || !cell.additional_dependencies.is_empty()
             || cell.execution != CellExecutionState::NeverRun;
         if needs_confirmation {
             let dependent_count = self
-                .notebook
-                .cells
-                .iter()
-                .filter(|candidate| {
-                    candidate
-                        .dependency
-                        .is_some_and(|version| version.source_cell == cell.id)
-                })
-                .count();
+                .notebook_execution_tree(cell.id)
+                .len()
+                .saturating_sub(1);
             self.confirm_prompt = Some(ConfirmPrompt::new(
                 format!(
                     "Delete cell {}? {} dependent cell(s) will lose their source snapshot.",
-                    self.notebook.selected_index() + 1,
-                    dependent_count
+                    cell.id.0, dependent_count
                 ),
                 ConfirmContext::DeleteNotebookCell { cell_id: cell.id.0 },
             ));
@@ -10198,46 +11780,66 @@ impl App {
 
     fn delete_notebook_cell(&mut self, cell_id: super::execution::CellId) {
         let removed = self.notebook.remove_cell(cell_id);
-        let retained_handle = removed
-            .as_ref()
-            .and_then(|cell| cell.output.as_ref())
-            .and_then(|output| output.retained.as_ref())
-            .map(|retained| retained.handle);
-        if let Some(handle) = retained_handle {
-            self.pg_snapshot_order
-                .retain(|candidate| *candidate != handle);
+        let mut handles = self
+            .retained_versions
+            .iter()
+            .filter_map(|(version, handle)| (version.source_cell == cell_id).then_some(*handle))
+            .collect::<HashSet<_>>();
+        handles.extend(
+            removed
+                .as_ref()
+                .and_then(|cell| cell.output.as_ref())
+                .and_then(|output| output.retained.as_ref())
+                .map(|retained| retained.handle),
+        );
+        self.evicted_versions.extend(
             self.retained_versions
-                .retain(|_, candidate| *candidate != handle);
-            if let Some(snapshot) = self.pg_snapshots.remove(&handle) {
-                if let Some(client) = self.db.client.clone() {
-                    self.rt.spawn(async move {
-                        let guard = client.lock().await;
-                        let physical_name = snapshot.physical_name.replace('"', "\"\"");
-                        let _ = guard
-                            .batch_execute(&format!(
-                                "DROP TABLE IF EXISTS pg_temp.\"{physical_name}\""
-                            ))
-                            .await;
-                    });
-                }
-            }
-        }
+                .iter()
+                .filter_map(|(version, handle)| handles.contains(handle).then_some(*version)),
+        );
+        self.pg_snapshot_order
+            .retain(|candidate| !handles.contains(candidate));
+        self.pg_snapshot_lru
+            .retain(|candidate| !handles.contains(candidate));
+        self.retained_versions
+            .retain(|_, candidate| !handles.contains(candidate));
+        let snapshots = handles
+            .into_iter()
+            .filter_map(|handle| self.pg_snapshots.remove(&handle))
+            .collect();
+        self.drop_pg_snapshots(snapshots);
+        self.notebook_document_dirty = true;
         self.last_status = Some("Notebook cell deleted".to_string());
     }
 
     fn notebook_execution_tree(&self, root: CellId) -> HashSet<CellId> {
         let mut affected = HashSet::from([root]);
+        let named_sources = self
+            .notebook
+            .cells
+            .iter()
+            .filter_map(|cell| cell.result_name.clone().map(|name| (name, cell.id)))
+            .collect::<HashMap<_, _>>();
         loop {
             let previous_len = affected.len();
             for cell in &self.notebook.cells {
                 let bound_to_affected = cell
                     .dependency
-                    .is_some_and(|version| affected.contains(&version.source_cell));
-                let references_affected = matches!(
-                    logical_result_reference(&cell.source()),
-                    Ok(Some(LogicalResultReference::Cell(source_cell)))
-                        if affected.contains(&source_cell)
-                );
+                    .into_iter()
+                    .chain(cell.additional_dependencies.iter().copied())
+                    .any(|version| affected.contains(&version.source_cell));
+                let references_affected = self.db.kind != Some(DbKind::Mongo)
+                    && logical_result_references(&cell.source()).is_ok_and(|references| {
+                        references.into_iter().any(|reference| match reference {
+                            LogicalResultReference::Cell(source_cell) => {
+                                affected.contains(&source_cell)
+                            }
+                            LogicalResultReference::Named(name) => named_sources
+                                .get(&name)
+                                .is_some_and(|source_cell| affected.contains(source_cell)),
+                            LogicalResultReference::Latest => false,
+                        })
+                    });
                 if bound_to_affected || references_affected {
                     affected.insert(cell.id);
                 }
@@ -10312,10 +11914,21 @@ impl App {
                 .flatten()
         }));
 
+        self.evicted_versions
+            .extend(
+                self.retained_versions
+                    .iter()
+                    .filter_map(|(version, handle)| {
+                        (affected.contains(&version.source_cell) || handles.contains(handle))
+                            .then_some(*version)
+                    }),
+            );
         self.retained_versions.retain(|version, handle| {
             !affected.contains(&version.source_cell) && !handles.contains(handle)
         });
         self.pg_snapshot_order
+            .retain(|handle| !handles.contains(handle));
+        self.pg_snapshot_lru
             .retain(|handle| !handles.contains(handle));
         let snapshots = handles
             .into_iter()
@@ -10332,17 +11945,7 @@ impl App {
             }
         }
 
-        if let Some(client) = self.db.client.clone().filter(|_| !snapshots.is_empty()) {
-            self.rt.spawn(async move {
-                let guard = client.lock().await;
-                for snapshot in snapshots {
-                    let physical_name = snapshot.physical_name.replace('"', "\"\"");
-                    let _ = guard
-                        .batch_execute(&format!("DROP TABLE IF EXISTS pg_temp.\"{physical_name}\""))
-                        .await;
-                }
-            });
-        }
+        self.drop_pg_snapshots(snapshots);
 
         let dependent_count = affected.len().saturating_sub(1);
         self.last_status = Some(if dependent_count == 0 {
@@ -10367,7 +11970,15 @@ impl App {
     }
 
     fn refresh_last_query(&mut self) {
-        let Some(query) = self.last_executed_query.clone() else {
+        if !self.classic_result_transform.is_empty() {
+            self.execute_classic_result_transform();
+            return;
+        }
+        let Some(query) = self
+            .classic_result_base_query
+            .clone()
+            .or_else(|| self.last_executed_query.clone())
+        else {
             self.last_status = Some("No previous query to refresh".to_string());
             return;
         };
@@ -10531,11 +12142,20 @@ impl App {
         // Determine completion context
         let full_text = self.editor.text();
         // Calculate approximate position in full text
-        let pos_in_text: usize = lines.iter().take(row).map(|l| l.len() + 1).sum::<usize>() + col;
+        let pos_in_text: usize = lines
+            .iter()
+            .take(row)
+            .map(|line| line.chars().count() + 1)
+            .sum::<usize>()
+            + col;
         let context = determine_context(&full_text, pos_in_text);
 
         // Get completion items based on context
-        let items = self.schema_cache.get_completion_items(context);
+        let mut items = self.schema_cache.get_completion_items(context);
+        if self.workspace_mode == WorkspaceMode::Notebook && self.db.kind == Some(DbKind::Postgres)
+        {
+            items.extend(self.notebook_result_completion_items());
+        }
 
         if items.is_empty() {
             self.last_status = Some("No completions available".to_string());
@@ -10543,6 +12163,51 @@ impl App {
         }
 
         self.completion.open(items, prefix, start_col);
+    }
+
+    fn notebook_result_completion_items(&self) -> Vec<crate::ui::CompletionItem> {
+        let mut items = Vec::new();
+        let Some(latest) = self.latest_notebook_result_version(None) else {
+            return items;
+        };
+
+        let detail = |version: ResultVersion| {
+            let rows = self
+                .retained_versions
+                .get(&version)
+                .and_then(|handle| self.pg_snapshots.get(handle))
+                .map_or(0, |snapshot| snapshot.row_count);
+            format!(
+                "cell {} · run {} · {} row{}",
+                version.source_cell.0,
+                version.source_execution.0,
+                rows,
+                if rows == 1 { "" } else { "s" }
+            )
+        };
+        items.push(crate::ui::CompletionItem::result(
+            "@result".to_string(),
+            format!("latest · {}", detail(latest)),
+        ));
+
+        for cell in &self.notebook.cells {
+            let Some(version) = self.latest_notebook_result_version(Some(cell.id)) else {
+                continue;
+            };
+            let detail = detail(version);
+            items.push(crate::ui::CompletionItem::result(
+                format!("@result_{}", cell.id.0),
+                detail.clone(),
+            ));
+            if let Some(name) = &cell.result_name {
+                items.push(crate::ui::CompletionItem::result(
+                    format!("@result_{name}"),
+                    detail,
+                ));
+            }
+        }
+
+        items
     }
 
     fn apply_completion(&mut self) {
@@ -10580,7 +12245,8 @@ impl App {
         crossterm::execute!(
             terminal.backend_mut(),
             crossterm::terminal::LeaveAlternateScreen,
-            crossterm::event::DisableMouseCapture
+            crossterm::event::DisableMouseCapture,
+            crossterm::event::DisableBracketedPaste
         )?;
         terminal.show_cursor()?;
 
@@ -10607,7 +12273,8 @@ impl App {
         crossterm::execute!(
             terminal.backend_mut(),
             crossterm::terminal::EnterAlternateScreen,
-            crossterm::event::EnableMouseCapture
+            crossterm::event::EnableMouseCapture,
+            crossterm::event::EnableBracketedPaste
         )?;
         terminal.clear()?;
         self.last_cursor_style = None;
@@ -10668,13 +12335,44 @@ impl App {
         }
         self.db.running = false;
         self.active_query_kind = None;
+        self.active_classic_execution = None;
+        self.active_notebook_sql = None;
+        self.notebook_run_queue.clear();
+        self.notebook_run_total = 0;
+        self.notebook_run_rebind_sources.clear();
+        if let Some(cancelled) = self.active_notebook_cancelled.take() {
+            cancelled.store(true, Ordering::Release);
+        }
         self.query_ui.clear();
+    }
+
+    fn drop_pg_snapshots(&self, snapshots: Vec<PgTempSnapshot>) {
+        let Some(client) = self.db.client.clone().filter(|_| !snapshots.is_empty()) else {
+            return;
+        };
+        self.rt.spawn(async move {
+            let guard = client.lock().await;
+            for snapshot in snapshots {
+                let _ = pg_snapshot::drop_if_identity_matches(&guard, &snapshot).await;
+            }
+        });
     }
 
     fn invalidate_pg_snapshots(&mut self, drop_relations: bool) {
         let snapshots = std::mem::take(&mut self.pg_snapshots);
         self.retained_versions.clear();
         self.pg_snapshot_order.clear();
+        self.pg_snapshot_lru.clear();
+        self.evicted_versions.clear();
+        self.notebook_page_loading = None;
+        self.notebook_page_to_end = false;
+        if let Some(cancelled) = self.notebook_page_cancelled.take() {
+            cancelled.store(true, Ordering::Release);
+        }
+        self.notebook_export_loading = None;
+        if let Some(cancelled) = self.notebook_export_cancelled.take() {
+            cancelled.store(true, Ordering::Release);
+        }
         for cell in &mut self.notebook.cells {
             if let Some(output) = &mut cell.output {
                 if output.retained.is_some() {
@@ -10687,26 +12385,16 @@ impl App {
         if !drop_relations || snapshots.is_empty() {
             return;
         }
-        let Some(client) = self.db.client.clone() else {
-            return;
-        };
-        self.rt.spawn(async move {
-            let guard = client.lock().await;
-            for snapshot in snapshots.into_values() {
-                let physical_name = snapshot.physical_name.replace('"', "\"\"");
-                let _ = guard
-                    .batch_execute(&format!("DROP TABLE IF EXISTS pg_temp.\"{physical_name}\""))
-                    .await;
-            }
-        });
+        self.drop_pg_snapshots(snapshots.into_values().collect());
     }
 
     fn register_pg_snapshot(
         &mut self,
         retained: &super::refinement::RetainedResult,
         snapshot: PgTempSnapshot,
-    ) {
+    ) -> bool {
         self.pg_snapshot_order.push_back(retained.handle);
+        self.pg_snapshot_lru.push_back(retained.handle);
         self.retained_versions
             .insert(retained.version, retained.handle);
         self.pg_snapshots.insert(retained.handle, snapshot);
@@ -10717,18 +12405,24 @@ impl App {
                 .values()
                 .map(|snapshot| snapshot.byte_size)
                 .sum();
-            let over_count =
-                self.pg_snapshots.len() > self.config.notebook.max_retained_snapshots.max(1);
+            let over_count = self.pg_snapshots.len() > self.config.notebook.max_retained_snapshots;
             let over_bytes = total_bytes > self.config.notebook.snapshot_total_bytes;
             if !over_count && !over_bytes {
                 break;
             }
-            let Some(handle) = self.pg_snapshot_order.pop_front() else {
+            let Some(handle) = self.pg_snapshot_lru.pop_front() else {
                 break;
             };
             let Some(evicted) = self.pg_snapshots.remove(&handle) else {
                 continue;
             };
+            self.pg_snapshot_order
+                .retain(|candidate| *candidate != handle);
+            self.evicted_versions.extend(
+                self.retained_versions
+                    .iter()
+                    .filter_map(|(version, candidate)| (*candidate == handle).then_some(*version)),
+            );
             self.retained_versions
                 .retain(|_, candidate| *candidate != handle);
             for cell in &mut self.notebook.cells {
@@ -10740,16 +12434,10 @@ impl App {
                     }
                 }
             }
-            if let Some(client) = self.db.client.clone() {
-                self.rt.spawn(async move {
-                    let guard = client.lock().await;
-                    let physical_name = evicted.physical_name.replace('"', "\"\"");
-                    let _ = guard
-                        .batch_execute(&format!("DROP TABLE IF EXISTS pg_temp.\"{physical_name}\""))
-                        .await;
-                });
-            }
+            self.drop_pg_snapshots(vec![evicted]);
         }
+
+        self.pg_snapshots.contains_key(&retained.handle)
     }
 
     fn latest_notebook_result_version(&self, source_cell: Option<CellId>) -> Option<ResultVersion> {
@@ -10759,20 +12447,18 @@ impl App {
                 return None;
             }
 
-            self.notebook.cells.iter().find_map(|cell| {
-                let output = cell.output.as_ref()?;
-                let retained = output.retained.as_ref()?;
-                let RefinementAvailability::Available(available) = &output.refinement else {
-                    return None;
-                };
-                (retained.handle == *handle
-                    && available.handle == *handle
-                    && retained.connection_generation == self.connect_generation
-                    && self.retained_versions.get(&retained.version) == Some(handle)
-                    && source_cell
-                        .is_none_or(|source_cell| retained.version.source_cell == source_cell))
-                .then_some(retained.version)
-            })
+            self.retained_versions
+                .iter()
+                .find_map(|(version, candidate)| {
+                    (*candidate == *handle
+                        && self
+                            .notebook
+                            .cells
+                            .iter()
+                            .any(|cell| cell.id == version.source_cell)
+                        && source_cell.is_none_or(|source_cell| version.source_cell == source_cell))
+                    .then_some(*version)
+                })
         })
     }
 
@@ -10780,14 +12466,25 @@ impl App {
         self.execute_notebook_cell_with_snapshot(true);
     }
 
-    fn notebook_snapshot_for_version(&self, version: ResultVersion) -> Option<PgTempSnapshot> {
-        let handle = self.retained_versions.get(&version)?;
-        let snapshot = self.pg_snapshots.get(handle)?;
-        (snapshot.connection_generation == self.connect_generation).then(|| snapshot.clone())
+    fn notebook_snapshot_for_version(&mut self, version: ResultVersion) -> Option<PgTempSnapshot> {
+        let handle = *self.retained_versions.get(&version)?;
+        let snapshot = self.pg_snapshots.get(&handle)?;
+        if snapshot.connection_generation != self.connect_generation {
+            return None;
+        }
+        let snapshot = snapshot.clone();
+        self.touch_pg_snapshot(handle);
+        Some(snapshot)
+    }
+
+    fn touch_pg_snapshot(&mut self, handle: RetainedResultHandle) {
+        self.pg_snapshot_lru
+            .retain(|candidate| *candidate != handle);
+        self.pg_snapshot_lru.push_back(handle);
     }
 
     fn resolve_notebook_result_dependency(
-        &self,
+        &mut self,
         source: &str,
         dependency: Option<ResultVersion>,
     ) -> Result<Option<(ResultVersion, PgTempSnapshot)>, String> {
@@ -10817,6 +12514,13 @@ impl App {
                     return Ok(Some((version, snapshot)));
                 }
 
+                if dependency.is_some_and(|version| self.evicted_versions.contains(&version)) {
+                    return Err(format!(
+                        "Result for cell {} was evicted. Use :rebase or rerun the source cell",
+                        source_cell.0
+                    ));
+                }
+
                 self.latest_notebook_result_version(Some(source_cell))
                     .and_then(|version| {
                         self.notebook_snapshot_for_version(version)
@@ -10830,25 +12534,78 @@ impl App {
                         )
                     })
             }
-            None => dependency
-                .map(|version| {
-                    self.notebook_snapshot_for_version(version)
-                        .map(|snapshot| (version, snapshot))
-                        .ok_or_else(|| {
-                            "Source snapshot is unavailable. Run the source cell first".to_string()
-                        })
-                })
-                .transpose(),
+            Some(LogicalResultReference::Named(name)) => {
+                let source_cell = self
+                    .notebook
+                    .cells
+                    .iter()
+                    .find(|cell| cell.result_name.as_deref() == Some(name.as_str()))
+                    .map(|cell| cell.id)
+                    .ok_or_else(|| format!("No notebook cell is named '{name}'"))?;
+                self.resolve_notebook_result_dependency(
+                    &format!("SELECT * FROM @result_{}", source_cell.0),
+                    dependency,
+                )
+            }
+            None => Ok(None),
         }
     }
 
+    fn resolve_notebook_result_dependencies(
+        &mut self,
+        source: &str,
+        primary_dependency: Option<ResultVersion>,
+        additional_dependencies: &[ResultVersion],
+    ) -> Result<Vec<(LogicalResultReference, ResultVersion, PgTempSnapshot)>, String> {
+        let mut resolved = Vec::new();
+        for reference in logical_result_references(source)? {
+            let (reference_source, dependency) = match &reference {
+                LogicalResultReference::Latest => ("@result".to_string(), None),
+                LogicalResultReference::Cell(source_cell) => (
+                    format!("@result_{}", source_cell.0),
+                    primary_dependency
+                        .into_iter()
+                        .chain(additional_dependencies.iter().copied())
+                        .find(|dependency| dependency.source_cell == *source_cell),
+                ),
+                LogicalResultReference::Named(name) => {
+                    let source_cell = self
+                        .notebook
+                        .cells
+                        .iter()
+                        .find(|cell| cell.result_name.as_deref() == Some(name.as_str()))
+                        .map(|cell| cell.id)
+                        .ok_or_else(|| format!("No notebook cell is named '{name}'"))?;
+                    (
+                        format!("@result_{}", source_cell.0),
+                        primary_dependency
+                            .into_iter()
+                            .chain(additional_dependencies.iter().copied())
+                            .find(|dependency| dependency.source_cell == source_cell),
+                    )
+                }
+            };
+            let Some((version, snapshot)) =
+                self.resolve_notebook_result_dependency(&reference_source, dependency)?
+            else {
+                continue;
+            };
+            resolved.push((reference, version, snapshot));
+        }
+        Ok(resolved)
+    }
+
     fn execute_notebook_cell_with_snapshot(&mut self, allow_snapshot: bool) {
-        if self.db.running {
-            self.last_status = Some("A query is already running".to_string());
+        if self.db.running || self.notebook_export_loading.is_some() {
+            self.last_status = Some(if self.notebook_export_loading.is_some() {
+                "Wait for the notebook export to finish before running a cell".to_string()
+            } else {
+                "A query is already running".to_string()
+            });
             return;
         }
 
-        let (cell_id, source_revision, logical_query, dependency) = {
+        let (cell_id, source_revision, logical_query, dependency, additional_dependencies) = {
             let cell = self.notebook.selected_cell();
             if cell
                 .bound_connection_generation
@@ -10859,7 +12616,13 @@ impl App {
                 );
                 return;
             }
-            (cell.id, cell.revision, cell.source(), cell.dependency)
+            (
+                cell.id,
+                cell.revision,
+                cell.source(),
+                cell.dependency,
+                cell.additional_dependencies.clone(),
+            )
         };
         if logical_query.trim().is_empty() {
             self.last_status = Some("No query to run".to_string());
@@ -10871,9 +12634,15 @@ impl App {
                 Some("Not connected. Use :connect <url> or select a connection first.".to_string());
             return;
         }
-        let resolved_dependency =
-            match self.resolve_notebook_result_dependency(&logical_query, dependency) {
-                Ok(dependency) => dependency,
+        let resolved_dependencies = if is_mongo {
+            Vec::new()
+        } else {
+            match self.resolve_notebook_result_dependencies(
+                &logical_query,
+                dependency,
+                &additional_dependencies,
+            ) {
+                Ok(dependencies) => dependencies,
                 Err(error) => {
                     if let Some(cell) = self.notebook.cell_mut(cell_id) {
                         cell.execution = CellExecutionState::Failed;
@@ -10882,17 +12651,48 @@ impl App {
                     self.last_status = Some(format!("Notebook cell {} failed", cell_id.0));
                     return;
                 }
-            };
-        let (query, source_snapshot) = if let Some((version, snapshot)) = resolved_dependency {
-            match compile_logical_reference(
-                &logical_query,
-                version,
-                &snapshot.physical_name,
-                &snapshot.public_columns,
-            ) {
+            }
+        };
+        let (query, source_snapshots, source_map) = if resolved_dependencies.is_empty() {
+            let cell = self.notebook.selected_cell_mut();
+            cell.dependency = None;
+            cell.additional_dependencies.clear();
+            (
+                logical_query.clone(),
+                Vec::new(),
+                SqlSourceMap::identity(&logical_query),
+            )
+        } else {
+            let bindings = resolved_dependencies
+                .iter()
+                .map(|(reference, version, snapshot)| {
+                    (
+                        reference.clone(),
+                        *version,
+                        snapshot.physical_name.clone(),
+                        snapshot.public_columns.clone(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            match compile_logical_references_mapped(&logical_query, &bindings) {
                 Ok(compiled) => {
-                    self.notebook.selected_cell_mut().dependency = Some(version);
-                    (compiled, Some(snapshot))
+                    let cell = self.notebook.selected_cell_mut();
+                    cell.dependency = resolved_dependencies
+                        .first()
+                        .map(|(_, version, _)| *version);
+                    cell.additional_dependencies = resolved_dependencies
+                        .iter()
+                        .skip(1)
+                        .map(|(_, version, _)| *version)
+                        .collect();
+                    (
+                        compiled.sql,
+                        resolved_dependencies
+                            .into_iter()
+                            .map(|(_, _, snapshot)| snapshot)
+                            .collect(),
+                        compiled.source_map,
+                    )
                 }
                 Err(error) => {
                     if let Some(cell) = self.notebook.cell_mut(cell_id) {
@@ -10903,8 +12703,6 @@ impl App {
                     return;
                 }
             }
-        } else {
-            (logical_query.clone(), None)
         };
         if !is_mongo
             && matches!(
@@ -10914,10 +12712,12 @@ impl App {
                     | TransactionControl::CommitAndChain
                     | TransactionControl::Rollback
                     | TransactionControl::RollbackAndChain
+                    | TransactionControl::Ambiguous
             )
         {
             self.last_status = Some(
-                "Transaction control is available in Classic mode for this release".to_string(),
+                "Transaction control and multi-statement execution are available in Classic mode"
+                    .to_string(),
             );
             return;
         }
@@ -10934,6 +12734,10 @@ impl App {
             kind: QueryExecutionKind::New,
             cancelling: false,
         });
+        self.active_classic_execution = None;
+        self.active_notebook_sql = Some(query.clone());
+        let cancelled = Arc::new(AtomicBool::new(false));
+        self.active_notebook_cancelled = Some(cancelled.clone());
         if let Some(cell) = self.notebook.cell_mut(cell_id) {
             cell.execution = CellExecutionState::Running(context);
             cell.failure = None;
@@ -10948,6 +12752,10 @@ impl App {
             .conn_str
             .as_ref()
             .map(|connection| ConnectionInfo::parse(connection).format(50));
+        self.notebook
+            .selected_cell_mut()
+            .editor
+            .push_history(logical_query.clone());
         self.history.push(logical_query, conn_info);
 
         let max_rows = effective_max_rows(self.config.connection.max_rows);
@@ -10961,7 +12769,19 @@ impl App {
                 .clone()
                 .unwrap_or_else(|| "admin".to_string());
             let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
-            self.execute_query_mongo(mongo_client, database, query, max_rows, proxy_tx);
+            self.execute_query_mongo(
+                mongo_client,
+                database,
+                query,
+                MongoQueryLimits {
+                    max_rows,
+                    max_bytes: notebook_display_byte_budget(
+                        self.config.notebook.snapshot_max_bytes,
+                    ),
+                    timeout_secs: self.config.connection.query_timeout_secs,
+                },
+                proxy_tx,
+            );
             let tx = self.db_events_tx.clone();
             self.rt.spawn(async move {
                 while let Some(event) = proxy_rx.recv().await {
@@ -11005,7 +12825,9 @@ impl App {
                 display_max_rows: max_rows,
                 max_bytes: self.config.notebook.snapshot_max_bytes,
                 timeout_secs: self.config.connection.query_timeout_secs,
-                source_snapshot,
+                source_snapshots,
+                cancelled: Some(cancelled),
+                source_map: Some(source_map),
             };
             let tx = self.db_events_tx.clone();
             self.rt.spawn(async move {
@@ -11029,9 +12851,15 @@ impl App {
             client,
             query,
             max_rows,
+            notebook_display_byte_budget(self.config.notebook.snapshot_max_bytes),
             source_table,
             self.db_events_tx.clone(),
             Some(context),
+            source_snapshots,
+            self.config.connection.query_timeout_secs,
+            self.db.connected_with_tls,
+            Some(cancelled),
+            Some(source_map),
         );
     }
 
@@ -11059,6 +12887,15 @@ impl App {
             return;
         }
 
+        if kind == QueryExecutionKind::New {
+            self.classic_result_base_query = Some(query.clone());
+            self.classic_result_base_headers.clear();
+            self.classic_result_transform.reset();
+            self.classic_result_applied_transform.reset();
+            self.result_columns_picker = None;
+            self.result_columns_draft.clear();
+        }
+
         self.db.running = true;
         self.last_status = Some(
             match kind {
@@ -11069,7 +12906,15 @@ impl App {
         );
         self.query_ui.start();
 
-        let tx = self.db_events_tx.clone();
+        let context = ExecutionContext {
+            id: ExecutionId(self.next_execution_id),
+            target: ExecutionTarget::Classic,
+            source_revision: 0,
+            connection_generation: self.connect_generation,
+        };
+        self.next_execution_id = self.next_execution_id.wrapping_add(1);
+        self.active_classic_execution = Some(context);
+        let tx = self.classic_event_sender(context);
         let max_rows = effective_max_rows(self.config.connection.max_rows);
 
         if self.db.kind == Some(DbKind::Mongo) {
@@ -11088,7 +12933,17 @@ impl App {
             self.last_executed_query = Some(query.clone());
             self.active_query_kind = Some(kind);
             self.paged_query = None;
-            self.execute_query_mongo(client, db_name, query, max_rows, tx);
+            self.execute_query_mongo(
+                client,
+                db_name,
+                query,
+                MongoQueryLimits {
+                    max_rows,
+                    max_bytes: usize::MAX,
+                    timeout_secs: self.config.connection.query_timeout_secs,
+                },
+                tx,
+            );
             return;
         }
 
@@ -11113,8 +12968,11 @@ impl App {
         let source_table = extract_table_from_query(&query);
         let page_size = DEFAULT_PAGE_SIZE;
 
-        // Use cursor-based paging for simple SELECT queries
-        if is_pageable_query(&query) {
+        // Transformed results remain a single validated SELECT and can use the
+        // same server-side cursor even though the wrapper contains a subquery.
+        let transformed_pageable =
+            kind == QueryExecutionKind::Refresh && !self.classic_result_transform.is_empty();
+        if is_pageable_query(&query) || transformed_pageable {
             // Create channel for fetch-more requests
             let (fetch_more_tx, fetch_more_rx) = mpsc::unbounded_channel();
 
@@ -11131,10 +12989,26 @@ impl App {
                 source_table,
                 tx,
                 fetch_more_rx,
+                self.config.connection.query_timeout_secs,
+                transformed_pageable,
+                self.db.connected_with_tls,
             );
         } else {
             self.paged_query = None;
-            self.execute_query_simple(client, query, max_rows, source_table, tx, None);
+            self.execute_query_simple(
+                client,
+                query,
+                max_rows,
+                usize::MAX,
+                source_table,
+                tx,
+                None,
+                Vec::new(),
+                self.config.connection.query_timeout_secs,
+                self.db.connected_with_tls,
+                None,
+                None,
+            );
         }
     }
 
@@ -11151,6 +13025,9 @@ impl App {
         source_table: Option<String>,
         tx: mpsc::UnboundedSender<DbEvent>,
         mut fetch_more_rx: mpsc::UnboundedReceiver<()>,
+        timeout_secs: u32,
+        read_only: bool,
+        connected_with_tls: bool,
     ) {
         let started = Instant::now();
 
@@ -11168,33 +13045,57 @@ impl App {
             // WITH HOLD allows the cursor to persist after COMMIT, so we can
             // release the transaction while keeping the cursor open for paging.
             // This prevents holding locks and snapshots for idle paged queries.
-            if let Err(e) = guard.simple_query("BEGIN").await {
+            let begin = if read_only {
+                "BEGIN READ ONLY"
+            } else {
+                "BEGIN"
+            };
+            if let Err(e) = guard.simple_query(begin).await {
                 let _ = tx.send(DbEvent::QueryError {
                     error: format!("Failed to begin transaction: {}", format_pg_error(&e)),
                 });
                 return;
             }
 
+            if timeout_secs > 0 {
+                let timeout_ms = timeout_secs.saturating_mul(1_000);
+                if let Err(e) = guard
+                    .simple_query(&format!("SET LOCAL statement_timeout = {timeout_ms}"))
+                    .await
+                {
+                    let _ = guard.simple_query("ROLLBACK").await;
+                    let _ = tx.send(DbEvent::QueryError {
+                        error: format!(
+                            "Failed to set cursor statement timeout: {}",
+                            format_pg_error(&e)
+                        ),
+                    });
+                    return;
+                }
+            }
+
             let cursor_query = format!(
                 "DECLARE tsql_cursor NO SCROLL CURSOR WITH HOLD FOR {}",
                 query.trim().trim_end_matches(';')
             );
-            if let Err(e) = guard.simple_query(&cursor_query).await {
+            if let Err(error) =
+                cursor_simple_query(&guard, &cursor_query, timeout_secs, connected_with_tls).await
+            {
                 // Rollback on failure - cursor wasn't created
                 let _ = guard.simple_query("ROLLBACK").await;
                 let _ = tx.send(DbEvent::QueryError {
-                    error: format!("Failed to declare cursor: {}", format_pg_error(&e)),
+                    error: format!("Failed to declare cursor: {error}"),
                 });
                 return;
             }
 
             // Commit the transaction - WITH HOLD cursor persists after commit
-            if let Err(e) = guard.simple_query("COMMIT").await {
+            if let Err(error) =
+                cursor_simple_query(&guard, "COMMIT", timeout_secs, connected_with_tls).await
+            {
+                let _ = guard.simple_query("ROLLBACK").await;
                 let _ = tx.send(DbEvent::QueryError {
-                    error: format!(
-                        "Failed to commit cursor transaction: {}",
-                        format_pg_error(&e)
-                    ),
+                    error: format!("Failed to commit cursor transaction: {error}"),
                 });
                 return;
             }
@@ -11205,15 +13106,17 @@ impl App {
             // Fetch first page to get headers and initial rows.
             // Bound the first fetch to max_rows if it's smaller than page_size.
             let first_page_size = page_size.min(max_rows);
-            let fetch_query = format!("FETCH FORWARD {} FROM tsql_cursor", first_page_size);
+            let fetch_query = cursor_fetch_query(first_page_size, timeout_secs, read_only);
             let mut headers: Vec<String> = Vec::new();
             let mut first_page_rows: Vec<Vec<String>> = Vec::new();
+            let mut first_page_null_cells: Vec<Vec<bool>> = Vec::new();
             let mut total_fetched: usize = 0;
             let mut done = false;
             let mut truncated = false;
 
             // First fetch
-            match guard.simple_query(&fetch_query).await {
+            match cursor_simple_query(&guard, &fetch_query, timeout_secs, connected_with_tls).await
+            {
                 Ok(messages) => {
                     for msg in messages {
                         match msg {
@@ -11228,14 +13131,24 @@ impl App {
                                 // Enforce max_rows on the initial page too
                                 if total_fetched < max_rows {
                                     let mut out_row = Vec::with_capacity(row.len());
+                                    let mut null_row = Vec::with_capacity(row.len());
                                     for i in 0..row.len() {
-                                        out_row.push(row.get(i).unwrap_or("NULL").to_string());
+                                        let cell = row.get(i);
+                                        null_row.push(cell.is_none());
+                                        out_row.push(cell.unwrap_or("NULL").to_string());
                                     }
                                     first_page_rows.push(out_row);
+                                    first_page_null_cells.push(null_row);
                                     total_fetched += 1;
                                 } else {
                                     truncated = true;
                                 }
+                            }
+                            SimpleQueryMessage::RowDescription(columns) if headers.is_empty() => {
+                                headers = columns
+                                    .iter()
+                                    .map(|column| column.name().to_string())
+                                    .collect();
                             }
                             SimpleQueryMessage::CommandComplete(_) => {}
                             _ => {}
@@ -11250,11 +13163,12 @@ impl App {
                         done = true;
                     }
                 }
-                Err(e) => {
+                Err(error) => {
+                    let _ = guard.simple_query("ROLLBACK").await;
                     drop(guard);
                     close_cursor(&client).await;
                     let _ = tx.send(DbEvent::QueryError {
-                        error: format!("Failed to fetch rows: {}", format_pg_error(&e)),
+                        error: format!("Failed to fetch rows: {error}"),
                     });
                     return;
                 }
@@ -11274,21 +13188,9 @@ impl App {
             // Send initial result with first page IMMEDIATELY (no metadata yet)
             // This gives instant feedback to the user
             let result = QueryResult {
-                headers: if first_page_rows.is_empty() && headers.is_empty() {
-                    vec!["status".to_string()]
-                } else {
-                    headers
-                },
-                rows: if first_page_rows.is_empty() {
-                    let status = if is_row_returning_query(&query) {
-                        "No rows".to_string()
-                    } else {
-                        "OK".to_string()
-                    };
-                    vec![vec![status]]
-                } else {
-                    first_page_rows
-                },
+                headers,
+                rows: first_page_rows,
+                null_cells: first_page_null_cells,
                 command_tag: Some(format!("{} rows", total_fetched)),
                 truncated, // Set true if max_rows limit was hit
                 elapsed,
@@ -11328,6 +13230,7 @@ impl App {
                 // Send final completion signal so paged_query state is cleared
                 let _ = tx.send(DbEvent::RowsAppended {
                     rows: vec![],
+                    null_cells: vec![],
                     done: true,
                     truncated,
                 });
@@ -11336,7 +13239,7 @@ impl App {
 
             // Wait for fetch-more signals and fetch additional pages on demand.
             // Continuation fetches use page_size (not first_page_size which was bounded by max_rows).
-            let continuation_fetch_query = format!("FETCH FORWARD {} FROM tsql_cursor", page_size);
+            let continuation_fetch_query = cursor_fetch_query(page_size, timeout_secs, read_only);
             while let Some(()) = fetch_more_rx.recv().await {
                 // Drain any additional pending requests (user may have scrolled multiple times)
                 while fetch_more_rx.try_recv().is_ok() {}
@@ -11345,6 +13248,7 @@ impl App {
                 if total_fetched >= max_rows {
                     let _ = tx.send(DbEvent::RowsAppended {
                         rows: vec![],
+                        null_cells: vec![],
                         done: true,
                         truncated: true,
                     });
@@ -11352,16 +13256,28 @@ impl App {
                 }
 
                 let guard = client.lock().await;
-                match guard.simple_query(&continuation_fetch_query).await {
+                match cursor_simple_query(
+                    &guard,
+                    &continuation_fetch_query,
+                    timeout_secs,
+                    connected_with_tls,
+                )
+                .await
+                {
                     Ok(messages) => {
                         let mut page_rows: Vec<Vec<String>> = Vec::new();
+                        let mut page_null_cells: Vec<Vec<bool>> = Vec::new();
                         for msg in messages {
                             if let SimpleQueryMessage::Row(row) = msg {
                                 let mut out_row = Vec::with_capacity(row.len());
+                                let mut null_row = Vec::with_capacity(row.len());
                                 for i in 0..row.len() {
-                                    out_row.push(row.get(i).unwrap_or("NULL").to_string());
+                                    let cell = row.get(i);
+                                    null_row.push(cell.is_none());
+                                    out_row.push(cell.unwrap_or("NULL").to_string());
                                 }
                                 page_rows.push(out_row);
+                                page_null_cells.push(null_row);
                                 total_fetched += 1;
 
                                 // Stop collecting if we hit max_rows mid-page
@@ -11379,6 +13295,7 @@ impl App {
                         // Send appended rows
                         let _ = tx.send(DbEvent::RowsAppended {
                             rows: page_rows,
+                            null_cells: page_null_cells,
                             done: page_done,
                             truncated: hit_max,
                         });
@@ -11387,9 +13304,10 @@ impl App {
                             break;
                         }
                     }
-                    Err(e) => {
+                    Err(error) => {
+                        let _ = guard.simple_query("ROLLBACK").await;
                         let _ = tx.send(DbEvent::QueryError {
-                            error: format!("Failed to fetch rows: {}", format_pg_error(&e)),
+                            error: format!("Failed to fetch rows: {error}"),
                         });
                         break;
                     }
@@ -11407,88 +13325,108 @@ impl App {
     }
 
     /// Execute a query using simple_query (for non-pageable queries).
+    #[allow(clippy::too_many_arguments)]
     fn execute_query_simple(
         &self,
         client: SharedClient,
         query: String,
         max_rows: usize,
+        max_bytes: usize,
         source_table: Option<String>,
         tx: mpsc::UnboundedSender<DbEvent>,
         context: Option<ExecutionContext>,
+        source_snapshots: Vec<PgTempSnapshot>,
+        timeout_secs: u32,
+        connected_with_tls: bool,
+        cancelled: Option<Arc<AtomicBool>>,
+        source_map: Option<SqlSourceMap>,
     ) {
         let started = Instant::now();
 
         self.rt.spawn(async move {
             let guard = client.lock().await;
-            match guard.simple_query(&query).await {
-                Ok(messages) => {
+            if cancelled
+                .as_ref()
+                .is_some_and(|cancelled| cancelled.load(Ordering::Acquire))
+            {
+                let error = "query was cancelled before execution".to_string();
+                let event = match context {
+                    Some(context) => DbEvent::NotebookQueryError { context, error },
+                    None => DbEvent::QueryError { error },
+                };
+                let _ = tx.send(event);
+                return;
+            }
+            for snapshot in &source_snapshots {
+                if let Err(error) = pg_snapshot::validate_snapshot_identity(&guard, snapshot).await
+                {
+                    let event = match context {
+                        Some(context) => DbEvent::NotebookQueryError { context, error },
+                        None => DbEvent::QueryError { error },
+                    };
+                    let _ = tx.send(event);
+                    return;
+                }
+            }
+            let bounded_preview =
+                context.and_then(|_| bounded_notebook_preview_query(&query, max_rows));
+            let generated_prefix = if bounded_preview.is_some() {
+                "SELECT * FROM (\n"
+            } else {
+                ""
+            };
+            let execution_query = bounded_preview.unwrap_or_else(|| query.clone());
+            let query_result = if timeout_secs == 0 {
+                stream_simple_query(&guard, &execution_query, max_rows, max_bytes).await
+            } else {
+                match tokio::time::timeout(
+                    Duration::from_secs(u64::from(timeout_secs)),
+                    stream_simple_query(&guard, &execution_query, max_rows, max_bytes),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => {
+                        let token = guard.cancel_token();
+                        drop(guard);
+                        if connected_with_tls {
+                            let _ = token.cancel_query(make_rustls_connect_insecure()).await;
+                        } else {
+                            let _ = token.cancel_query(NoTls).await;
+                        }
+                        let error = format!("query timed out after {timeout_secs}s");
+                        let event = match context {
+                            Some(context) => DbEvent::NotebookQueryError { context, error },
+                            None => DbEvent::QueryError { error },
+                        };
+                        let _ = tx.send(event);
+                        return;
+                    }
+                }
+            };
+            match query_result {
+                Ok(streamed) => {
                     drop(guard);
                     let elapsed = started.elapsed();
 
-                    let mut current_headers: Option<Vec<String>> = None;
-                    let mut current_rows: Vec<Vec<String>> = Vec::new();
-                    let mut last_headers: Vec<String> = Vec::new();
-                    let mut last_rows: Vec<Vec<String>> = Vec::new();
-                    let mut last_cmd: Option<String> = None;
-                    let mut truncated = false;
-
-                    for msg in messages {
-                        match msg {
-                            SimpleQueryMessage::Row(row) => {
-                                if current_headers.is_none() {
-                                    current_headers = Some(
-                                        row.columns()
-                                            .iter()
-                                            .map(|c| c.name().to_string())
-                                            .collect(),
-                                    );
-                                }
-
-                                if current_rows.len() < max_rows {
-                                    let mut out_row = Vec::with_capacity(row.len());
-                                    for i in 0..row.len() {
-                                        out_row.push(row.get(i).unwrap_or("NULL").to_string());
-                                    }
-                                    current_rows.push(out_row);
-                                } else {
-                                    truncated = true;
-                                }
-                            }
-                            SimpleQueryMessage::CommandComplete(rows_affected) => {
-                                last_cmd = Some(format!("{} rows", rows_affected));
-
-                                if let Some(h) = current_headers.take() {
-                                    last_headers = h;
-                                    last_rows = std::mem::take(&mut current_rows);
-                                } else {
-                                    current_rows.clear();
-                                }
-                            }
-                            SimpleQueryMessage::RowDescription(_) => {
-                                // We get headers from the Row itself.
-                            }
-                            _ => {
-                                // Catch any future variants; do nothing.
-                            }
-                        }
-                    }
-
-                    if let Some(h) = current_headers.take() {
-                        last_headers = h;
-                        last_rows = current_rows;
-                    }
-
-                    let (headers, rows) = if last_headers.is_empty() {
-                        let status = if last_cmd.as_deref() == Some("0 rows")
+                    let (headers, rows, null_cells) = if streamed.headers.is_empty() {
+                        let status = if streamed.command_tag.as_deref() == Some("0 rows")
                             && is_row_returning_query(&query)
                         {
                             "No rows".to_string()
                         } else {
-                            last_cmd.clone().unwrap_or_else(|| "OK".to_string())
+                            streamed
+                                .command_tag
+                                .clone()
+                                .unwrap_or_else(|| "OK".to_string())
                         };
-                        (vec!["status".to_string()], vec![vec![status]])
+                        (
+                            vec!["status".to_string()],
+                            vec![vec![status]],
+                            vec![vec![false]],
+                        )
                     } else {
-                        (last_headers, last_rows)
+                        (streamed.headers, streamed.rows, streamed.null_cells)
                     };
 
                     // Fetch column types if we have a source table
@@ -11512,8 +13450,9 @@ impl App {
                     let result = QueryResult {
                         headers,
                         rows,
-                        command_tag: last_cmd,
-                        truncated,
+                        null_cells,
+                        command_tag: streamed.command_tag,
+                        truncated: streamed.truncated,
                         elapsed,
                         source_table,
                         primary_keys,
@@ -11533,7 +13472,11 @@ impl App {
                     let _ = tx.send(event);
                 }
                 Err(e) => {
-                    let error = format_pg_error(&e);
+                    let error = format_pg_error_with_position(&e, |position| {
+                        source_map
+                            .as_ref()
+                            .and_then(|map| map.map_position(position, generated_prefix))
+                    });
                     let event = if let Some(context) = context {
                         DbEvent::NotebookQueryError { context, error }
                     } else {
@@ -11545,354 +13488,427 @@ impl App {
         });
     }
 
+    fn classic_event_sender(&self, context: ExecutionContext) -> mpsc::UnboundedSender<DbEvent> {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let destination = self.db_events_tx.clone();
+        self.rt.spawn(async move {
+            while let Some(event) = rx.recv().await {
+                let event = match event {
+                    DbEvent::QueryFinished { .. }
+                    | DbEvent::QueryError { .. }
+                    | DbEvent::RowsAppended { .. }
+                    | DbEvent::MetadataLoaded { .. } => DbEvent::ClassicExecution {
+                        context,
+                        event: Box::new(event),
+                    },
+                    other => other,
+                };
+                if destination.send(event).is_err() {
+                    break;
+                }
+            }
+        });
+        tx
+    }
+
     fn execute_query_mongo(
         &self,
         client: SharedMongoClient,
         db_name: String,
         query: String,
-        max_rows: usize,
+        limits: MongoQueryLimits,
         tx: mpsc::UnboundedSender<DbEvent>,
     ) {
         let started = Instant::now();
+        let MongoQueryLimits {
+            max_rows,
+            max_bytes,
+            timeout_secs,
+        } = limits;
 
+        let timeout_tx = tx.clone();
         self.rt.spawn(async move {
-            let parsed = match parse_mongo_query(&query) {
-                Ok(parsed) => parsed,
-                Err(e) => {
-                    let _ = tx.send(DbEvent::QueryError { error: e });
-                    return;
-                }
-            };
-
-            let db = client.database(&db_name);
-
-            let result = match parsed {
-                MongoQuery::Find {
-                    collection,
-                    filter,
-                    projection,
-                    limit,
-                } => {
-                    let coll = db.collection::<Document>(&collection);
-                    let mut action = coll.find(filter);
-                    if let Some(proj) = projection {
-                        action = action.projection(proj);
+            let execution = async move {
+                let parsed = match parse_mongo_query(&query) {
+                    Ok(parsed) => parsed,
+                    Err(e) => {
+                        let _ = tx.send(DbEvent::QueryError { error: e });
+                        return;
                     }
-                    if let Some(limit) = limit {
-                        action = action.limit(limit);
-                    }
-                    match action.await {
-                        Ok(mut cursor) => {
-                            let mut docs = Vec::new();
-                            let mut truncated = false;
-                            loop {
-                                match cursor.try_next().await {
-                                    Ok(Some(doc)) => {
-                                        if docs.len() >= max_rows {
-                                            truncated = true;
-                                            break;
+                };
+
+                let db = client.database(&db_name);
+
+                let result = match parsed {
+                    MongoQuery::Find {
+                        collection,
+                        filter,
+                        projection,
+                        limit,
+                    } => {
+                        let coll = db.collection::<Document>(&collection);
+                        let mut action = coll.find(filter);
+                        if let Some(proj) = projection {
+                            action = action.projection(proj);
+                        }
+                        if let Some(limit) = limit {
+                            action = action.limit(limit);
+                        }
+                        match action.await {
+                            Ok(mut cursor) => {
+                                let mut docs = Vec::new();
+                                let mut used_bytes = 0;
+                                let mut truncated = false;
+                                loop {
+                                    match cursor.try_next().await {
+                                        Ok(Some(doc)) => {
+                                            if !push_bounded_mongo_document(
+                                                &mut docs,
+                                                doc,
+                                                &mut used_bytes,
+                                                max_rows,
+                                                max_bytes,
+                                            ) {
+                                                truncated = true;
+                                                break;
+                                            }
                                         }
-                                        docs.push(doc);
-                                    }
-                                    Ok(None) => break,
-                                    Err(e) => {
-                                        let _ = tx.send(DbEvent::QueryError {
-                                            error: format!("Mongo find cursor error: {e}"),
-                                        });
-                                        return;
+                                        Ok(None) => break,
+                                        Err(e) => {
+                                            let _ = tx.send(DbEvent::QueryError {
+                                                error: format!("Mongo find cursor error: {e}"),
+                                            });
+                                            return;
+                                        }
                                     }
                                 }
+                                mongo_result_from_documents(
+                                    docs,
+                                    Some(collection),
+                                    started.elapsed(),
+                                    truncated,
+                                )
                             }
-                            mongo_result_from_documents(
-                                docs,
-                                Some(collection),
-                                started.elapsed(),
-                                truncated,
-                            )
-                        }
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo find error: {e}"),
-                            });
-                            return;
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo find error: {e}"),
+                                });
+                                return;
+                            }
                         }
                     }
-                }
-                MongoQuery::FindOne {
-                    collection,
-                    filter,
-                    projection,
-                } => {
-                    let coll = db.collection::<Document>(&collection);
-                    let mut action = coll.find_one(filter);
-                    if let Some(proj) = projection {
-                        action = action.projection(proj);
-                    }
-                    match action.await {
-                        Ok(doc) => mongo_result_from_documents(
-                            doc.into_iter().collect(),
-                            Some(collection),
-                            started.elapsed(),
-                            false,
-                        ),
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo findOne error: {e}"),
-                            });
-                            return;
+                    MongoQuery::FindOne {
+                        collection,
+                        filter,
+                        projection,
+                    } => {
+                        let coll = db.collection::<Document>(&collection);
+                        let mut action = coll.find_one(filter);
+                        if let Some(proj) = projection {
+                            action = action.projection(proj);
+                        }
+                        match action.await {
+                            Ok(doc) => {
+                                let mut docs = Vec::new();
+                                let mut used_bytes = 0;
+                                let truncated = doc.is_some_and(|doc| {
+                                    !push_bounded_mongo_document(
+                                        &mut docs,
+                                        doc,
+                                        &mut used_bytes,
+                                        max_rows,
+                                        max_bytes,
+                                    )
+                                });
+                                mongo_result_from_documents(
+                                    docs,
+                                    Some(collection),
+                                    started.elapsed(),
+                                    truncated,
+                                )
+                            }
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo findOne error: {e}"),
+                                });
+                                return;
+                            }
                         }
                     }
-                }
-                MongoQuery::Aggregate {
-                    collection,
-                    pipeline,
-                } => {
-                    let coll = db.collection::<Document>(&collection);
-                    match coll.aggregate(pipeline).await {
-                        Ok(mut cursor) => {
-                            let mut docs = Vec::new();
-                            let mut truncated = false;
-                            loop {
-                                match cursor.try_next().await {
-                                    Ok(Some(doc)) => {
-                                        if docs.len() >= max_rows {
-                                            truncated = true;
-                                            break;
+                    MongoQuery::Aggregate {
+                        collection,
+                        pipeline,
+                    } => {
+                        let coll = db.collection::<Document>(&collection);
+                        match coll.aggregate(pipeline).await {
+                            Ok(mut cursor) => {
+                                let mut docs = Vec::new();
+                                let mut used_bytes = 0;
+                                let mut truncated = false;
+                                loop {
+                                    match cursor.try_next().await {
+                                        Ok(Some(doc)) => {
+                                            if !push_bounded_mongo_document(
+                                                &mut docs,
+                                                doc,
+                                                &mut used_bytes,
+                                                max_rows,
+                                                max_bytes,
+                                            ) {
+                                                truncated = true;
+                                                break;
+                                            }
                                         }
-                                        docs.push(doc);
-                                    }
-                                    Ok(None) => break,
-                                    Err(e) => {
-                                        let _ = tx.send(DbEvent::QueryError {
-                                            error: format!("Mongo aggregate cursor error: {e}"),
-                                        });
-                                        return;
+                                        Ok(None) => break,
+                                        Err(e) => {
+                                            let _ = tx.send(DbEvent::QueryError {
+                                                error: format!("Mongo aggregate cursor error: {e}"),
+                                            });
+                                            return;
+                                        }
                                     }
                                 }
+                                mongo_result_from_documents(
+                                    docs,
+                                    Some(collection),
+                                    started.elapsed(),
+                                    truncated,
+                                )
                             }
-                            mongo_result_from_documents(
-                                docs,
-                                Some(collection),
-                                started.elapsed(),
-                                truncated,
-                            )
-                        }
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo aggregate error: {e}"),
-                            });
-                            return;
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo aggregate error: {e}"),
+                                });
+                                return;
+                            }
                         }
                     }
-                }
-                MongoQuery::CountDocuments { collection, filter } => {
-                    let coll = db.collection::<Document>(&collection);
-                    match coll.count_documents(filter).await {
-                        Ok(count) => QueryResult {
-                            headers: vec!["count".to_string()],
-                            rows: vec![vec![count.to_string()]],
-                            command_tag: Some("countDocuments".to_string()),
-                            truncated: false,
-                            elapsed: started.elapsed(),
-                            source_table: None,
-                            primary_keys: Vec::new(),
-                            col_types: vec!["int64".to_string()],
-                        },
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo countDocuments error: {e}"),
-                            });
-                            return;
-                        }
-                    }
-                }
-                MongoQuery::InsertOne {
-                    collection,
-                    document,
-                } => {
-                    let coll = db.collection::<Document>(&collection);
-                    match coll.insert_one(document).await {
-                        Ok(res) => {
-                            let inserted_id = bson_to_grid_cell(&res.inserted_id);
-                            QueryResult {
-                                headers: vec!["status".to_string(), "inserted_id".to_string()],
-                                rows: vec![vec!["insertOne".to_string(), inserted_id]],
-                                command_tag: Some("insertOne".to_string()),
+                    MongoQuery::CountDocuments { collection, filter } => {
+                        let coll = db.collection::<Document>(&collection);
+                        match coll.count_documents(filter).await {
+                            Ok(count) => QueryResult {
+                                null_cells: Vec::new(),
+                                headers: vec!["count".to_string()],
+                                rows: vec![vec![count.to_string()]],
+                                command_tag: Some("countDocuments".to_string()),
                                 truncated: false,
                                 elapsed: started.elapsed(),
                                 source_table: None,
                                 primary_keys: Vec::new(),
-                                col_types: vec!["string".to_string(), "objectId".to_string()],
+                                col_types: vec!["int64".to_string()],
+                            },
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo countDocuments error: {e}"),
+                                });
+                                return;
                             }
                         }
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo insertOne error: {e}"),
-                            });
-                            return;
+                    }
+                    MongoQuery::InsertOne {
+                        collection,
+                        document,
+                    } => {
+                        let coll = db.collection::<Document>(&collection);
+                        match coll.insert_one(document).await {
+                            Ok(res) => {
+                                let inserted_id = bson_to_grid_cell(&res.inserted_id);
+                                QueryResult {
+                                    null_cells: Vec::new(),
+                                    headers: vec!["status".to_string(), "inserted_id".to_string()],
+                                    rows: vec![vec!["insertOne".to_string(), inserted_id]],
+                                    command_tag: Some("insertOne".to_string()),
+                                    truncated: false,
+                                    elapsed: started.elapsed(),
+                                    source_table: None,
+                                    primary_keys: Vec::new(),
+                                    col_types: vec!["string".to_string(), "objectId".to_string()],
+                                }
+                            }
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo insertOne error: {e}"),
+                                });
+                                return;
+                            }
                         }
                     }
-                }
-                MongoQuery::InsertMany {
-                    collection,
-                    documents,
-                } => {
-                    let coll = db.collection::<Document>(&collection);
-                    match coll.insert_many(documents).await {
-                        Ok(res) => QueryResult {
-                            headers: vec!["status".to_string(), "inserted_count".to_string()],
-                            rows: vec![vec![
-                                "insertMany".to_string(),
-                                res.inserted_ids.len().to_string(),
-                            ]],
-                            command_tag: Some("insertMany".to_string()),
-                            truncated: false,
-                            elapsed: started.elapsed(),
-                            source_table: None,
-                            primary_keys: Vec::new(),
-                            col_types: vec!["string".to_string(), "int64".to_string()],
-                        },
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo insertMany error: {e}"),
-                            });
-                            return;
+                    MongoQuery::InsertMany {
+                        collection,
+                        documents,
+                    } => {
+                        let coll = db.collection::<Document>(&collection);
+                        match coll.insert_many(documents).await {
+                            Ok(res) => QueryResult {
+                                null_cells: Vec::new(),
+                                headers: vec!["status".to_string(), "inserted_count".to_string()],
+                                rows: vec![vec![
+                                    "insertMany".to_string(),
+                                    res.inserted_ids.len().to_string(),
+                                ]],
+                                command_tag: Some("insertMany".to_string()),
+                                truncated: false,
+                                elapsed: started.elapsed(),
+                                source_table: None,
+                                primary_keys: Vec::new(),
+                                col_types: vec!["string".to_string(), "int64".to_string()],
+                            },
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo insertMany error: {e}"),
+                                });
+                                return;
+                            }
                         }
                     }
-                }
-                MongoQuery::UpdateOne {
-                    collection,
-                    filter,
-                    update,
-                } => {
-                    let coll = db.collection::<Document>(&collection);
-                    match coll.update_one(filter, update).await {
-                        Ok(res) => QueryResult {
-                            headers: vec![
-                                "status".to_string(),
-                                "matched".to_string(),
-                                "modified".to_string(),
-                            ],
-                            rows: vec![vec![
-                                "updateOne".to_string(),
-                                res.matched_count.to_string(),
-                                res.modified_count.to_string(),
-                            ]],
-                            command_tag: Some("updateOne".to_string()),
-                            truncated: false,
-                            elapsed: started.elapsed(),
-                            source_table: None,
-                            primary_keys: Vec::new(),
-                            col_types: vec![
-                                "string".to_string(),
-                                "int64".to_string(),
-                                "int64".to_string(),
-                            ],
-                        },
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo updateOne error: {e}"),
-                            });
-                            return;
+                    MongoQuery::UpdateOne {
+                        collection,
+                        filter,
+                        update,
+                    } => {
+                        let coll = db.collection::<Document>(&collection);
+                        match coll.update_one(filter, update).await {
+                            Ok(res) => QueryResult {
+                                null_cells: Vec::new(),
+                                headers: vec![
+                                    "status".to_string(),
+                                    "matched".to_string(),
+                                    "modified".to_string(),
+                                ],
+                                rows: vec![vec![
+                                    "updateOne".to_string(),
+                                    res.matched_count.to_string(),
+                                    res.modified_count.to_string(),
+                                ]],
+                                command_tag: Some("updateOne".to_string()),
+                                truncated: false,
+                                elapsed: started.elapsed(),
+                                source_table: None,
+                                primary_keys: Vec::new(),
+                                col_types: vec![
+                                    "string".to_string(),
+                                    "int64".to_string(),
+                                    "int64".to_string(),
+                                ],
+                            },
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo updateOne error: {e}"),
+                                });
+                                return;
+                            }
                         }
                     }
-                }
-                MongoQuery::UpdateMany {
-                    collection,
-                    filter,
-                    update,
-                } => {
-                    let coll = db.collection::<Document>(&collection);
-                    match coll.update_many(filter, update).await {
-                        Ok(res) => QueryResult {
-                            headers: vec![
-                                "status".to_string(),
-                                "matched".to_string(),
-                                "modified".to_string(),
-                            ],
-                            rows: vec![vec![
-                                "updateMany".to_string(),
-                                res.matched_count.to_string(),
-                                res.modified_count.to_string(),
-                            ]],
-                            command_tag: Some("updateMany".to_string()),
-                            truncated: false,
-                            elapsed: started.elapsed(),
-                            source_table: None,
-                            primary_keys: Vec::new(),
-                            col_types: vec![
-                                "string".to_string(),
-                                "int64".to_string(),
-                                "int64".to_string(),
-                            ],
-                        },
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo updateMany error: {e}"),
-                            });
-                            return;
+                    MongoQuery::UpdateMany {
+                        collection,
+                        filter,
+                        update,
+                    } => {
+                        let coll = db.collection::<Document>(&collection);
+                        match coll.update_many(filter, update).await {
+                            Ok(res) => QueryResult {
+                                null_cells: Vec::new(),
+                                headers: vec![
+                                    "status".to_string(),
+                                    "matched".to_string(),
+                                    "modified".to_string(),
+                                ],
+                                rows: vec![vec![
+                                    "updateMany".to_string(),
+                                    res.matched_count.to_string(),
+                                    res.modified_count.to_string(),
+                                ]],
+                                command_tag: Some("updateMany".to_string()),
+                                truncated: false,
+                                elapsed: started.elapsed(),
+                                source_table: None,
+                                primary_keys: Vec::new(),
+                                col_types: vec![
+                                    "string".to_string(),
+                                    "int64".to_string(),
+                                    "int64".to_string(),
+                                ],
+                            },
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo updateMany error: {e}"),
+                                });
+                                return;
+                            }
                         }
                     }
-                }
-                MongoQuery::DeleteOne { collection, filter } => {
-                    let coll = db.collection::<Document>(&collection);
-                    match coll.delete_one(filter).await {
-                        Ok(res) => QueryResult {
-                            headers: vec!["status".to_string(), "deleted".to_string()],
-                            rows: vec![vec![
-                                "deleteOne".to_string(),
-                                res.deleted_count.to_string(),
-                            ]],
-                            command_tag: Some("deleteOne".to_string()),
-                            truncated: false,
-                            elapsed: started.elapsed(),
-                            source_table: None,
-                            primary_keys: Vec::new(),
-                            col_types: vec!["string".to_string(), "int64".to_string()],
-                        },
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo deleteOne error: {e}"),
-                            });
-                            return;
+                    MongoQuery::DeleteOne { collection, filter } => {
+                        let coll = db.collection::<Document>(&collection);
+                        match coll.delete_one(filter).await {
+                            Ok(res) => QueryResult {
+                                null_cells: Vec::new(),
+                                headers: vec!["status".to_string(), "deleted".to_string()],
+                                rows: vec![vec![
+                                    "deleteOne".to_string(),
+                                    res.deleted_count.to_string(),
+                                ]],
+                                command_tag: Some("deleteOne".to_string()),
+                                truncated: false,
+                                elapsed: started.elapsed(),
+                                source_table: None,
+                                primary_keys: Vec::new(),
+                                col_types: vec!["string".to_string(), "int64".to_string()],
+                            },
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo deleteOne error: {e}"),
+                                });
+                                return;
+                            }
                         }
                     }
-                }
-                MongoQuery::DeleteMany { collection, filter } => {
-                    let coll = db.collection::<Document>(&collection);
-                    match coll.delete_many(filter).await {
-                        Ok(res) => QueryResult {
-                            headers: vec!["status".to_string(), "deleted".to_string()],
-                            rows: vec![vec![
-                                "deleteMany".to_string(),
-                                res.deleted_count.to_string(),
-                            ]],
-                            command_tag: Some("deleteMany".to_string()),
-                            truncated: false,
-                            elapsed: started.elapsed(),
-                            source_table: None,
-                            primary_keys: Vec::new(),
-                            col_types: vec!["string".to_string(), "int64".to_string()],
-                        },
-                        Err(e) => {
-                            let _ = tx.send(DbEvent::QueryError {
-                                error: format!("Mongo deleteMany error: {e}"),
-                            });
-                            return;
+                    MongoQuery::DeleteMany { collection, filter } => {
+                        let coll = db.collection::<Document>(&collection);
+                        match coll.delete_many(filter).await {
+                            Ok(res) => QueryResult {
+                                null_cells: Vec::new(),
+                                headers: vec!["status".to_string(), "deleted".to_string()],
+                                rows: vec![vec![
+                                    "deleteMany".to_string(),
+                                    res.deleted_count.to_string(),
+                                ]],
+                                command_tag: Some("deleteMany".to_string()),
+                                truncated: false,
+                                elapsed: started.elapsed(),
+                                source_table: None,
+                                primary_keys: Vec::new(),
+                                col_types: vec!["string".to_string(), "int64".to_string()],
+                            },
+                            Err(e) => {
+                                let _ = tx.send(DbEvent::QueryError {
+                                    error: format!("Mongo deleteMany error: {e}"),
+                                });
+                                return;
+                            }
                         }
                     }
-                }
-            };
+                };
 
-            let _ = tx.send(DbEvent::MetadataLoaded {
-                primary_keys: if result.headers.iter().any(|h| h == "_id") {
-                    vec!["_id".to_string()]
-                } else {
-                    Vec::new()
-                },
-                col_types: result.col_types.clone(),
-            });
-            let _ = tx.send(DbEvent::QueryFinished { result });
+                let _ = tx.send(DbEvent::MetadataLoaded {
+                    primary_keys: if result.headers.iter().any(|h| h == "_id") {
+                        vec!["_id".to_string()]
+                    } else {
+                        Vec::new()
+                    },
+                    col_types: result.col_types.clone(),
+                });
+                let _ = tx.send(DbEvent::QueryFinished { result });
+            };
+            if timeout_secs == 0 {
+                execution.await;
+            } else if tokio::time::timeout(Duration::from_secs(u64::from(timeout_secs)), execution)
+                .await
+                .is_err()
+            {
+                let _ = timeout_tx.send(DbEvent::QueryError {
+                    error: format!("Mongo query timed out after {timeout_secs}s"),
+                });
+            }
         });
     }
 
@@ -11930,13 +13946,179 @@ impl App {
         }
     }
 
+    fn maybe_fetch_notebook_result_rows(&mut self, to_end: bool) {
+        if self.notebook_page_loading.is_some() {
+            self.notebook_page_to_end |= to_end;
+            return;
+        }
+        let cell = self.notebook.selected_cell();
+        let Some(output) = cell.output.as_ref() else {
+            return;
+        };
+        let RefinementAvailability::Available(retained) = &output.refinement else {
+            return;
+        };
+        let offset = output.grid.rows.len();
+        if offset >= retained.rows {
+            return;
+        }
+        if !to_end {
+            let threshold = DEFAULT_PAGE_SIZE / 2;
+            if output.grid_state.cursor_row.saturating_add(threshold) < offset {
+                return;
+            }
+        }
+        let Some(snapshot) = self.pg_snapshots.get(&retained.handle).cloned() else {
+            self.last_status = Some("Session snapshot is no longer available".to_string());
+            return;
+        };
+        let Some(client) = self.db.client.clone() else {
+            return;
+        };
+        let cell_id = cell.id;
+        let version = retained.version;
+        let handle = retained.handle;
+        let connection_generation = retained.connection_generation;
+        let remaining = retained.rows.saturating_sub(offset);
+        let byte_budget = notebook_display_byte_budget(self.config.notebook.snapshot_max_bytes);
+        let loaded_bytes = notebook_grid_bytes(output);
+        if loaded_bytes >= byte_budget {
+            self.notebook_page_to_end = false;
+            self.last_status = Some(format!(
+                "Loaded {} of {} retained rows; notebook display byte limit reached",
+                offset, retained.rows
+            ));
+            return;
+        }
+        let remaining_bytes = byte_budget.saturating_sub(loaded_bytes);
+        let limit = DEFAULT_PAGE_SIZE.min(remaining);
+        self.touch_pg_snapshot(handle);
+        self.notebook_page_loading = Some(NotebookPageLoad {
+            cell_id,
+            version,
+            handle,
+            connection_generation,
+        });
+        self.notebook_page_to_end = to_end;
+        let cancelled = Arc::new(AtomicBool::new(false));
+        self.notebook_page_cancelled = Some(cancelled.clone());
+        self.last_status = Some(format!(
+            "Loading result rows {}-{}...",
+            offset + 1,
+            offset + limit
+        ));
+
+        let tx = self.db_events_tx.clone();
+        self.rt.spawn(async move {
+            let guard = client.lock().await;
+            if cancelled.load(Ordering::Acquire) {
+                return;
+            }
+            if let Err(error) = pg_snapshot::validate_snapshot_identity(&guard, &snapshot).await {
+                let _ = tx.send(DbEvent::NotebookRowsError {
+                    cell_id,
+                    version,
+                    handle,
+                    connection_generation,
+                    error,
+                });
+                return;
+            }
+            let qualified = format!(
+                "pg_temp.\"{}\"",
+                snapshot.physical_name.replace('"', "\"\"")
+            );
+            let columns = snapshot
+                .public_columns
+                .iter()
+                .map(|column| format!("\"{}\"", column.replace('"', "\"\"")))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let ordinal = format!("__tsql_row_ordinal_{:016x}", version.source_execution.0);
+            let query = format!(
+                "SELECT {columns} FROM {qualified} ORDER BY \"{ordinal}\" LIMIT {limit} OFFSET {offset}"
+            );
+            match stream_simple_query(&guard, &query, limit, remaining_bytes).await {
+                Ok(streamed) => {
+                    let _ = tx.send(DbEvent::NotebookRowsAppended {
+                        cell_id,
+                        version,
+                        handle,
+                        connection_generation,
+                        offset,
+                        rows: streamed.rows,
+                        null_cells: streamed.null_cells,
+                        truncated_by_bytes: streamed.truncated,
+                    });
+                }
+                Err(error) => {
+                    let _ = tx.send(DbEvent::NotebookRowsError {
+                        cell_id,
+                        version,
+                        handle,
+                        connection_generation,
+                        error: format!(
+                            "failed to read retained result rows: {}",
+                            format_pg_error(&error)
+                        ),
+                    });
+                }
+            }
+        });
+    }
+
+    fn enforce_notebook_display_budget(&mut self, keep_cell: CellId) {
+        let budget = self.config.notebook.snapshot_total_bytes as usize;
+        let preview_rows = self.config.notebook.output_preview_rows;
+        let mut used = self
+            .notebook
+            .cells
+            .iter()
+            .filter_map(|cell| cell.output.as_ref())
+            .map(notebook_grid_bytes)
+            .sum::<usize>();
+        if used <= budget {
+            return;
+        }
+        let mut compacted = 0usize;
+        for cell in &mut self.notebook.cells {
+            if used <= budget || cell.id == keep_cell {
+                continue;
+            }
+            let Some(output) = cell.output.as_mut() else {
+                continue;
+            };
+            if !matches!(output.refinement, RefinementAvailability::Available(_))
+                || output.grid.rows.len() <= preview_rows
+            {
+                continue;
+            }
+            let before = notebook_grid_bytes(output);
+            output.grid.rows.truncate(preview_rows);
+            output.grid_state.clamp_to_bounds(&output.grid);
+            output.truncated = true;
+            cell.output_collapsed = true;
+            used = used.saturating_sub(before.saturating_sub(notebook_grid_bytes(output)));
+            compacted += 1;
+        }
+        if compacted > 0 {
+            self.last_status = Some(format!(
+                "Compacted {} older result(s) to stay within the notebook display budget",
+                compacted
+            ));
+        }
+    }
+
     fn cancel_query(&mut self) {
         // Check if there's anything to cancel:
         // 1. A query is actively running (db.running)
         // 2. A paged fetch is in progress (paged_query.loading)
         let paged_loading = self.paged_query.as_ref().is_some_and(|p| p.loading);
+        let notebook_page_loading = self.notebook_page_loading.is_some();
+        let notebook_export_loading = self.notebook_export_loading.is_some();
 
-        if !self.db.running && !paged_loading {
+        if !self.db.running && !paged_loading && !notebook_page_loading && !notebook_export_loading
+        {
             return;
         }
 
@@ -11946,15 +14128,12 @@ impl App {
             );
             return;
         }
-
-        let Some(token) = self.db.cancel_token.clone() else {
-            self.last_status = Some("No cancel token available".to_string());
-            return;
-        };
-
         self.last_status = Some("Cancelling...".to_string());
         if let Some(active) = &mut self.active_execution {
             active.cancelling = true;
+        }
+        if let Some(cancelled) = &self.active_notebook_cancelled {
+            cancelled.store(true, Ordering::Release);
         }
 
         // If cancelling a paged fetch, clear the paged_query state.
@@ -11963,9 +14142,32 @@ impl App {
         if paged_loading {
             self.paged_query = None;
         }
+        if notebook_page_loading {
+            self.notebook_page_loading = None;
+            self.notebook_page_to_end = false;
+            if let Some(cancelled) = self.notebook_page_cancelled.take() {
+                cancelled.store(true, Ordering::Release);
+            }
+        }
+        if notebook_export_loading {
+            self.notebook_export_loading = None;
+            if let Some(cancelled) = self.notebook_export_cancelled.take() {
+                cancelled.store(true, Ordering::Release);
+            }
+        }
+
+        let Some(token) = self.db.cancel_token.clone() else {
+            self.last_status = Some("No cancel token available".to_string());
+            return;
+        };
 
         let tx = self.db_events_tx.clone();
         let connected_with_tls = self.db.connected_with_tls;
+        let context = self
+            .active_execution
+            .map(|active| active.context)
+            .or(self.active_classic_execution);
+        let connection_generation = self.connect_generation;
 
         self.rt.spawn(async move {
             // Attempt to cancel. We ignore errors since cancellation is best-effort.
@@ -11979,7 +14181,10 @@ impl App {
             }
             // The query task will return an error which we handle normally.
             // We also send a cancelled event in case the query finished before the cancel arrived.
-            let _ = tx.send(DbEvent::QueryCancelled);
+            let _ = tx.send(DbEvent::QueryCancelled {
+                context,
+                connection_generation,
+            });
         });
     }
 
@@ -11991,6 +14196,15 @@ impl App {
 
     fn apply_db_event(&mut self, ev: DbEvent) {
         match ev {
+            DbEvent::ClassicExecution { context, event } => {
+                if context.connection_generation != self.connect_generation
+                    || self.active_classic_execution != Some(context)
+                    || self.active_execution.is_some()
+                {
+                    return;
+                }
+                self.apply_db_event(*event);
+            }
             DbEvent::Connected {
                 client,
                 cancel_token,
@@ -12055,6 +14269,10 @@ impl App {
                 self.db.mongo_database = None;
                 self.db.running = false;
                 self.last_executed_query = None;
+                self.classic_result_base_query = None;
+                self.classic_result_base_headers.clear();
+                self.classic_result_transform.reset();
+                self.classic_result_applied_transform.reset();
                 self.active_query_kind = None;
                 self.query_ui.clear();
                 self.current_connection_name = None;
@@ -12079,6 +14297,10 @@ impl App {
                 self.db.mongo_database = None;
                 self.db.running = false;
                 self.last_executed_query = None;
+                self.classic_result_base_query = None;
+                self.classic_result_base_headers.clear();
+                self.classic_result_transform.reset();
+                self.classic_result_applied_transform.reset();
                 self.active_query_kind = None;
                 self.query_ui.clear();
                 self.current_connection_name = None;
@@ -12107,7 +14329,12 @@ impl App {
                     }
                 }
 
+                if self.classic_result_transform.is_empty() {
+                    self.classic_result_base_headers = result.headers.clone();
+                }
+                self.classic_result_applied_transform = self.classic_result_transform.clone();
                 self.grid = GridModel::new(result.headers, result.rows)
+                    .with_null_cells(result.null_cells)
                     .with_source_table(result.source_table)
                     .with_primary_keys(result.primary_keys)
                     .with_col_types(result.col_types);
@@ -12155,7 +14382,7 @@ impl App {
             DbEvent::NotebookQueryFinished {
                 context,
                 result,
-                retained,
+                mut retained,
                 snapshot,
             } => {
                 let is_current = self
@@ -12163,23 +14390,42 @@ impl App {
                     .is_some_and(|active| active.context == context)
                     && context.connection_generation == self.connect_generation;
                 if !is_current {
+                    if let Some(snapshot) = snapshot {
+                        self.drop_pg_snapshots(vec![snapshot]);
+                    }
                     return;
                 }
                 self.active_execution = None;
+                let submitted_sql = self.active_notebook_sql.take();
+                self.active_notebook_cancelled = None;
                 self.db.running = false;
                 self.query_ui.clear();
 
-                let ExecutionTarget::Notebook(cell_id) = context.target else {
-                    return;
-                };
-                if let (Some(retained), Some(snapshot)) = (&retained, snapshot) {
-                    self.register_pg_snapshot(retained, snapshot);
+                if self.db.kind == Some(DbKind::Postgres) {
+                    if let Some(sql) = submitted_sql.as_deref() {
+                        self.db.transaction_state =
+                            self.db.transaction_state.after_execution(sql, true);
+                    }
                 }
-                let Some(cell) = self.notebook.cell_mut(cell_id) else {
+
+                let ExecutionTarget::Notebook(cell_id) = context.target else {
+                    if let Some(snapshot) = snapshot {
+                        self.drop_pg_snapshots(vec![snapshot]);
+                    }
                     return;
                 };
-                if cell.revision != context.source_revision {
-                    cell.execution = CellExecutionState::Succeeded;
+                let destination_matches = self
+                    .notebook
+                    .cells
+                    .iter()
+                    .any(|cell| cell.id == cell_id && cell.revision == context.source_revision);
+                if !destination_matches {
+                    if let Some(snapshot) = snapshot {
+                        self.drop_pg_snapshots(vec![snapshot]);
+                    }
+                    if let Some(cell) = self.notebook.cell_mut(cell_id) {
+                        cell.execution = CellExecutionState::NeverRun;
+                    }
                     self.last_status = Some(format!(
                         "Cell {} finished, but its source changed; output was ignored",
                         cell_id.0
@@ -12187,16 +14433,44 @@ impl App {
                     return;
                 }
 
-                if self.db.kind == Some(DbKind::Postgres) {
-                    self.db.transaction_state = self
-                        .db
-                        .transaction_state
-                        .after_execution(&cell.source(), true);
+                let snapshot_was_evicted = match (retained.as_ref(), snapshot) {
+                    (Some(retained_result), Some(snapshot)) => {
+                        !self.register_pg_snapshot(retained_result, snapshot)
+                    }
+                    (_, Some(snapshot)) => {
+                        self.drop_pg_snapshots(vec![snapshot]);
+                        false
+                    }
+                    _ => false,
+                };
+                if snapshot_was_evicted {
+                    retained = None;
                 }
+                let Some(cell) = self.notebook.cell_mut(cell_id) else {
+                    return;
+                };
                 cell.execution = CellExecutionState::Succeeded;
                 cell.bound_connection_generation = Some(context.connection_generation);
+                let row_count = retained
+                    .as_ref()
+                    .map_or(result.rows.len(), |retained| retained.rows);
+                let history = NotebookRunRecord::new(
+                    context.id.0,
+                    context.source_revision,
+                    cell.source(),
+                    NotebookRunStatus::Succeeded,
+                )
+                .with_output(
+                    result.elapsed,
+                    row_count,
+                    &result.headers,
+                    &result.rows,
+                    result.truncated,
+                );
+                cell.push_run(history);
                 cell.output = Some(NotebookOutput {
                     grid: GridModel::new(result.headers, result.rows)
+                        .with_null_cells(result.null_cells)
                         .with_source_table(result.source_table)
                         .with_primary_keys(result.primary_keys)
                         .with_col_types(result.col_types),
@@ -12208,6 +14482,8 @@ impl App {
                         || {
                             let reason = if self.db.kind == Some(DbKind::Mongo) {
                                 RefinementUnavailableReason::UnsupportedBackend
+                            } else if snapshot_was_evicted {
+                                RefinementUnavailableReason::SnapshotEvicted
                             } else if self.config.notebook.snapshot_mode == SnapshotMode::Off {
                                 RefinementUnavailableReason::SnapshotDisabled
                             } else if self.db.transaction_state != TransactionState::Idle {
@@ -12225,9 +14501,13 @@ impl App {
                     executed_revision: context.source_revision,
                     truncated: result.truncated,
                 });
-                cell.editor.mark_saved();
                 self.last_error = None;
                 self.last_status = Some(format!("Notebook cell {} finished", cell_id.0));
+                self.enforce_notebook_display_budget(cell_id);
+                if self.notebook_run_total > 0 {
+                    self.run_next_notebook_cell();
+                }
+                self.note_notebook_activity(cell_id, false);
             }
             DbEvent::QueryError { error } => {
                 if self.active_query_kind.is_some() {
@@ -12240,6 +14520,7 @@ impl App {
                 self.active_query_kind = None;
                 self.query_ui.clear();
                 self.paged_query = None; // Clear paged query state on error
+                self.classic_result_transform = self.classic_result_applied_transform.clone();
                 self.last_status = Some("Query error (see above)".to_string());
                 self.last_error = Some(error);
             }
@@ -12251,21 +14532,37 @@ impl App {
                     return;
                 }
                 let was_cancelled = active.is_some_and(|active| active.cancelling);
+                let elapsed = self
+                    .query_ui
+                    .start_time
+                    .map_or(Duration::ZERO, |started| started.elapsed());
                 self.active_execution = None;
+                let submitted_sql = self.active_notebook_sql.take();
+                self.active_notebook_cancelled = None;
                 self.db.running = false;
                 self.query_ui.clear();
+                if self.db.kind == Some(DbKind::Postgres) {
+                    if let Some(sql) = submitted_sql.as_deref() {
+                        self.db.transaction_state =
+                            self.db.transaction_state.after_execution(sql, false);
+                    }
+                }
                 let ExecutionTarget::Notebook(cell_id) = context.target else {
                     return;
                 };
                 if let Some(cell) = self.notebook.cell_mut(cell_id) {
-                    if cell.revision == context.source_revision
-                        && self.db.kind == Some(DbKind::Postgres)
-                    {
-                        self.db.transaction_state = self
-                            .db
-                            .transaction_state
-                            .after_execution(&cell.source(), false);
-                    }
+                    let history = NotebookRunRecord::new(
+                        context.id.0,
+                        context.source_revision,
+                        cell.source(),
+                        if was_cancelled {
+                            NotebookRunStatus::Cancelled
+                        } else {
+                            NotebookRunStatus::Failed
+                        },
+                    )
+                    .with_error(elapsed, (!was_cancelled).then(|| error.clone()));
+                    cell.push_run(history);
                     if was_cancelled {
                         cell.execution = CellExecutionState::Cancelled;
                         cell.failure = None;
@@ -12279,13 +14576,205 @@ impl App {
                 } else {
                     format!("Notebook cell {} failed", cell_id.0)
                 });
+                if self.notebook_run_total > 0 {
+                    self.notebook_run_queue.clear();
+                    self.notebook_run_total = 0;
+                    self.notebook_run_rebind_sources.clear();
+                    self.last_status = Some(format!("Notebook run stopped at cell {}", cell_id.0));
+                }
+                self.note_notebook_activity(cell_id, !was_cancelled);
             }
-            DbEvent::QueryCancelled => {
-                if self.active_execution.is_some() {
+            DbEvent::NotebookRowsAppended {
+                cell_id,
+                version,
+                handle,
+                connection_generation,
+                offset,
+                rows,
+                null_cells,
+                truncated_by_bytes,
+            } => {
+                if connection_generation != self.connect_generation
+                    || self.notebook_page_loading
+                        != Some(NotebookPageLoad {
+                            cell_id,
+                            version,
+                            handle,
+                            connection_generation,
+                        })
+                {
+                    return;
+                }
+                self.notebook_page_loading = None;
+                self.notebook_page_cancelled = None;
+                let to_end = self.notebook_page_to_end;
+                let (loaded, total_rows) = {
+                    let Some(cell) = self.notebook.cell_mut(cell_id) else {
+                        self.notebook_page_to_end = false;
+                        return;
+                    };
+                    let Some(output) = cell.output.as_mut() else {
+                        self.notebook_page_to_end = false;
+                        return;
+                    };
+                    let total_rows = match &output.refinement {
+                        RefinementAvailability::Available(retained)
+                            if retained.version == version
+                                && retained.handle == handle
+                                && retained.connection_generation == connection_generation =>
+                        {
+                            retained.rows
+                        }
+                        _ => {
+                            self.notebook_page_to_end = false;
+                            return;
+                        }
+                    };
+                    if output.grid.rows.len() != offset {
+                        self.notebook_page_to_end = false;
+                        return;
+                    }
+                    output.grid.append_rows_with_nulls(rows, null_cells);
+                    let loaded = output.grid.rows.len();
+                    if to_end && loaded > 0 {
+                        output.grid_state.cursor_row = loaded - 1;
+                    }
+                    if loaded >= total_rows && !truncated_by_bytes {
+                        output.truncated = false;
+                    }
+                    (loaded, total_rows)
+                };
+                self.enforce_notebook_display_budget(cell_id);
+                if truncated_by_bytes {
+                    self.notebook_page_to_end = false;
+                    self.last_status = Some(format!(
+                        "Loaded {} of {} retained rows; notebook display byte limit reached",
+                        loaded, total_rows
+                    ));
+                } else if loaded >= total_rows {
+                    self.notebook_page_to_end = false;
+                    self.last_status = Some(format!("Loaded all {} retained rows", total_rows));
+                } else if to_end {
+                    self.maybe_fetch_notebook_result_rows(true);
+                } else {
+                    self.last_status =
+                        Some(format!("Loaded {} of {} retained rows", loaded, total_rows));
+                }
+            }
+            DbEvent::NotebookRowsError {
+                cell_id,
+                version,
+                handle,
+                connection_generation,
+                error,
+            } => {
+                let matching_output = self
+                    .notebook
+                    .cells
+                    .iter()
+                    .find(|cell| cell.id == cell_id)
+                    .is_some_and(|cell| {
+                        cell.output.as_ref().is_some_and(|output| {
+                            matches!(
+                                &output.refinement,
+                                RefinementAvailability::Available(retained)
+                                    if retained.version == version
+                                        && retained.handle == handle
+                                        && retained.connection_generation == connection_generation
+                            )
+                        })
+                    });
+                if connection_generation != self.connect_generation
+                    || self.notebook_page_loading
+                        != Some(NotebookPageLoad {
+                            cell_id,
+                            version,
+                            handle,
+                            connection_generation,
+                        })
+                    || !matching_output
+                {
+                    return;
+                }
+                self.notebook_page_loading = None;
+                self.notebook_page_to_end = false;
+                self.notebook_page_cancelled = None;
+                self.last_error = Some(error);
+                self.last_status = Some(format!("Could not load more rows for cell {}", cell_id.0));
+            }
+            DbEvent::NotebookExportFinished {
+                cell_id,
+                version,
+                handle,
+                connection_generation,
+                rows,
+                path,
+                format,
+            } => {
+                if self.notebook_export_loading
+                    != Some(NotebookPageLoad {
+                        cell_id,
+                        version,
+                        handle,
+                        connection_generation,
+                    })
+                    || connection_generation != self.connect_generation
+                {
+                    return;
+                }
+                self.notebook_export_loading = None;
+                self.notebook_export_cancelled = None;
+                self.last_error = None;
+                self.last_status = Some(format!(
+                    "Exported {} retained row{} to {} as {}",
+                    rows,
+                    if rows == 1 { "" } else { "s" },
+                    path.display(),
+                    format
+                ));
+            }
+            DbEvent::NotebookExportError {
+                cell_id,
+                version,
+                handle,
+                connection_generation,
+                error,
+            } => {
+                if self.notebook_export_loading
+                    != Some(NotebookPageLoad {
+                        cell_id,
+                        version,
+                        handle,
+                        connection_generation,
+                    })
+                    || connection_generation != self.connect_generation
+                {
+                    return;
+                }
+                self.notebook_export_loading = None;
+                self.notebook_export_cancelled = None;
+                self.last_error = Some(error);
+                self.last_status = Some(format!("Export failed for notebook cell {}", cell_id.0));
+            }
+            DbEvent::QueryCancelled {
+                context,
+                connection_generation,
+            } => {
+                if connection_generation != self.connect_generation {
+                    return;
+                }
+                if let Some(active) = self.active_execution {
+                    if context != Some(active.context) {
+                        return;
+                    }
                     self.last_status = Some("Cancelling notebook cell...".to_string());
                     return;
                 }
+                if context.is_some() && context != self.active_classic_execution {
+                    return;
+                }
                 self.paged_query = None; // Clear paged query state on cancel
+                self.classic_result_transform = self.classic_result_applied_transform.clone();
                 self.db.running = false;
                 self.active_query_kind = None;
                 self.query_ui.clear();
@@ -12344,13 +14833,14 @@ impl App {
             }
             DbEvent::RowsAppended {
                 rows,
+                null_cells,
                 done,
                 truncated,
             } => {
                 // Append rows to the grid (streaming/paged results)
                 let new_rows_count = rows.len();
                 if !rows.is_empty() {
-                    self.grid.append_rows(rows);
+                    self.grid.append_rows_with_nulls(rows, null_cells);
                     // Clamp state for safety (though append should keep cursor valid)
                     self.grid_state.clamp_to_bounds(&self.grid);
                 }
@@ -12557,18 +15047,30 @@ impl App {
         };
         let notebook_focus = self.notebook.focus;
         let selected_cell = self.notebook.selected;
+        let (collapsed_glyph, expanded_glyph, rail_glyph) = if self.notebook_ascii {
+            (">", "v", "|\n")
+        } else {
+            ("▸", "▾", "┃\n")
+        };
         let retained_versions = &self.retained_versions;
         let pg_snapshots = &self.pg_snapshots;
-        let has_latest_result = self.latest_notebook_result_version(None).is_some();
-        let available_source_cells = self
+        let evicted_versions = &self.evicted_versions;
+        let available_source_cells = retained_versions
+            .iter()
+            .filter_map(|(version, handle)| {
+                pg_snapshots
+                    .get(handle)
+                    .filter(|snapshot| snapshot.connection_generation == self.connect_generation)
+                    .map(|_| version.source_cell)
+            })
+            .collect::<HashSet<_>>();
+        let has_latest_result = !available_source_cells.is_empty();
+        let named_source_cells = self
             .notebook
             .cells
             .iter()
-            .filter_map(|cell| {
-                self.latest_notebook_result_version(Some(cell.id))
-                    .map(|_| cell.id)
-            })
-            .collect::<HashSet<_>>();
+            .filter_map(|cell| cell.result_name.clone().map(|name| (name, cell.id)))
+            .collect::<HashMap<_, _>>();
         let mut render_areas = Vec::new();
 
         for (index, cell) in self
@@ -12584,7 +15086,7 @@ impl App {
             }
             let selected = cell.id == selected_cell;
             let source_lines = cell.editor.textarea.lines();
-            let source_height = if focused_result_layout {
+            let source_height = if focused_result_layout || cell.source_collapsed {
                 1
             } else {
                 source_lines.len().clamp(1, composer_max_rows) as u16
@@ -12633,7 +15135,7 @@ impl App {
             } else {
                 self.ui_theme.text_muted
             };
-            let rail = "┃\n".repeat(composer_area.height as usize);
+            let rail = rail_glyph.repeat(composer_area.height as usize);
             frame.render_widget(
                 Paragraph::new(rail).style(
                     self.ui_theme
@@ -12644,26 +15146,83 @@ impl App {
                 rail_area,
             );
 
-            let live_dependency = cell.dependency.is_some_and(|version| {
-                retained_versions
-                    .get(&version)
-                    .and_then(|handle| pg_snapshots.get(handle))
-                    .is_some_and(|snapshot| {
-                        snapshot.connection_generation == self.connect_generation
-                    })
-            });
-            let source_available = match logical_result_reference(&cell.source()) {
-                Ok(Some(LogicalResultReference::Latest)) => has_latest_result,
-                Ok(Some(LogicalResultReference::Cell(source_cell))) => {
-                    cell.dependency
-                        .is_none_or(|dependency| dependency.source_cell == source_cell)
-                        && (live_dependency || available_source_cells.contains(&source_cell))
+            let dependencies = cell
+                .dependency
+                .into_iter()
+                .chain(cell.additional_dependencies.iter().copied())
+                .collect::<Vec<_>>();
+            let live_dependency = !dependencies.is_empty()
+                && dependencies.iter().all(|version| {
+                    retained_versions
+                        .get(version)
+                        .and_then(|handle| pg_snapshots.get(handle))
+                        .is_some_and(|snapshot| {
+                            snapshot.connection_generation == self.connect_generation
+                        })
+                });
+            let reference = if self.db.kind == Some(DbKind::Mongo) {
+                Ok(Vec::new())
+            } else if source_lines.iter().any(|line| line.contains("@result")) {
+                logical_result_references(&source_lines.join("\n"))
+            } else {
+                Ok(Vec::new())
+            };
+            let source_available = match reference {
+                Ok(references) if references.is_empty() => {
+                    dependencies.is_empty() || live_dependency
                 }
-                Ok(None) => cell.dependency.is_none() || live_dependency,
+                Ok(references) => references.into_iter().all(|reference| match reference {
+                    LogicalResultReference::Latest => has_latest_result,
+                    LogicalResultReference::Cell(source_cell) => {
+                        let binding = dependencies
+                            .iter()
+                            .find(|dependency| dependency.source_cell == source_cell);
+                        binding.map_or_else(
+                            || available_source_cells.contains(&source_cell),
+                            |binding| {
+                                !evicted_versions.contains(binding)
+                                    && (available_source_cells.contains(&source_cell)
+                                        || retained_versions
+                                            .get(binding)
+                                            .and_then(|handle| pg_snapshots.get(handle))
+                                            .is_some_and(|snapshot| {
+                                                snapshot.connection_generation
+                                                    == self.connect_generation
+                                            }))
+                            },
+                        )
+                    }
+                    LogicalResultReference::Named(name) => {
+                        let Some(source_cell) = named_source_cells.get(&name).copied() else {
+                            return false;
+                        };
+                        let binding = dependencies
+                            .iter()
+                            .find(|dependency| dependency.source_cell == source_cell);
+                        binding.map_or_else(
+                            || available_source_cells.contains(&source_cell),
+                            |binding| {
+                                !evicted_versions.contains(binding)
+                                    && (available_source_cells.contains(&source_cell)
+                                        || retained_versions
+                                            .get(binding)
+                                            .and_then(|handle| pg_snapshots.get(handle))
+                                            .is_some_and(|snapshot| {
+                                                snapshot.connection_generation
+                                                    == self.connect_generation
+                                            }))
+                            },
+                        )
+                    }
+                }),
                 Err(_) => true,
             };
             let state = match cell.execution {
-                CellExecutionState::NeverRun if cell.is_empty() => "DRAFT",
+                CellExecutionState::NeverRun
+                    if source_lines.iter().all(|line| line.trim().is_empty()) =>
+                {
+                    "DRAFT"
+                }
                 CellExecutionState::NeverRun if !source_available => "SOURCE UNAVAILABLE",
                 CellExecutionState::NeverRun => "NEEDS RUN",
                 CellExecutionState::Running(_) => "RUNNING",
@@ -12687,19 +15246,32 @@ impl App {
             } else {
                 ""
             };
-            let dependency = cell.dependency.map_or_else(String::new, |version| {
+            let dependency = if dependencies.is_empty() {
+                String::new()
+            } else {
                 format!(
-                    " · from cell {}/run {}",
-                    version.source_cell.0, version.source_execution.0
+                    " · from {}",
+                    dependencies
+                        .iter()
+                        .map(|version| format!(
+                            "cell {}/run {}",
+                            version.source_cell.0, version.source_execution.0
+                        ))
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 )
-            });
+            };
             let output_summary = cell.output.as_ref().map_or_else(String::new, |output| {
                 format!(
                     " · {}",
                     notebook_output_summary(output, cell.output_is_stale(), focused_result_layout)
                 )
             });
-            let mut lines = Vec::with_capacity(source_lines.len().saturating_add(2));
+            let mut lines = Vec::with_capacity(source_height as usize + 2);
+            let result_name = cell
+                .result_name
+                .as_ref()
+                .map_or_else(String::new, |name| format!(" · @result_{name}"));
             let (cursor_row, cursor_col) = cell.editor.textarea.cursor();
             let source_scroll = if selected && notebook_focus == NotebookFocus::Editor {
                 cell.editor_scroll = calculate_editor_scroll(
@@ -12717,7 +15289,7 @@ impl App {
                 let source = notebook_source_summary(source_lines);
                 lines.push(Line::from(Span::styled(
                     format!(
-                        "▸ CELL {} · {language} · {state}{dependency}{output_summary}{}",
+                        "{collapsed_glyph} CELL {} · {language} · {state}{dependency}{output_summary}{result_name}{}",
                         cell.id.0,
                         if source.is_empty() {
                             String::new()
@@ -12730,8 +15302,12 @@ impl App {
             } else {
                 lines.push(Line::from(Span::styled(
                     format!(
-                        "{}CELL {} · {language} · {state}{dependency}{focus_label}{}",
-                        if focused_result_layout { "▾ " } else { "" },
+                        "{}CELL {} · {language} · {state}{dependency}{focus_label}{result_name}{}",
+                        if focused_result_layout {
+                            format!("{expanded_glyph} ")
+                        } else {
+                            String::new()
+                        },
                         cell.id.0,
                         if focused_result_layout {
                             output_summary.as_str()
@@ -12741,8 +15317,14 @@ impl App {
                     ),
                     header_style,
                 )));
-                if focused_result_layout {
+                if focused_result_layout || cell.source_collapsed {
                     lines.push(Line::from(notebook_source_summary(source_lines)));
+                    if cell.source_collapsed && !focused_result_layout {
+                        lines.push(Line::from(Span::styled(
+                            "Source collapsed · :expand-source or Enter to edit",
+                            Style::default().fg(self.ui_theme.text_muted),
+                        )));
+                    }
                 } else {
                     lines.extend(
                         source_lines
@@ -12757,20 +15339,52 @@ impl App {
                                 )
                             }),
                     );
-                    lines.push(Line::from(Span::styled(
-                        if selected {
-                            match notebook_focus {
-                                NotebookFocus::Cell => {
-                                    "j/k cells · h/l output · x clear · Enter edit · Ctrl+E run"
-                                }
-                                NotebookFocus::Editor => "Ctrl+E run · Esc cell mode",
-                                NotebookFocus::Result => {
-                                    "h/j/k/l table · / search · yy copy · Esc cell"
-                                }
-                            }
+                    let source_width = composer_body.width.saturating_sub(4) as usize;
+                    let lines_above = source_scroll.0 as usize;
+                    let lines_below = source_lines
+                        .len()
+                        .saturating_sub(lines_above.saturating_add(source_height as usize));
+                    let clipped_right = source_lines
+                        .iter()
+                        .skip(lines_above)
+                        .take(source_height as usize)
+                        .any(|line| {
+                            line.chars()
+                                .skip(source_scroll.1 as usize)
+                                .collect::<String>()
+                                .width()
+                                > source_width
+                        });
+                    let clipping = format!(
+                        "{}{}{}{}",
+                        if lines_above > 0 {
+                            format!("↑{lines_above} ")
                         } else {
-                            ""
+                            String::new()
                         },
+                        if lines_below > 0 {
+                            format!("↓{lines_below} ")
+                        } else {
+                            String::new()
+                        },
+                        if source_scroll.1 > 0 { "‹ " } else { "" },
+                        if clipped_right { "› " } else { "" },
+                    );
+                    let hint = if selected {
+                        match notebook_focus {
+                            NotebookFocus::Cell => {
+                                "j/k cells · h/l output · x clear · Enter edit · Ctrl+E run"
+                            }
+                            NotebookFocus::Editor => "Ctrl+E run · Esc cell mode",
+                            NotebookFocus::Result => {
+                                "h/j/k/l table · / search · yy copy · Esc cell"
+                            }
+                        }
+                    } else {
+                        ""
+                    };
+                    lines.push(Line::from(Span::styled(
+                        format!("{clipping}{hint}"),
                         Style::default().fg(self.ui_theme.text_muted),
                     )));
                 }
@@ -12790,30 +15404,121 @@ impl App {
                     }),
                 composer_body,
             );
+
+            if !focused_result_layout && !cell.source_collapsed {
+                let source_area = Rect::new(
+                    composer_body.x.saturating_add(2),
+                    composer_body.y.saturating_add(1),
+                    composer_body.width.saturating_sub(4),
+                    source_height,
+                );
+                let source_start = source_scroll.0 as usize;
+                let source_left = source_scroll.1 as usize;
+                let visible_source = source_lines
+                    .iter()
+                    .skip(source_start)
+                    .take(source_height as usize)
+                    .map(|line| line.chars().skip(source_left).collect::<String>())
+                    .collect::<Vec<_>>();
+                let source_text = visible_source.join("\n");
+                let highlighted_source = if matches!(language, "SQL" | "MONGOSH") {
+                    self.highlighter
+                        .highlight(
+                            if language == "MONGOSH" {
+                                "javascript"
+                            } else {
+                                "sql"
+                            },
+                            &source_text,
+                        )
+                        .unwrap_or_else(|_| {
+                            visible_source
+                                .iter()
+                                .map(|line| Line::from(line.clone()))
+                                .collect()
+                        })
+                } else {
+                    visible_source
+                        .iter()
+                        .map(|line| Line::from(line.clone()))
+                        .collect()
+                };
+                let mut source_editor = TextArea::new(visible_source.clone());
+                let visible_cursor = (
+                    cursor_row.saturating_sub(source_start),
+                    cursor_col.saturating_sub(source_left),
+                );
+                if selected && notebook_focus == NotebookFocus::Editor {
+                    if let Some((start, end)) = cell.editor.textarea.selection_range() {
+                        let last_row = source_start.saturating_add(source_height as usize - 1);
+                        if end.0 >= source_start && start.0 <= last_row {
+                            let clamp = |position: (usize, usize)| {
+                                let row = position.0.clamp(source_start, last_row);
+                                let col = if row == position.0 {
+                                    position.1.saturating_sub(source_left)
+                                } else if row == source_start {
+                                    0
+                                } else {
+                                    visible_source
+                                        .get(row.saturating_sub(source_start))
+                                        .map_or(0, |line| line.chars().count())
+                                };
+                                (row.saturating_sub(source_start), col)
+                            };
+                            let start = clamp(start);
+                            let end = clamp(end);
+                            let anchor = if visible_cursor == start { end } else { start };
+                            source_editor.move_cursor(CursorMove::Jump(
+                                anchor.0.min(u16::MAX as usize) as u16,
+                                anchor.1.min(u16::MAX as usize) as u16,
+                            ));
+                            source_editor.start_selection();
+                        }
+                    }
+                    source_editor.move_cursor(CursorMove::Jump(
+                        visible_cursor.0.min(u16::MAX as usize) as u16,
+                        visible_cursor.1.min(u16::MAX as usize) as u16,
+                    ));
+                }
+                let cursor_shape = if self.mode == Mode::Insert {
+                    CursorShape::Bar
+                } else {
+                    CursorShape::Block
+                };
+                let source_widget = HighlightedTextArea::new(&source_editor, highlighted_source)
+                    .cursor_style(self.ui_theme.editor_cursor)
+                    .selection_style(self.ui_theme.editor_selection)
+                    .show_cursor(selected && notebook_focus == NotebookFocus::Editor)
+                    .cursor_shape(cursor_shape);
+                let cursor = source_widget.cursor_screen_position(source_area);
+                frame.render_widget(source_widget, source_area);
+                decorate_notebook_source(
+                    frame.buffer_mut(),
+                    source_area,
+                    &visible_source,
+                    self.search.last_applied.as_deref(),
+                    self.ui_theme.accent,
+                    self.ui_theme.search_match,
+                );
+                if selected
+                    && notebook_focus == NotebookFocus::Editor
+                    && cursor_shape != CursorShape::Block
+                {
+                    if let Some(cursor) = cursor {
+                        frame.set_cursor_position(cursor);
+                    }
+                }
+            }
             if let Some(output_toggle) = output_toggle {
                 frame.render_widget(
-                    Paragraph::new(if cell.output_collapsed { "▸" } else { "▾" })
-                        .style(header_style),
+                    Paragraph::new(if cell.output_collapsed {
+                        collapsed_glyph
+                    } else {
+                        expanded_glyph
+                    })
+                    .style(header_style),
                     output_toggle,
                 );
-            }
-
-            if selected && notebook_focus == NotebookFocus::Editor {
-                let visible_row = cursor_row.saturating_sub(source_scroll.0 as usize);
-                let visible_col = cursor_col.saturating_sub(source_scroll.1 as usize);
-                if visible_row < composer_max_rows {
-                    let cursor_x = composer_body
-                        .x
-                        .saturating_add(2)
-                        .saturating_add(visible_col as u16)
-                        .min(composer_body.right().saturating_sub(1));
-                    let cursor_y = composer_body
-                        .y
-                        .saturating_add(1)
-                        .saturating_add(visible_row as u16)
-                        .min(composer_body.bottom().saturating_sub(1));
-                    frame.set_cursor_position((cursor_x, cursor_y));
-                }
             }
 
             y = y.saturating_add(composer_area.height);
@@ -12829,7 +15534,8 @@ impl App {
                 if error_height > 0 {
                     frame.render_widget(
                         Paragraph::new(format!("  ERROR · {failure}"))
-                            .style(Style::default().fg(self.ui_theme.error)),
+                            .style(Style::default().fg(self.ui_theme.error))
+                            .wrap(ratatui::widgets::Wrap { trim: false }),
                         Rect::new(composer_body.x, y, composer_body.width, error_height),
                     );
                     y = y.saturating_add(error_height);
@@ -13046,10 +15752,16 @@ impl App {
 
         // Query timing info
         let timing_info = if let Some(output) = notebook_output {
-            output
-                .command_tag
-                .as_ref()
-                .map(|tag| format!("{} ({}ms)", tag, output.elapsed.as_millis()))
+            let tag = if output.truncated && output.retained.is_none() {
+                format!(
+                    "{}{} rows",
+                    if self.notebook_ascii { ">=" } else { "≥" },
+                    output.grid.rows.len().saturating_add(1)
+                )
+            } else {
+                output.command_tag.clone().unwrap_or_default()
+            };
+            (!tag.is_empty()).then(|| format!("{tag} ({}ms)", output.elapsed.as_millis()))
         } else if self.workspace_mode == WorkspaceMode::Notebook {
             None
         } else if let Some(ref tag) = self.db.last_command_tag {
@@ -13066,15 +15778,45 @@ impl App {
         // Running/loading indicator
         let paged_loading = self.paged_query.as_ref().is_some_and(|p| p.loading);
         let running_indicator = if self.db.running {
-            Some("⏳ running")
+            Some(
+                match self.active_execution.map(|active| active.context.target) {
+                    Some(ExecutionTarget::Notebook(cell_id)) => {
+                        format!("⏳ cell {} running", cell_id.0)
+                    }
+                    Some(ExecutionTarget::Classic) | None => "⏳ running".to_string(),
+                },
+            )
         } else if paged_loading {
-            Some("⏳ loading")
+            Some("⏳ loading".to_string())
+        } else if self.notebook_export_loading.is_some() {
+            Some("⏳ exporting".to_string())
         } else {
             None
         };
 
         // Status message (right-aligned)
         let status = self.last_status.as_deref().unwrap_or("Ready").to_string();
+        let activity_indicator = (!self.notebook_activity.is_empty()).then(|| {
+            let failed = self
+                .notebook_activity
+                .iter()
+                .filter(|activity| activity.failed)
+                .count();
+            format!(
+                "{} cell update{}{} · :activity",
+                self.notebook_activity.len(),
+                if self.notebook_activity.len() == 1 {
+                    ""
+                } else {
+                    "s"
+                },
+                if failed > 0 {
+                    format!(" ({failed} failed)")
+                } else {
+                    String::new()
+                }
+            )
+        });
         let status_style = if self.last_error.is_some() {
             Style::default().fg(self.ui_theme.error)
         } else if self.last_status.is_none() {
@@ -13152,6 +15894,11 @@ impl App {
                     || self.db.transaction_state == TransactionState::Failed,
                 StatusSegment::new("TXN", Priority::High)
                     .style(Style::default().fg(self.ui_theme.transaction)),
+            )
+            .segment_if(
+                activity_indicator.is_some(),
+                StatusSegment::new(activity_indicator.unwrap_or_default(), Priority::High)
+                    .style(Style::default().fg(self.ui_theme.warning)),
             )
             // Medium: Row info
             .segment(StatusSegment::new(row_info, Priority::Medium).min_width(50))
@@ -13240,6 +15987,1002 @@ impl App {
         self.history_picker = Some(picker);
     }
 
+    fn open_action_palette(&mut self) {
+        let notebook = self.workspace_mode == WorkspaceMode::Notebook;
+        let (has_result, has_refinable_result, has_selection, has_error, has_cell_history) =
+            if notebook {
+                let cell = self.notebook.selected_cell();
+                (
+                    cell.output
+                        .as_ref()
+                        .is_some_and(|output| !output.grid.rows.is_empty()),
+                    cell.output.as_ref().is_some_and(|output| {
+                        matches!(output.refinement, RefinementAvailability::Available(_))
+                    }),
+                    cell.output
+                        .as_ref()
+                        .is_some_and(|output| !output.grid_state.selected_rows.is_empty()),
+                    cell.failure.is_some()
+                        || cell
+                            .output
+                            .as_ref()
+                            .is_some_and(|output| output.error.is_some()),
+                    !cell.execution_history.is_empty(),
+                )
+            } else {
+                (
+                    !self.grid.headers.is_empty(),
+                    false,
+                    !self.grid_state.selected_rows.is_empty(),
+                    self.last_error.is_some(),
+                    false,
+                )
+            };
+        let classic_transform_source = !notebook
+            && self.db.kind == Some(DbKind::Postgres)
+            && self.db.transaction_state == TransactionState::Idle
+            && !self.db.running
+            && self
+                .classic_result_base_query
+                .as_deref()
+                .is_some_and(pg_snapshot::is_snapshot_candidate)
+            && !self.classic_result_base_headers.is_empty();
+        let classic_has_column = classic_transform_source
+            && !self.grid.headers.is_empty()
+            && self.current_classic_base_column().is_some();
+        let classic_has_cell = classic_has_column
+            && !self.grid.rows.is_empty()
+            && self
+                .current_classic_filter_value()
+                .is_some_and(|value| value != FilterValue::Null);
+        let entries = action_entries(ActionContext {
+            notebook,
+            has_query: self.query_editor_has_content(),
+            has_result,
+            has_refinable_result,
+            has_selection,
+            has_error,
+            has_cell_history,
+            has_activity: !self.notebook_activity.is_empty(),
+            has_column: classic_has_column,
+            has_cell: classic_has_cell,
+            has_transform: !notebook && !self.classic_result_transform.is_empty(),
+            has_filters: !notebook && !self.classic_result_transform.filters.is_empty(),
+            has_sort: !notebook && !self.classic_result_transform.orders.is_empty(),
+        });
+        self.last_error = None;
+        self.action_palette = Some(
+            FuzzyPicker::with_display(
+                entries,
+                "Actions - type to filter | Enter select  Esc close",
+                ActionEntry::display,
+            )
+            .with_original_order(),
+        );
+    }
+
+    fn classic_transform_available(&mut self) -> bool {
+        if self.workspace_mode != WorkspaceMode::Classic {
+            self.last_status =
+                Some("Result transformations are only available in Classic mode".into());
+            return false;
+        }
+        if self.db.kind != Some(DbKind::Postgres) {
+            self.last_status = Some("Result transformations currently require PostgreSQL".into());
+            return false;
+        }
+        if self.db.running {
+            self.last_status =
+                Some("Wait for the running query before transforming its result".into());
+            return false;
+        }
+        if self.db.transaction_state != TransactionState::Idle {
+            self.last_status =
+                Some("Result transformations require an idle PostgreSQL transaction".into());
+            return false;
+        }
+        if self.classic_result_base_query.is_none() || self.classic_result_base_headers.is_empty() {
+            self.last_status =
+                Some("Run a row-returning query before transforming its result".into());
+            return false;
+        }
+        if !self
+            .classic_result_base_query
+            .as_deref()
+            .is_some_and(pg_snapshot::is_snapshot_candidate)
+        {
+            self.last_status = Some(
+                "Result transformations require one read-only, row-returning source query".into(),
+            );
+            return false;
+        }
+        true
+    }
+
+    fn current_classic_base_column(&self) -> Option<usize> {
+        if self.grid.headers.is_empty() || self.grid_state.cursor_col >= self.grid.headers.len() {
+            return None;
+        }
+        if let Some(grouped) = self.classic_result_transform.group_count {
+            return (self.grid_state.cursor_col == 0).then_some(grouped);
+        }
+        if self.classic_result_transform.projection.is_empty() {
+            Some(self.grid_state.cursor_col)
+        } else {
+            self.classic_result_transform
+                .projection
+                .get(self.grid_state.cursor_col)
+                .copied()
+        }
+    }
+
+    fn resolve_classic_result_column(&self, token: &str) -> Option<usize> {
+        let token = token.trim().trim_matches('"');
+        if let Some(number) = token.strip_prefix('#') {
+            return number
+                .parse::<usize>()
+                .ok()
+                .and_then(|number| number.checked_sub(1))
+                .filter(|ordinal| *ordinal < self.classic_result_base_headers.len());
+        }
+        let mut matches = self
+            .classic_result_base_headers
+            .iter()
+            .enumerate()
+            .filter(|(_, header)| header.eq_ignore_ascii_case(token));
+        let first = matches.next().map(|(ordinal, _)| ordinal)?;
+        matches.next().is_none().then_some(first)
+    }
+
+    fn classic_result_sql(&self) -> Result<String, String> {
+        let base = self
+            .classic_result_base_query
+            .as_deref()
+            .ok_or_else(|| "no Classic query result is available".to_string())?;
+        if self.classic_result_transform.is_empty() {
+            return Ok(base.to_string());
+        }
+        compile_result_transform(
+            base,
+            &self.classic_result_base_headers,
+            &self.classic_result_transform,
+        )
+    }
+
+    fn execute_classic_result_transform(&mut self) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let sql = match self.classic_result_sql() {
+            Ok(sql) => sql,
+            Err(error) => {
+                self.classic_result_transform = self.classic_result_applied_transform.clone();
+                self.last_status = Some(format!("Cannot transform result: {error}"));
+                return;
+            }
+        };
+        self.grid_state.selected_rows.clear();
+        self.execute_query_text(sql, QueryExecutionKind::Refresh);
+        if self.db.running {
+            self.last_status = Some("Applying result transform (reruns source query)...".into());
+        }
+    }
+
+    fn set_classic_result_order(&mut self, direction: OrderDirection, append: bool) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let Some(ordinal) = self.current_classic_base_column() else {
+            self.last_status = Some("Choose a source-result column to sort".into());
+            return;
+        };
+        self.classic_result_transform
+            .set_order(ordinal, direction, append);
+        self.execute_classic_result_transform();
+    }
+
+    fn current_classic_filter_value(&self) -> Option<FilterValue> {
+        let row = self.grid_state.cursor_row;
+        let col = self.grid_state.cursor_col;
+        let value = self.grid.cell(row, col)?;
+        if self.grid.cell_is_null(row, col) {
+            Some(FilterValue::Null)
+        } else {
+            Some(FilterValue::Text(value.to_string()))
+        }
+    }
+
+    fn add_classic_current_value_filter(&mut self, op: FilterOp) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let Some(ordinal) = self.current_classic_base_column() else {
+            self.last_status = Some("Choose a source-result cell to filter".into());
+            return;
+        };
+        let Some(value) = self.current_classic_filter_value() else {
+            self.last_status = Some("Choose a result cell to filter".into());
+            return;
+        };
+        if matches!(op, FilterOp::Contains | FilterOp::NotContains) && value == FilterValue::Null {
+            self.last_status = Some("Contains filters cannot use a SQL NULL value".into());
+            return;
+        }
+        self.classic_result_transform
+            .add_filter(ResultFilter { ordinal, op, value });
+        self.execute_classic_result_transform();
+    }
+
+    fn add_classic_null_filter(&mut self, op: FilterOp) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let Some(ordinal) = self.current_classic_base_column() else {
+            self.last_status = Some("Choose a source-result column to filter".into());
+            return;
+        };
+        self.classic_result_transform.add_filter(ResultFilter {
+            ordinal,
+            op,
+            value: FilterValue::Null,
+        });
+        self.execute_classic_result_transform();
+    }
+
+    fn group_classic_result_by_current(&mut self) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let Some(ordinal) = self.current_classic_base_column() else {
+            self.last_status = Some("Choose a source-result column to group".into());
+            return;
+        };
+        self.classic_result_transform.set_group_count(Some(ordinal));
+        self.classic_result_transform.set_projection(Vec::new());
+        self.classic_result_transform.clear_orders();
+        self.execute_classic_result_transform();
+    }
+
+    fn reset_classic_result_transform(&mut self) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        self.classic_result_transform.reset();
+        self.result_columns_picker = None;
+        self.result_columns_draft.clear();
+        self.execute_classic_result_transform();
+    }
+
+    fn clear_classic_result_filters(&mut self) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        self.classic_result_transform.clear_filters();
+        self.execute_classic_result_transform();
+    }
+
+    fn clear_classic_result_sorting(&mut self) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        self.classic_result_transform.clear_orders();
+        self.execute_classic_result_transform();
+    }
+
+    fn handle_classic_sort_command(&mut self, args: &str) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let mut parts = args.split_whitespace();
+        let Some(first) = parts.next() else {
+            self.last_status = Some("Usage: :sort asc|desc|add-asc|add-desc [#column|name]".into());
+            return;
+        };
+        if first.eq_ignore_ascii_case("toggle") {
+            let ordinal = match parts.next() {
+                Some(token) => self.resolve_classic_result_column(token),
+                None => self.current_classic_base_column(),
+            };
+            let Some(ordinal) = ordinal else {
+                self.last_status =
+                    Some("Unknown or ambiguous result column; use #1, #2, ...".into());
+                return;
+            };
+            self.classic_result_transform.toggle_order(ordinal);
+            self.execute_classic_result_transform();
+            return;
+        }
+        let (direction, append) = match first.to_ascii_lowercase().as_str() {
+            "asc" => (OrderDirection::Asc, false),
+            "desc" => (OrderDirection::Desc, false),
+            "add-asc" | "then-asc" => (OrderDirection::Asc, true),
+            "add-desc" | "then-desc" => (OrderDirection::Desc, true),
+            _ => {
+                self.last_status =
+                    Some("Usage: :sort asc|desc|add-asc|add-desc [#column|name]".into());
+                return;
+            }
+        };
+        let ordinal = match parts.next() {
+            Some(token) => self.resolve_classic_result_column(token),
+            None => self.current_classic_base_column(),
+        };
+        let Some(ordinal) = ordinal else {
+            self.last_status = Some("Unknown or ambiguous result column; use #1, #2, ...".into());
+            return;
+        };
+        self.classic_result_transform
+            .set_order(ordinal, direction, append);
+        self.execute_classic_result_transform();
+    }
+
+    fn handle_classic_filter_command(&mut self, args: &str) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let mut parts = args.split_whitespace();
+        let Some(first) = parts.next() else {
+            self.last_status = Some(
+                "Usage: :filter [#column|name] eq|ne|<|<=|>|>=|contains|not-contains [value]"
+                    .into(),
+            );
+            return;
+        };
+        let (ordinal, operator) = if let Some(ordinal) = self.resolve_classic_result_column(first) {
+            let Some(operator) = parts.next() else {
+                self.last_status = Some("A filter column must be followed by an operator".into());
+                return;
+            };
+            (Some(ordinal), operator)
+        } else {
+            (self.current_classic_base_column(), first)
+        };
+        let value_text = parts.collect::<Vec<_>>().join(" ");
+        let Some(ordinal) = ordinal else {
+            self.last_status = Some("Choose a source-result column to filter".into());
+            return;
+        };
+        let op = match operator.to_ascii_lowercase().as_str() {
+            "eq" | "=" | "==" => FilterOp::Eq,
+            "ne" | "!=" | "<>" => FilterOp::Ne,
+            "<" | "lt" => FilterOp::Lt,
+            "<=" | "lte" => FilterOp::Lte,
+            ">" | "gt" => FilterOp::Gt,
+            ">=" | "gte" => FilterOp::Gte,
+            "contains" => FilterOp::Contains,
+            "not-contains" | "!contains" => FilterOp::NotContains,
+            "starts" | "starts-with" => FilterOp::StartsWith,
+            "not-starts" | "not-starts-with" => FilterOp::NotStartsWith,
+            "ends" | "ends-with" => FilterOp::EndsWith,
+            "not-ends" | "not-ends-with" => FilterOp::NotEndsWith,
+            "null" | "is-null" => FilterOp::IsNull,
+            "not-null" | "is-not-null" => FilterOp::IsNotNull,
+            _ => {
+                self.last_status = Some("Unknown filter operator; use eq, ne, <, <=, >, >=, contains, not-contains, null, or not-null".into());
+                return;
+            }
+        };
+        let value = if matches!(op, FilterOp::IsNull | FilterOp::IsNotNull) {
+            FilterValue::Null
+        } else if !value_text.trim().is_empty() {
+            // Database output columns retain their native types. Keep command
+            // values as unknown text literals so PostgreSQL can coerce `10`
+            // for an integer column while still accepting text value `10`.
+            match parse_filter_value(&value_text) {
+                FilterValue::Text(value) => FilterValue::Text(value),
+                _ => FilterValue::Text(value_text.trim().to_string()),
+            }
+        } else if let Some(value) = self.current_classic_filter_value() {
+            value
+        } else {
+            self.last_status = Some("Provide a filter value or focus a result cell".into());
+            return;
+        };
+        if matches!(
+            op,
+            FilterOp::Contains
+                | FilterOp::NotContains
+                | FilterOp::StartsWith
+                | FilterOp::NotStartsWith
+                | FilterOp::EndsWith
+                | FilterOp::NotEndsWith
+        ) && !matches!(value, FilterValue::Text(_))
+        {
+            self.last_status = Some("Text-match filters require a text value".into());
+            return;
+        }
+        self.classic_result_transform
+            .add_filter(ResultFilter { ordinal, op, value });
+        self.execute_classic_result_transform();
+    }
+
+    fn handle_classic_columns_command(&mut self, args: &str) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let args = args.trim();
+        if args.is_empty() {
+            self.open_result_columns_picker();
+            return;
+        }
+        if matches!(args, "all" | "reset" | "*") {
+            self.classic_result_transform.set_projection(Vec::new());
+            self.classic_result_transform.set_group_count(None);
+            self.execute_classic_result_transform();
+            return;
+        }
+        let mut projection = Vec::new();
+        for token in args.split([',', ' ']).filter(|token| !token.is_empty()) {
+            let Some(ordinal) = self.resolve_classic_result_column(token) else {
+                self.last_status = Some(format!(
+                    "Unknown or ambiguous result column '{token}'; use #1, #2, ..."
+                ));
+                return;
+            };
+            if !projection.contains(&ordinal) {
+                projection.push(ordinal);
+            }
+        }
+        if projection.is_empty() {
+            self.last_status = Some("Choose at least one result column".into());
+            return;
+        }
+        self.classic_result_transform.set_projection(projection);
+        self.classic_result_transform.set_group_count(None);
+        self.execute_classic_result_transform();
+    }
+
+    fn handle_classic_group_count_command(&mut self, args: &str) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let ordinal = if args.trim().is_empty() {
+            self.current_classic_base_column()
+        } else {
+            self.resolve_classic_result_column(args.trim())
+        };
+        let Some(ordinal) = ordinal else {
+            self.last_status =
+                Some("Unknown or ambiguous result column; use :group-count #1".into());
+            return;
+        };
+        self.classic_result_transform.set_group_count(Some(ordinal));
+        self.classic_result_transform.set_projection(Vec::new());
+        self.classic_result_transform.clear_orders();
+        self.execute_classic_result_transform();
+    }
+
+    fn handle_result_sql_command(&mut self, args: &str) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        let sql = match self.classic_result_sql() {
+            Ok(sql) => sql,
+            Err(error) => {
+                self.last_status = Some(format!("Cannot build result SQL: {error}"));
+                return;
+            }
+        };
+        match args.trim() {
+            "" | "copy" => {
+                if self.copy_to_clipboard(&sql) {
+                    self.last_status = Some("Copied transformed result SQL".into());
+                }
+            }
+            "open" | "edit" => {
+                self.editor.set_text(sql);
+                self.set_focus(Focus::Query);
+                self.mode = Mode::Normal;
+                self.last_status = Some("Opened transformed result SQL in the query editor".into());
+            }
+            _ => self.last_status = Some("Usage: :result-sql copy|open".into()),
+        }
+    }
+
+    fn open_result_columns_picker(&mut self) {
+        if !self.classic_transform_available() {
+            return;
+        }
+        self.result_columns_draft = if self.classic_result_transform.projection.is_empty() {
+            (0..self.classic_result_base_headers.len()).collect()
+        } else {
+            self.classic_result_transform.projection.clone()
+        };
+        self.rebuild_result_columns_picker(String::new(), 0);
+    }
+
+    fn rebuild_result_columns_picker(&mut self, query: String, selected: usize) {
+        let entries = self
+            .classic_result_base_headers
+            .iter()
+            .enumerate()
+            .map(|(ordinal, name)| ResultColumnEntry {
+                ordinal,
+                name: name.clone(),
+                selected_position: self
+                    .result_columns_draft
+                    .iter()
+                    .position(|selected| *selected == ordinal),
+            })
+            .collect();
+        let mut picker = FuzzyPicker::with_display(
+            entries,
+            "Columns - type to filter | Space toggle  Ctrl+Up/Down reorder  Enter apply  Esc close",
+            ResultColumnEntry::display,
+        )
+        .with_original_order();
+        picker.set_query(query);
+        picker.set_selected(selected);
+        self.result_columns_picker = Some(picker);
+    }
+
+    fn handle_result_columns_picker_key(&mut self, key: KeyEvent) -> bool {
+        let Some(picker) = self.result_columns_picker.as_mut() else {
+            return false;
+        };
+        let selected = picker.selected();
+        let query = picker.query().to_string();
+        let ordinal = picker.selected_original_index();
+        match (key.code, key.modifiers) {
+            (KeyCode::Char(' '), KeyModifiers::NONE) => {
+                let Some(ordinal) = ordinal else {
+                    return false;
+                };
+                self.toggle_result_column(ordinal);
+                self.rebuild_result_columns_picker(query, selected);
+            }
+            (KeyCode::Up, KeyModifiers::CONTROL) | (KeyCode::Down, KeyModifiers::CONTROL) => {
+                let Some(ordinal) = ordinal else {
+                    return false;
+                };
+                let Some(position) = self
+                    .result_columns_draft
+                    .iter()
+                    .position(|selected| *selected == ordinal)
+                else {
+                    return false;
+                };
+                let next = if key.code == KeyCode::Up {
+                    position.checked_sub(1)
+                } else {
+                    position
+                        .checked_add(1)
+                        .filter(|next| *next < self.result_columns_draft.len())
+                };
+                if let Some(next) = next {
+                    self.result_columns_draft.swap(position, next);
+                    self.rebuild_result_columns_picker(query, selected);
+                }
+            }
+            (KeyCode::Enter, _) => self.apply_result_columns_draft(),
+            _ => match picker.handle_key(key) {
+                PickerAction::Continue => {}
+                PickerAction::Cancelled => {
+                    self.result_columns_picker = None;
+                    self.result_columns_draft.clear();
+                }
+                PickerAction::Selected(_) => self.apply_result_columns_draft(),
+            },
+        }
+        false
+    }
+
+    fn toggle_result_column(&mut self, ordinal: usize) {
+        if let Some(position) = self
+            .result_columns_draft
+            .iter()
+            .position(|selected| *selected == ordinal)
+        {
+            self.result_columns_draft.remove(position);
+        } else {
+            self.result_columns_draft.push(ordinal);
+        }
+    }
+
+    fn apply_result_columns_draft(&mut self) {
+        if self.result_columns_draft.is_empty() {
+            self.last_status = Some("Choose at least one result column".into());
+            return;
+        }
+        let natural = (0..self.classic_result_base_headers.len()).collect::<Vec<_>>();
+        let projection = if self.result_columns_draft == natural {
+            Vec::new()
+        } else {
+            self.result_columns_draft.clone()
+        };
+        self.classic_result_transform.set_projection(projection);
+        self.classic_result_transform.set_group_count(None);
+        self.result_columns_picker = None;
+        self.result_columns_draft.clear();
+        self.execute_classic_result_transform();
+    }
+
+    fn handle_action_palette_key(&mut self, key: KeyEvent) -> bool {
+        let Some(picker) = self.action_palette.as_mut() else {
+            return false;
+        };
+        match picker.handle_key(key) {
+            PickerAction::Continue => false,
+            PickerAction::Cancelled => {
+                self.action_palette = None;
+                false
+            }
+            PickerAction::Selected(entry) => {
+                self.action_palette = None;
+                self.run_palette_action(entry.action);
+                false
+            }
+        }
+    }
+
+    fn run_palette_action(&mut self, action: PaletteAction) {
+        match action {
+            PaletteAction::Run => {
+                if self.workspace_mode == WorkspaceMode::Notebook {
+                    self.execute_notebook_cell();
+                } else {
+                    self.execute_query();
+                }
+            }
+            PaletteAction::History => self.open_history_picker(),
+            PaletteAction::Snippets => self.open_snippet_picker(),
+            PaletteAction::SaveSnippet => self.open_command_prefilled("snippet-save "),
+            PaletteAction::ExportCsv => self.open_command_prefilled("export csv ./result.csv"),
+            PaletteAction::ExportJson => self.open_command_prefilled("export json ./result.json"),
+            PaletteAction::ExportTsv => self.open_command_prefilled("export tsv ./result.tsv"),
+            PaletteAction::ExportSql => self.open_command_prefilled("export sql ./result.sql"),
+            PaletteAction::GenerateInsert => self.run_palette_generate("insert"),
+            PaletteAction::GenerateUpdate => self.run_palette_generate("update"),
+            PaletteAction::GenerateDelete => self.run_palette_generate("delete"),
+            PaletteAction::SortAscending => {
+                self.set_classic_result_order(OrderDirection::Asc, false);
+            }
+            PaletteAction::SortDescending => {
+                self.set_classic_result_order(OrderDirection::Desc, false);
+            }
+            PaletteAction::AddSortAscending => {
+                self.set_classic_result_order(OrderDirection::Asc, true);
+            }
+            PaletteAction::AddSortDescending => {
+                self.set_classic_result_order(OrderDirection::Desc, true);
+            }
+            PaletteAction::FilterCurrentValue => {
+                self.add_classic_current_value_filter(FilterOp::Eq);
+            }
+            PaletteAction::ExcludeCurrentValue => {
+                self.add_classic_current_value_filter(FilterOp::Ne);
+            }
+            PaletteAction::FilterNull => self.add_classic_null_filter(FilterOp::IsNull),
+            PaletteAction::FilterNotNull => self.add_classic_null_filter(FilterOp::IsNotNull),
+            PaletteAction::FilterContains => {
+                self.add_classic_current_value_filter(FilterOp::Contains);
+            }
+            PaletteAction::FilterNotContains => {
+                self.add_classic_current_value_filter(FilterOp::NotContains);
+            }
+            PaletteAction::CustomFilter => self.open_command_prefilled("filter "),
+            PaletteAction::ChooseColumns => self.open_result_columns_picker(),
+            PaletteAction::GroupCountCurrentColumn => self.group_classic_result_by_current(),
+            PaletteAction::ClearFilters => self.clear_classic_result_filters(),
+            PaletteAction::ClearSorting => self.clear_classic_result_sorting(),
+            PaletteAction::ResetResult => self.reset_classic_result_transform(),
+            PaletteAction::CopyTransformedSql => self.handle_result_sql_command("copy"),
+            PaletteAction::OpenTransformedSql => self.handle_result_sql_command("open"),
+            PaletteAction::NewCell => {
+                self.notebook.insert_cell(true);
+                self.notebook_document_dirty = true;
+                self.mode = Mode::Insert;
+                self.last_status = Some("Inserted notebook cell below".to_string());
+            }
+            PaletteAction::RefineCell => self.refine_selected_cell(),
+            PaletteAction::RunAll => self.queue_notebook_run(NotebookRunScope::All),
+            PaletteAction::RunAbove => self.queue_notebook_run(NotebookRunScope::Above),
+            PaletteAction::RunBelow => self.queue_notebook_run(NotebookRunScope::Below),
+            PaletteAction::RunDependents => self.queue_notebook_run(NotebookRunScope::Dependents),
+            PaletteAction::ExplainCell => self.explain_selected_notebook_cell(),
+            PaletteAction::ToggleOutput => {
+                let cell = self.notebook.selected_cell_mut();
+                cell.output_collapsed = !cell.output_collapsed;
+                self.last_status = Some(if cell.output_collapsed {
+                    "Collapsed notebook result".to_string()
+                } else {
+                    "Expanded notebook result".to_string()
+                });
+            }
+            PaletteAction::ToggleSource => {
+                self.execute_command("toggle-source");
+            }
+            PaletteAction::ClearCell => self.request_clear_notebook_cell_execution(),
+            PaletteAction::CellHistory => self.open_cell_history_picker(),
+            PaletteAction::InspectError => {
+                self.execute_command("error");
+            }
+            PaletteAction::JumpToError => self.jump_to_notebook_error(),
+            PaletteAction::JumpToActivity => self.goto_latest_notebook_activity(),
+            PaletteAction::SwitchNotebook => self.switch_workspace(WorkspaceMode::Notebook),
+            PaletteAction::SwitchClassic => self.switch_workspace(WorkspaceMode::Classic),
+        }
+    }
+
+    fn open_command_prefilled(&mut self, command: &str) {
+        self.command.open();
+        self.command.textarea.insert_str(command);
+        self.command.textarea.move_cursor(CursorMove::End);
+    }
+
+    fn run_palette_generate(&mut self, kind: &str) {
+        let source_table = if self.workspace_mode == WorkspaceMode::Notebook {
+            self.notebook
+                .selected_cell()
+                .output
+                .as_ref()
+                .and_then(|output| output.grid.source_table.as_ref())
+        } else {
+            self.grid.source_table.as_ref()
+        };
+        if source_table.is_some() {
+            self.handle_gen_command(kind);
+        } else {
+            self.open_command_prefilled(&format!("gen {kind} "));
+        }
+    }
+
+    fn open_snippet_picker(&mut self) {
+        let snippets = self.history.search_snippets("");
+        if snippets.is_empty() {
+            self.last_status = Some("No saved snippets. Use :snippet-save <name>".to_string());
+            return;
+        }
+        self.snippet_picker = Some(
+            FuzzyPicker::with_display(
+                snippets,
+                "Saved snippets - type to filter | Enter load  C-d delete  Esc close",
+                |snippet| {
+                    let query = snippet
+                        .query
+                        .split_whitespace()
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let preview = query.chars().take(80).collect::<String>();
+                    format!("{}  {}", snippet.name, preview)
+                },
+            )
+            .with_original_order(),
+        );
+    }
+
+    fn handle_snippet_picker_key(&mut self, key: KeyEvent) -> bool {
+        if key.code == KeyCode::Char('d') && key.modifiers == KeyModifiers::CONTROL {
+            let name = self.snippet_picker.as_ref().and_then(|picker| {
+                picker
+                    .selected_original_index()
+                    .and_then(|index| self.history.search_snippets("").get(index).cloned())
+                    .map(|snippet| snippet.name)
+            });
+            if let Some(name) = name {
+                self.history.remove_snippet(&name);
+                if let Err(error) = self.history.save() {
+                    self.last_error = Some(format!("Failed to save snippets: {error}"));
+                }
+                self.snippet_picker = None;
+                self.open_snippet_picker();
+                self.last_status = Some(format!("Deleted snippet '{name}'"));
+            }
+            return false;
+        }
+        let Some(picker) = self.snippet_picker.as_mut() else {
+            return false;
+        };
+        match picker.handle_key(key) {
+            PickerAction::Continue => false,
+            PickerAction::Cancelled => {
+                self.snippet_picker = None;
+                false
+            }
+            PickerAction::Selected(snippet) => {
+                self.snippet_picker = None;
+                self.load_snippet(snippet);
+                false
+            }
+        }
+    }
+
+    fn save_current_snippet(&mut self, name: &str) {
+        let query = if self.workspace_mode == WorkspaceMode::Notebook {
+            self.notebook.selected_cell().source()
+        } else {
+            self.editor.text()
+        };
+        let connection = self
+            .db
+            .conn_str
+            .as_ref()
+            .map(|value| ConnectionInfo::parse(value).format(50));
+        match self.history.save_snippet(name, query, connection) {
+            Ok(()) => match self.history.save() {
+                Ok(()) => {
+                    self.last_error = None;
+                    self.last_status = Some(format!("Saved snippet '{}'", name.trim()));
+                }
+                Err(error) => self.last_error = Some(format!("Failed to save snippets: {error}")),
+            },
+            Err(error) => self.last_error = Some(error.to_string()),
+        }
+    }
+
+    fn delete_snippet(&mut self, name: &str) {
+        let name = name.trim();
+        if name.is_empty() {
+            self.last_status = Some("Usage: :snippet-delete <name>".to_string());
+            return;
+        }
+        if !self.history.remove_snippet(name) {
+            self.last_error = Some(format!("Snippet '{name}' was not found"));
+            return;
+        }
+        match self.history.save() {
+            Ok(()) => self.last_status = Some(format!("Deleted snippet '{name}'")),
+            Err(error) => self.last_error = Some(format!("Failed to save snippets: {error}")),
+        }
+    }
+
+    fn handle_snippet_command(&mut self, args: &str) {
+        if args.is_empty() {
+            self.open_snippet_picker();
+            return;
+        }
+        if let Some(name) = args.strip_prefix("save ") {
+            self.save_current_snippet(name);
+            return;
+        }
+        if let Some(name) = args.strip_prefix("delete ") {
+            self.delete_snippet(name);
+            return;
+        }
+        let Some(snippet) = self
+            .history
+            .snippets()
+            .iter()
+            .find(|snippet| snippet.name.eq_ignore_ascii_case(args.trim()))
+            .cloned()
+        else {
+            self.last_error = Some(format!("Snippet '{}' was not found", args.trim()));
+            return;
+        };
+        self.load_snippet(snippet);
+    }
+
+    fn load_snippet(&mut self, snippet: SavedQuerySnippet) {
+        if self.workspace_mode == WorkspaceMode::Notebook {
+            self.notebook
+                .selected_cell_mut()
+                .replace_source(snippet.query);
+            self.notebook.focus = NotebookFocus::Editor;
+            self.set_focus(Focus::Notebook);
+        } else {
+            self.editor.set_text(snippet.query);
+            self.editor.mark_saved();
+            self.set_focus(Focus::Query);
+        }
+        self.last_error = None;
+        self.last_status = Some(format!("Loaded snippet '{}'", snippet.name));
+    }
+
+    fn open_cell_history_picker(&mut self) {
+        let cell = self.notebook.selected_cell();
+        if cell.execution_history.is_empty() {
+            self.last_status = Some("Selected notebook cell has no execution history".to_string());
+            return;
+        }
+        let runs = cell
+            .execution_history
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>();
+        self.cell_history_picker = Some(
+            FuzzyPicker::with_display(
+                runs,
+                format!(
+                    "Cell {} history - Enter restore source  Esc close",
+                    cell.id.0
+                ),
+                |record| {
+                    let status = match record.status {
+                        NotebookRunStatus::Succeeded => "OK",
+                        NotebookRunStatus::Failed => "FAILED",
+                        NotebookRunStatus::Cancelled => "CANCELLED",
+                    };
+                    let source = record
+                        .source
+                        .split_whitespace()
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let preview = source.chars().take(64).collect::<String>();
+                    let result_preview = record.error.as_ref().map_or_else(
+                        || {
+                            record.rows.first().map_or_else(
+                                || "no preview".to_string(),
+                                |row| {
+                                    record
+                                        .headers
+                                        .iter()
+                                        .zip(row.iter())
+                                        .take(3)
+                                        .map(|(header, value)| format!("{header}={value}"))
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                },
+                            )
+                        },
+                        |error| error.lines().next().unwrap_or(error).to_string(),
+                    );
+                    let result_preview = result_preview.chars().take(48).collect::<String>();
+                    format!(
+                        "run {}  {}  {} rows  {}ms  {}  | {}",
+                        record.execution_id,
+                        status,
+                        record.row_count,
+                        record.elapsed_ms,
+                        result_preview,
+                        preview
+                    )
+                },
+            )
+            .with_original_order(),
+        );
+    }
+
+    fn handle_cell_history_picker_key(&mut self, key: KeyEvent) -> bool {
+        let Some(picker) = self.cell_history_picker.as_mut() else {
+            return false;
+        };
+        match picker.handle_key(key) {
+            PickerAction::Continue => false,
+            PickerAction::Cancelled => {
+                self.cell_history_picker = None;
+                false
+            }
+            PickerAction::Selected(record) => {
+                self.cell_history_picker = None;
+                self.restore_notebook_run(record.execution_id);
+                false
+            }
+        }
+    }
+
+    fn inspect_notebook_run(&mut self, args: &str) {
+        let Ok(execution_id) = args.trim().parse::<u64>() else {
+            self.last_status = Some("Usage: :cell-run <execution-id>".to_string());
+            return;
+        };
+        self.restore_notebook_run(execution_id);
+    }
+
+    fn restore_notebook_run(&mut self, execution_id: u64) {
+        let cell = self.notebook.selected_cell_mut();
+        let Some(index) = cell
+            .execution_history
+            .iter()
+            .position(|record| record.execution_id == execution_id)
+        else {
+            self.last_error = Some(format!("Run {execution_id} was not found for this cell"));
+            return;
+        };
+        let record = cell.execution_history[index].clone();
+        cell.restore_run_source(index);
+        cell.source_collapsed = false;
+        self.notebook.focus = NotebookFocus::Editor;
+        self.set_focus(Focus::Notebook);
+        self.mode = Mode::Normal;
+        self.notebook_document_dirty = true;
+        self.last_error = None;
+        self.last_status = Some(format!(
+            "Restored cell source from run {} ({} rows, {}ms)",
+            record.execution_id, record.row_count, record.elapsed_ms
+        ));
+    }
+
     fn reopen_history_picker_with_state(
         &mut self,
         saved_query: Option<String>,
@@ -13317,7 +17060,6 @@ impl App {
                 if self.workspace_mode == WorkspaceMode::Notebook {
                     let cell = self.notebook.selected_cell_mut();
                     cell.replace_source(entry.query);
-                    cell.editor.mark_saved();
                     self.notebook.focus = NotebookFocus::Editor;
                 } else {
                     self.editor.set_text(entry.query);
@@ -13338,6 +17080,17 @@ impl App {
 }
 
 const GRID_DOUBLE_CLICK_THRESHOLD: Duration = Duration::from_millis(400);
+
+fn expand_user_path(path: &str) -> std::path::PathBuf {
+    if let Some(stripped) = path.strip_prefix("~/") {
+        std::env::var_os("HOME").map_or_else(
+            || std::path::PathBuf::from(path),
+            |home| std::path::PathBuf::from(home).join(stripped),
+        )
+    } else {
+        std::path::PathBuf::from(path)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GridMouseTarget {
@@ -13479,16 +17232,193 @@ fn hit_test_data_column(
 }
 
 fn notebook_source_summary(lines: &[String]) -> String {
-    lines
+    const MAX_CHARS: usize = 160;
+    let mut summary = String::new();
+    let mut truncated = false;
+
+    for line in lines
         .iter()
         .map(|line| line.trim())
         .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ")
+    {
+        if !summary.is_empty() {
+            summary.push(' ');
+        }
+        let remaining = MAX_CHARS.saturating_sub(summary.chars().count());
+        summary.extend(line.chars().take(remaining));
+        if line.chars().count() > remaining {
+            truncated = true;
+            break;
+        }
+    }
+
+    if truncated {
+        summary.push('…');
+    }
+    summary
+}
+
+fn decorate_notebook_source(
+    buffer: &mut ratatui::buffer::Buffer,
+    area: Rect,
+    lines: &[String],
+    search: Option<&str>,
+    accent: Color,
+    search_style: Style,
+) {
+    let patch_range = |buffer: &mut ratatui::buffer::Buffer,
+                       y: u16,
+                       line: &str,
+                       start: usize,
+                       end: usize,
+                       style: Style| {
+        let x = area
+            .x
+            .saturating_add(line[..start].width().min(u16::MAX as usize) as u16);
+        let width = line[start..end].width().min(u16::MAX as usize) as u16;
+        for x in x..x.saturating_add(width).min(area.right()) {
+            if let Some(cell) = buffer.cell_mut((x, y)) {
+                cell.set_style(cell.style().patch(style));
+            }
+        }
+    };
+
+    for (row, line) in lines.iter().take(area.height as usize).enumerate() {
+        let y = area.y.saturating_add(row as u16);
+        if let Some(search) = search.filter(|search| !search.is_empty()) {
+            for (start, _) in line.match_indices(search) {
+                patch_range(buffer, y, line, start, start + search.len(), search_style);
+            }
+        }
+
+        let mut offset = 0;
+        while let Some(relative) = line[offset..].find("@result") {
+            let start = offset + relative;
+            let mut end = start + "@result".len();
+            let suffix = &line[end..];
+            if let Some(suffix) = suffix.strip_prefix('_') {
+                let identifier = suffix
+                    .bytes()
+                    .take_while(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+                    .count();
+                if identifier == 0 {
+                    offset = end;
+                    continue;
+                }
+                end += 1 + identifier;
+            } else if suffix
+                .chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_alphanumeric() || character == '_')
+            {
+                offset = end;
+                continue;
+            }
+
+            patch_range(
+                buffer,
+                y,
+                line,
+                start,
+                end,
+                Style::default().fg(accent).add_modifier(Modifier::BOLD),
+            );
+            offset = end;
+        }
+    }
+}
+
+fn notebook_editor_key_is_navigation_only(
+    mode: Mode,
+    key: KeyEvent,
+    action: Option<Action>,
+    pending_key: Option<char>,
+) -> bool {
+    if pending_key.is_some() {
+        return false;
+    }
+
+    if matches!(
+        action,
+        Some(
+            Action::MoveUp
+                | Action::MoveDown
+                | Action::MoveLeft
+                | Action::MoveRight
+                | Action::MoveToTop
+                | Action::MoveToBottom
+                | Action::MoveToStart
+                | Action::MoveToEnd
+                | Action::PageUp
+                | Action::PageDown
+                | Action::HalfPageUp
+                | Action::HalfPageDown
+                | Action::EnterInsertMode
+                | Action::EnterNormalMode
+                | Action::EnterVisualMode
+                | Action::EnterCommandMode
+                | Action::StartSearch
+                | Action::NextMatch
+                | Action::PrevMatch
+                | Action::Copy
+                | Action::SelectAll
+                | Action::ToggleFocus
+                | Action::FocusNext
+                | Action::FocusPrevious
+                | Action::FocusLeft
+                | Action::FocusDown
+                | Action::FocusUp
+                | Action::FocusRight
+        )
+    ) {
+        return true;
+    }
+
+    match mode {
+        Mode::Insert => matches!(
+            key.code,
+            KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::Up
+                | KeyCode::Down
+                | KeyCode::Home
+                | KeyCode::End
+        ),
+        Mode::Normal | Mode::Visual => {
+            key.modifiers == KeyModifiers::NONE
+                && matches!(
+                    key.code,
+                    KeyCode::Left
+                        | KeyCode::Right
+                        | KeyCode::Up
+                        | KeyCode::Down
+                        | KeyCode::Home
+                        | KeyCode::End
+                        | KeyCode::Char('h')
+                        | KeyCode::Char('j')
+                        | KeyCode::Char('k')
+                        | KeyCode::Char('l')
+                        | KeyCode::Char('w')
+                        | KeyCode::Char('W')
+                        | KeyCode::Char('b')
+                        | KeyCode::Char('B')
+                        | KeyCode::Char('e')
+                        | KeyCode::Char('E')
+                        | KeyCode::Char('0')
+                        | KeyCode::Char('$')
+                        | KeyCode::Char('g')
+                        | KeyCode::Char('G')
+                )
+        }
+    }
 }
 
 fn notebook_output_summary(output: &NotebookOutput, stale: bool, compact: bool) -> String {
-    let completeness = if output.retained.is_some() {
+    let retained = match &output.refinement {
+        RefinementAvailability::Available(retained) => Some(retained),
+        RefinementAvailability::Unavailable(_) => None,
+    };
+    let completeness = if retained.is_some() {
         if compact {
             "SNAPSHOT"
         } else {
@@ -13501,12 +17431,26 @@ fn notebook_output_summary(output: &NotebookOutput, stale: bool, compact: bool) 
     };
     let extent = if output.truncated {
         if compact {
-            format!("≥{} rows", output.grid.rows.len().saturating_add(1))
+            retained.map_or_else(
+                || format!("≥{} rows", output.grid.rows.len().saturating_add(1)),
+                |retained| format!("{} rows", retained.rows),
+            )
         } else {
-            format!(
-                "{} fetched · at least {} total",
-                output.grid.rows.len(),
-                output.grid.rows.len().saturating_add(1)
+            retained.map_or_else(
+                || {
+                    format!(
+                        "{} fetched · at least {} total",
+                        output.grid.rows.len(),
+                        output.grid.rows.len().saturating_add(1)
+                    )
+                },
+                |retained| {
+                    format!(
+                        "{} fetched · {} total",
+                        output.grid.rows.len(),
+                        retained.rows
+                    )
+                },
             )
         }
     } else {
@@ -13517,6 +17461,40 @@ fn notebook_output_summary(output: &NotebookOutput, stale: bool, compact: bool) 
         if stale { "STALE OUTPUT · " } else { "" },
         output.elapsed.as_millis()
     )
+}
+
+fn notebook_grid_bytes(output: &NotebookOutput) -> usize {
+    output
+        .grid
+        .headers
+        .iter()
+        .map(String::len)
+        .chain(output.grid.rows.iter().flatten().map(String::len))
+        .sum()
+}
+
+fn notebook_ascii_fallback() -> bool {
+    if std::env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")) {
+        return true;
+    }
+    std::env::var("TSQL_ASCII").is_ok_and(|value| {
+        !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        )
+    })
+}
+
+fn notebook_explain_source(source: &str) -> Result<String, String> {
+    let statement = single_statement(source)
+        .map_err(|error| format!("Explain cell requires one valid SQL statement: {error}"))?;
+    if code_words(statement, 1)?
+        .first()
+        .is_some_and(|word| word == "EXPLAIN")
+    {
+        return Err("Selected notebook cell already contains EXPLAIN".to_string());
+    }
+    Ok(format!("EXPLAIN\n{statement}"))
 }
 
 fn notebook_focused_cell_window(
@@ -13555,13 +17533,16 @@ fn notebook_cell_render_height(
     composer_max_rows: usize,
     output_preview_rows: usize,
 ) -> usize {
-    let composer = cell
-        .editor
-        .textarea
-        .lines()
-        .len()
-        .clamp(1, composer_max_rows)
-        .saturating_add(3);
+    let source_height = if cell.source_collapsed {
+        1
+    } else {
+        cell.editor
+            .textarea
+            .lines()
+            .len()
+            .clamp(1, composer_max_rows)
+    };
+    let composer = source_height.saturating_add(3);
     let error = usize::from(cell.failure.is_some()).saturating_mul(2);
     let output = cell
         .output
@@ -13757,6 +17738,523 @@ mod tests {
         app
     }
 
+    fn classic_result_transform_test_app(runtime: &tokio::runtime::Runtime) -> App {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let base = "SELECT id, amount, note FROM source_rows LIMIT 1500;";
+        let headers = vec!["id".to_string(), "amount".to_string(), "note".to_string()];
+        let grid = GridModel::new(
+            headers.clone(),
+            vec![
+                vec!["1".to_string(), "10".to_string(), "NULL".to_string()],
+                vec!["2".to_string(), "2".to_string(), "NULL".to_string()],
+                vec!["3".to_string(), "10".to_string(), "O'Reilly_%".to_string()],
+            ],
+        )
+        .with_null_cells(vec![
+            vec![false, false, false],
+            vec![false, false, true],
+            vec![false, false, false],
+        ]);
+        let mut app = App::new(grid, runtime.handle().clone(), tx, rx, None);
+        app.connection_picker = None;
+        app.connection_manager = None;
+        app.db.kind = Some(DbKind::Postgres);
+        app.db.transaction_state = TransactionState::Idle;
+        app.focus = Focus::Grid;
+        app.editor.set_text(base.to_string());
+        app.last_executed_query = Some(base.to_string());
+        app.classic_result_base_query = Some(base.to_string());
+        app.classic_result_base_headers = headers;
+        app
+    }
+
+    #[test]
+    fn classic_result_transform_palette_actions_are_classic_only() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+
+        app.open_action_palette();
+        let picker = app.action_palette.as_mut().unwrap();
+        picker.set_query("Sort current column ascending".to_string());
+        assert!(picker.filtered_count() > 0);
+        picker.set_query("Filter to current value".to_string());
+        assert!(picker.filtered_count() > 0);
+
+        app.action_palette = None;
+        app.switch_workspace(WorkspaceMode::Notebook);
+        app.notebook.cells[0].output = Some(notebook_test_output(1));
+        app.open_action_palette();
+        let picker = app.action_palette.as_mut().unwrap();
+        picker.set_query("Sort current column ascending".to_string());
+        assert_eq!(picker.filtered_count(), 0);
+        picker.set_query("Filter to current value".to_string());
+        assert_eq!(picker.filtered_count(), 0);
+    }
+
+    #[test]
+    fn classic_result_transform_zero_row_palette_keeps_non_cell_actions_available() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+        app.grid = GridModel::new(
+            vec!["id".to_string(), "amount".to_string(), "note".to_string()],
+            Vec::new(),
+        );
+        app.classic_result_transform.add_filter(ResultFilter {
+            ordinal: 0,
+            op: FilterOp::Gt,
+            value: FilterValue::Integer(5000),
+        });
+
+        app.open_action_palette();
+        let picker = app.action_palette.as_mut().unwrap();
+        for action in [
+            "Add custom filter",
+            "Choose result columns",
+            "Clear result filters",
+            "Reset result transformations",
+        ] {
+            picker.set_query(action.to_string());
+            assert!(
+                picker.filtered_count() > 0,
+                "missing zero-row action: {action}"
+            );
+        }
+        for action in [
+            "Filter to current value",
+            "Exclude current value",
+            "Filter current column containing value",
+            "Filter current column not containing value",
+        ] {
+            picker.set_query(action.to_string());
+            assert_eq!(
+                picker.filtered_count(),
+                0,
+                "unexpected zero-row action: {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn classic_result_transform_distinguishes_literal_null_from_sql_null() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut literal = classic_result_transform_test_app(&runtime);
+        literal.grid_state.cursor_row = 0;
+        literal.grid_state.cursor_col = 2;
+
+        literal.run_palette_action(PaletteAction::FilterCurrentValue);
+
+        assert_eq!(literal.classic_result_transform.filters.len(), 1);
+        assert_eq!(literal.classic_result_transform.filters[0].ordinal, 2);
+        assert_eq!(literal.classic_result_transform.filters[0].op, FilterOp::Eq);
+        assert_eq!(
+            literal.classic_result_transform.filters[0].value,
+            FilterValue::Text("NULL".to_string())
+        );
+        let literal_sql = literal.classic_result_sql().unwrap();
+        assert!(literal_sql.contains("\"__tsql_col_3\" IS NOT DISTINCT FROM E'NULL'"));
+
+        let mut null = classic_result_transform_test_app(&runtime);
+        null.grid_state.cursor_row = 1;
+        null.grid_state.cursor_col = 2;
+        null.run_palette_action(PaletteAction::ExcludeCurrentValue);
+
+        assert_eq!(null.classic_result_transform.filters.len(), 1);
+        assert_eq!(null.classic_result_transform.filters[0].ordinal, 2);
+        assert_eq!(null.classic_result_transform.filters[0].op, FilterOp::Ne);
+        assert_eq!(
+            null.classic_result_transform.filters[0].value,
+            FilterValue::Null
+        );
+        let null_sql = null.classic_result_sql().unwrap();
+        assert!(null_sql.contains("\"__tsql_col_3\" IS NOT NULL"));
+    }
+
+    #[test]
+    fn classic_result_transform_commands_parse_spacing_ordinals_names_and_values() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+
+        assert!(!app.execute_command("sort   desc   #2"));
+        assert!(!app.execute_command("sort   add-asc   ID"));
+        assert_eq!(app.classic_result_transform.orders.len(), 2);
+        assert_eq!(app.classic_result_transform.orders[0].ordinal, 1);
+        assert_eq!(
+            app.classic_result_transform.orders[0].direction,
+            OrderDirection::Desc
+        );
+        assert_eq!(app.classic_result_transform.orders[1].ordinal, 0);
+        assert_eq!(
+            app.classic_result_transform.orders[1].direction,
+            OrderDirection::Asc
+        );
+
+        assert!(!app.execute_command("filter   #2   >=   10"));
+        assert!(!app.execute_command("filter   note   contains   'O''Reilly_%'"));
+        assert_eq!(app.classic_result_transform.filters.len(), 2);
+        assert_eq!(app.classic_result_transform.filters[0].ordinal, 1);
+        assert_eq!(app.classic_result_transform.filters[0].op, FilterOp::Gte);
+        assert_eq!(
+            app.classic_result_transform.filters[0].value,
+            FilterValue::Text("10".to_string())
+        );
+        assert_eq!(app.classic_result_transform.filters[1].ordinal, 2);
+        assert_eq!(
+            app.classic_result_transform.filters[1].op,
+            FilterOp::Contains
+        );
+        assert_eq!(
+            app.classic_result_transform.filters[1].value,
+            FilterValue::Text("O'Reilly_%".to_string())
+        );
+        let sql = app.classic_result_sql().unwrap();
+        assert!(sql.contains("\"__tsql_col_2\" >= E'10'"));
+        assert!(sql.contains("\"__tsql_col_3\"::text ILIKE E'%O''Reilly\\\\_\\\\%%'"));
+        assert!(sql.ends_with(
+            "ORDER BY \"__tsql_result\".\"__tsql_col_2\" DESC, \"__tsql_result\".\"__tsql_col_1\" ASC"
+        ));
+    }
+
+    #[test]
+    fn classic_result_transform_column_picker_toggles_reorders_applies_and_cancels() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+
+        assert!(!app.execute_command("columns"));
+        assert!(app.result_columns_picker.is_some());
+        assert_eq!(app.result_columns_draft, vec![0, 1, 2]);
+        app.handle_result_columns_picker_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        assert_eq!(app.result_columns_draft, vec![1, 2]);
+
+        app.result_columns_picker.as_mut().unwrap().set_selected(2);
+        app.handle_result_columns_picker_key(KeyEvent::new(KeyCode::Up, KeyModifiers::CONTROL));
+        assert_eq!(app.result_columns_draft, vec![2, 1]);
+        app.handle_result_columns_picker_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(app.result_columns_picker.is_none());
+        assert!(app.result_columns_draft.is_empty());
+        assert_eq!(app.classic_result_transform.projection, vec![2, 1]);
+
+        app.open_result_columns_picker();
+        assert_eq!(app.result_columns_draft, vec![2, 1]);
+        app.result_columns_picker.as_mut().unwrap().set_selected(2);
+        app.handle_result_columns_picker_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        assert_eq!(app.result_columns_draft, vec![1]);
+        app.handle_result_columns_picker_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(app.result_columns_picker.is_none());
+        assert!(app.result_columns_draft.is_empty());
+        assert_eq!(app.classic_result_transform.projection, vec![2, 1]);
+    }
+
+    #[test]
+    fn classic_result_transform_projection_and_group_count_compile_against_base_query() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+
+        assert!(!app.execute_command("columns   #3,   id"));
+        assert_eq!(app.classic_result_transform.projection, vec![2, 0]);
+        let projected_sql = app.classic_result_sql().unwrap();
+        assert!(projected_sql.starts_with(
+            "SELECT \"__tsql_result\".\"__tsql_col_3\" AS \"note\", \"__tsql_result\".\"__tsql_col_1\" AS \"id\""
+        ));
+        assert!(projected_sql.contains("FROM source_rows LIMIT 1500"));
+
+        assert!(!app.execute_command("filter   id   >   1"));
+        assert!(!app.execute_command("group-count   amount"));
+        assert_eq!(app.classic_result_transform.group_count, Some(1));
+        assert!(app.classic_result_transform.projection.is_empty());
+        assert!(app.classic_result_transform.orders.is_empty());
+        let grouped_sql = app.classic_result_sql().unwrap();
+        assert!(grouped_sql.starts_with(
+            "SELECT \"__tsql_result\".\"__tsql_col_2\" AS \"amount\", COUNT(*) AS \"count\""
+        ));
+        assert!(grouped_sql.contains("WHERE \"__tsql_result\".\"__tsql_col_1\" > E'1'"));
+        assert!(grouped_sql.contains("GROUP BY \"__tsql_result\".\"__tsql_col_2\""));
+        assert!(grouped_sql.ends_with("ORDER BY COUNT(*) DESC"));
+
+        assert!(!app.execute_command("result-sql open"));
+        assert_eq!(app.editor.text(), grouped_sql);
+        assert_eq!(app.focus, Focus::Query);
+    }
+
+    #[test]
+    fn classic_result_transform_reset_and_new_execution_clear_transform_state() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+
+        app.execute_command("filter #1 > 0");
+        app.execute_command("sort desc #2");
+        assert!(!app.classic_result_transform.is_empty());
+        app.execute_command("reset-result");
+        assert!(app.classic_result_transform.is_empty());
+        assert_eq!(
+            app.classic_result_sql().as_deref(),
+            Ok("SELECT id, amount, note FROM source_rows LIMIT 1500;")
+        );
+
+        app.execute_command("filter note contains row");
+        assert!(!app.classic_result_transform.is_empty());
+        app.open_result_columns_picker();
+        assert!(app.result_columns_picker.is_some());
+        app.execute_query_text(
+            "SELECT 42 AS replacement".to_string(),
+            QueryExecutionKind::New,
+        );
+        assert!(app.classic_result_transform.is_empty());
+        assert_eq!(
+            app.classic_result_base_query.as_deref(),
+            Some("SELECT 42 AS replacement")
+        );
+        assert!(app.classic_result_base_headers.is_empty());
+        assert!(app.result_columns_picker.is_none());
+        assert!(app.result_columns_draft.is_empty());
+    }
+
+    #[test]
+    fn classic_result_transform_rejects_mutations_while_query_is_running() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+        app.classic_result_transform.add_filter(ResultFilter {
+            ordinal: 0,
+            op: FilterOp::Gt,
+            value: FilterValue::Integer(0),
+        });
+        app.classic_result_transform
+            .set_order(1, OrderDirection::Desc, false);
+        let before = app.classic_result_transform.clone();
+        app.db.running = true;
+
+        for command in [
+            "sort asc #1",
+            "filter #2 >= 10",
+            "columns #3,#1",
+            "group-count note",
+            "reset-result",
+            "clear-filters",
+            "clear-sort",
+        ] {
+            app.execute_command(command);
+            assert_eq!(
+                app.classic_result_transform, before,
+                "running query mutated transform for command: {command}"
+            );
+            assert!(app
+                .last_status
+                .as_deref()
+                .is_some_and(|status| status.contains("Wait for the running query")));
+        }
+    }
+
+    #[tokio::test]
+    async fn classic_result_transform_command_literals_coerce_for_text_numeric_and_boolean_columns()
+    {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let (tx, rx) = mpsc::unbounded_channel();
+        let base = "SELECT '10'::text AS text_number, 'true'::text AS text_boolean, \
+                    10::integer AS amount, true::boolean AS enabled";
+        let headers = vec![
+            "text_number".to_string(),
+            "text_boolean".to_string(),
+            "amount".to_string(),
+            "enabled".to_string(),
+        ];
+        let mut app = App::new(
+            GridModel::new(
+                headers.clone(),
+                vec![vec![
+                    "10".to_string(),
+                    "true".to_string(),
+                    "10".to_string(),
+                    "true".to_string(),
+                ]],
+            ),
+            tokio::runtime::Handle::current(),
+            tx,
+            rx,
+            None,
+        );
+        app.db.kind = Some(DbKind::Postgres);
+        app.db.transaction_state = TransactionState::Idle;
+        app.classic_result_base_query = Some(base.to_string());
+        app.classic_result_base_headers = headers;
+        app.focus = Focus::Grid;
+
+        for command in [
+            "filter text_number eq 10",
+            "filter text_boolean eq true",
+            "filter amount >= 10",
+            "filter enabled eq true",
+        ] {
+            assert!(!app.execute_command(command));
+        }
+        let sql = app.classic_result_sql().unwrap();
+        assert!(sql.contains("\"__tsql_col_1\" IS NOT DISTINCT FROM E'10'"));
+        assert!(sql.contains("\"__tsql_col_2\" IS NOT DISTINCT FROM E'true'"));
+        assert!(sql.contains("\"__tsql_col_3\" >= E'10'"));
+        assert!(sql.contains("\"__tsql_col_4\" IS NOT DISTINCT FROM E'true'"));
+
+        let messages = client
+            .simple_query(&sql)
+            .await
+            .expect("compiled filters must execute");
+        let rows = messages
+            .iter()
+            .filter(|message| matches!(message, SimpleQueryMessage::Row(_)))
+            .count();
+        assert_eq!(
+            rows, 1,
+            "typed-looking text filters did not match source row"
+        );
+    }
+
+    #[test]
+    fn classic_result_transform_error_and_cancel_restore_applied_transform_and_old_grid() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+        let applied = ResultTransform {
+            filters: vec![ResultFilter {
+                ordinal: 0,
+                op: FilterOp::Gt,
+                value: FilterValue::Text("0".to_string()),
+            }],
+            ..ResultTransform::default()
+        };
+        let mut pending = applied.clone();
+        pending.set_order(1, OrderDirection::Desc, false);
+        let old_headers = app.grid.headers.clone();
+        let old_rows = app.grid.rows.clone();
+        app.classic_result_applied_transform = applied.clone();
+        app.classic_result_transform = pending.clone();
+        app.db.running = true;
+
+        app.apply_db_event(DbEvent::QueryError {
+            error: "invalid input syntax".to_string(),
+        });
+
+        assert_eq!(app.classic_result_transform, applied);
+        assert_eq!(app.classic_result_applied_transform, applied);
+        assert_eq!(app.grid.headers, old_headers);
+        assert_eq!(app.grid.rows, old_rows);
+        assert!(!app.db.running);
+
+        app.classic_result_transform = pending;
+        app.db.running = true;
+        app.apply_db_event(DbEvent::QueryCancelled {
+            context: None,
+            connection_generation: app.connect_generation,
+        });
+
+        assert_eq!(app.classic_result_transform, applied);
+        assert_eq!(app.classic_result_applied_transform, applied);
+        assert_eq!(app.grid.headers, old_headers);
+        assert_eq!(app.grid.rows, old_rows);
+        assert!(!app.db.running);
+        assert_eq!(app.last_status.as_deref(), Some("Query cancelled"));
+    }
+
+    #[test]
+    fn classic_result_transform_unsafe_sources_hide_actions_and_reject_commands_without_mutation() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        for source in [
+            "SELECT 1 AS id; SELECT 2 AS id",
+            "SELECT id FROM source_rows FOR UPDATE",
+            "UPDATE source_rows SET amount = 2 RETURNING id",
+            "WITH removed AS (DELETE FROM source_rows RETURNING id) SELECT id FROM removed",
+        ] {
+            let mut app = classic_result_transform_test_app(&runtime);
+            app.classic_result_base_query = Some(source.to_string());
+            let before = app.classic_result_transform.clone();
+
+            app.open_action_palette();
+            let picker = app.action_palette.as_mut().unwrap();
+            for action in [
+                "Sort current column ascending",
+                "Filter to current value",
+                "Add custom filter",
+                "Choose result columns",
+                "Group and count by current column",
+            ] {
+                picker.set_query(action.to_string());
+                assert_eq!(
+                    picker.filtered_count(),
+                    0,
+                    "unsafe source exposed action '{action}': {source}"
+                );
+            }
+            app.action_palette = None;
+
+            for command in [
+                "sort asc #1",
+                "filter #1 eq 1",
+                "columns #1",
+                "group-count #1",
+                "reset-result",
+            ] {
+                app.execute_command(command);
+                assert_eq!(
+                    app.classic_result_transform, before,
+                    "unsafe source mutated transform for '{command}': {source}"
+                );
+                assert!(app.last_status.as_deref().is_some_and(|status| {
+                    status.contains("one read-only, row-returning source query")
+                }));
+            }
+        }
+    }
+
+    #[test]
+    fn classic_result_transform_columns_all_clears_grouping() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+        app.classic_result_transform.set_group_count(Some(1));
+        app.classic_result_applied_transform = app.classic_result_transform.clone();
+
+        assert!(!app.execute_command("columns all"));
+
+        assert!(app.classic_result_transform.projection.is_empty());
+        assert_eq!(app.classic_result_transform.group_count, None);
+        let sql = app.classic_result_sql().unwrap();
+        assert_eq!(sql, "SELECT id, amount, note FROM source_rows LIMIT 1500;");
+    }
+
     fn notebook_test_output(rows: usize) -> NotebookOutput {
         NotebookOutput {
             grid: GridModel::new(
@@ -13815,7 +18313,1439 @@ mod tests {
             },
         );
         app.pg_snapshot_order.push_back(handle);
+        app.pg_snapshot_lru.push_back(handle);
         version
+    }
+
+    #[test]
+    fn bounded_notebook_preview_wraps_valid_reads_and_preserves_sql_boundaries() {
+        let query = "SELECT E'it\\'s @result_1; -- text' AS value -- trailing comment";
+        let bounded = bounded_notebook_preview_query(query, 5).unwrap();
+
+        assert!(bounded.contains(query));
+        assert!(bounded.ends_with("LIMIT 6"));
+        assert!(bounded.contains("\n) AS __tsql_notebook_preview"));
+        assert!(bounded_notebook_preview_query("UPDATE users SET active = true", 5).is_none());
+        assert!(bounded_notebook_preview_query("SELECT 1; SELECT 2", 5).is_none());
+
+        let indented = "\n  SELECT 1 AS value";
+        let bounded = bounded_notebook_preview_query(indented, 5).unwrap();
+        assert!(bounded.contains(indented), "{bounded}");
+    }
+
+    #[tokio::test]
+    async fn streamed_simple_query_retains_only_the_configured_prefix_and_headers() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+
+        let result = stream_simple_query(
+            &client,
+            "SELECT value FROM generate_series(1, 25000) value",
+            5,
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.headers, ["value"]);
+        assert_eq!(result.rows.len(), 5);
+        assert_eq!(result.rows[0], ["1"]);
+        assert!(result.truncated);
+
+        let empty = stream_simple_query(&client, "SELECT 1 AS value WHERE false", 5, usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(empty.headers, ["value"]);
+        assert!(empty.rows.is_empty());
+        assert!(!empty.truncated);
+
+        let explain = stream_simple_query(&client, "EXPLAIN SELECT 1", 5, usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(explain.headers, ["QUERY PLAN"]);
+        assert!(!explain.rows.is_empty());
+        assert_eq!(
+            explain.command_tag.as_deref(),
+            Some(format!("{} rows", explain.rows.len()).as_str())
+        );
+
+        let bounded = stream_simple_query(
+            &client,
+            "SELECT repeat('á', 128) AS value FROM generate_series(1, 2)",
+            5,
+            64,
+        )
+        .await
+        .unwrap();
+        assert_eq!(bounded.rows.len(), 1);
+        assert!(bounded.rows[0][0].ends_with('…'));
+        assert!(
+            bounded.headers.iter().map(String::len).sum::<usize>()
+                + bounded
+                    .rows
+                    .iter()
+                    .flatten()
+                    .map(String::len)
+                    .sum::<usize>()
+                <= 64
+        );
+        assert!(bounded.truncated);
+    }
+
+    #[tokio::test]
+    async fn classic_result_transform_paged_cursor_fetches_continuations_and_preserves_empty_headers(
+    ) {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let shared = Arc::new(Mutex::new(client));
+        let (app_tx, app_rx) = mpsc::unbounded_channel();
+        let app = App::new(
+            GridModel::empty(),
+            tokio::runtime::Handle::current(),
+            app_tx,
+            app_rx,
+            None,
+        );
+        let headers = vec!["id".to_string(), "amount".to_string()];
+        let mut transform = ResultTransform::default();
+        transform.add_filter(ResultFilter {
+            ordinal: 0,
+            op: FilterOp::Gt,
+            value: FilterValue::Integer(0),
+        });
+        transform.set_order(0, OrderDirection::Asc, false);
+        let query = compile_result_transform(
+            "SELECT n AS id, CASE WHEN n % 2 = 0 THEN 2 ELSE 10 END AS amount \
+             FROM generate_series(1, 1205) AS n",
+            &headers,
+            &transform,
+        )
+        .unwrap();
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        let (fetch_more_tx, fetch_more_rx) = mpsc::unbounded_channel();
+        app.execute_query_paged(
+            shared,
+            query,
+            1500,
+            500,
+            None,
+            events_tx,
+            fetch_more_rx,
+            10,
+            true,
+            false,
+        );
+
+        let event = tokio::time::timeout(Duration::from_secs(10), events_rx.recv())
+            .await
+            .expect("initial transformed page timed out")
+            .expect("initial transformed page channel closed");
+        let first_rows = match event {
+            DbEvent::QueryFinished { result } => {
+                assert_eq!(result.headers, headers);
+                assert_eq!(result.rows.len(), 500);
+                assert_eq!(result.null_cells.len(), 500);
+                assert_eq!(result.rows.first().unwrap(), &["1", "10"]);
+                assert_eq!(result.rows.last().unwrap(), &["500", "2"]);
+                result.rows.len()
+            }
+            DbEvent::QueryError { error } => panic!("initial transformed page failed: {error}"),
+            _ => panic!("unexpected initial transformed-page event"),
+        };
+        assert_eq!(first_rows, 500);
+
+        fetch_more_tx.send(()).unwrap();
+        let event = tokio::time::timeout(Duration::from_secs(10), events_rx.recv())
+            .await
+            .expect("second transformed page timed out")
+            .expect("second transformed page channel closed");
+        match event {
+            DbEvent::RowsAppended {
+                rows,
+                null_cells,
+                done,
+                truncated,
+            } => {
+                assert_eq!(rows.len(), 500);
+                assert_eq!(null_cells.len(), 500);
+                assert_eq!(rows.first().unwrap(), &["501", "10"]);
+                assert_eq!(rows.last().unwrap(), &["1000", "2"]);
+                assert!(!done);
+                assert!(!truncated);
+            }
+            DbEvent::QueryError { error } => panic!("second transformed page failed: {error}"),
+            _ => panic!("unexpected second transformed-page event"),
+        }
+
+        fetch_more_tx.send(()).unwrap();
+        let event = tokio::time::timeout(Duration::from_secs(10), events_rx.recv())
+            .await
+            .expect("final transformed page timed out")
+            .expect("final transformed page channel closed");
+        match event {
+            DbEvent::RowsAppended {
+                rows,
+                null_cells,
+                done,
+                truncated,
+            } => {
+                assert_eq!(rows.len(), 205);
+                assert_eq!(null_cells.len(), 205);
+                assert_eq!(rows.first().unwrap(), &["1001", "10"]);
+                assert_eq!(rows.last().unwrap(), &["1205", "10"]);
+                assert!(done);
+                assert!(!truncated);
+            }
+            DbEvent::QueryError { error } => panic!("final transformed page failed: {error}"),
+            _ => panic!("unexpected final transformed-page event"),
+        }
+
+        let (empty_client, empty_connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            let _ = empty_connection.await;
+        });
+        let empty_query = compile_result_transform(
+            "SELECT n AS id, n * 10 AS amount FROM generate_series(1, 10) AS n WHERE false",
+            &headers,
+            &transform,
+        )
+        .unwrap();
+        let (empty_events_tx, mut empty_events_rx) = mpsc::unbounded_channel();
+        let (_empty_fetch_more_tx, empty_fetch_more_rx) = mpsc::unbounded_channel();
+        app.execute_query_paged(
+            Arc::new(Mutex::new(empty_client)),
+            empty_query,
+            1500,
+            500,
+            None,
+            empty_events_tx,
+            empty_fetch_more_rx,
+            10,
+            true,
+            false,
+        );
+        let event = tokio::time::timeout(Duration::from_secs(10), empty_events_rx.recv())
+            .await
+            .expect("empty transformed page timed out")
+            .expect("empty transformed page channel closed");
+        match event {
+            DbEvent::QueryFinished { result } => {
+                assert_eq!(result.headers, headers);
+                assert!(
+                    result.rows.is_empty(),
+                    "empty result created a synthetic row"
+                );
+                assert!(result.null_cells.is_empty());
+                assert_eq!(result.command_tag.as_deref(), Some("0 rows"));
+                assert!(!result.truncated);
+            }
+            DbEvent::QueryError { error } => panic!("empty transformed page failed: {error}"),
+            _ => panic!("unexpected empty transformed-page event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn classic_result_transform_paged_cursor_enforces_configured_statement_timeout() {
+        assert_eq!(
+            cursor_fetch_query(500, 0, false),
+            "FETCH FORWARD 500 FROM tsql_cursor"
+        );
+        assert_eq!(
+            cursor_fetch_query(25, 1, false),
+            "BEGIN; SET LOCAL statement_timeout = 1000; FETCH FORWARD 25 FROM tsql_cursor; COMMIT"
+        );
+        assert!(cursor_fetch_query(1, u32::MAX, false).contains("statement_timeout = 4294967295"));
+        assert_eq!(
+            cursor_fetch_query(25, 1, true),
+            "BEGIN READ ONLY; SET LOCAL statement_timeout = 1000; FETCH FORWARD 25 FROM tsql_cursor; COMMIT"
+        );
+
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let (app_tx, app_rx) = mpsc::unbounded_channel();
+        let app = App::new(
+            GridModel::empty(),
+            tokio::runtime::Handle::current(),
+            app_tx,
+            app_rx,
+            None,
+        );
+        let headers = vec!["id".to_string(), "delay".to_string()];
+        let mut transform = ResultTransform::default();
+        transform.set_order(0, OrderDirection::Asc, false);
+        let query = compile_result_transform(
+            "SELECT n AS id, pg_sleep(2) AS delay FROM generate_series(1, 2) AS n",
+            &headers,
+            &transform,
+        )
+        .unwrap();
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        let (_fetch_more_tx, fetch_more_rx) = mpsc::unbounded_channel();
+        let started = Instant::now();
+        app.execute_query_paged(
+            Arc::new(Mutex::new(client)),
+            query,
+            1500,
+            500,
+            None,
+            events_tx,
+            fetch_more_rx,
+            1,
+            true,
+            false,
+        );
+
+        let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
+            .await
+            .expect("slow cursor query ignored statement timeout")
+            .expect("slow cursor query channel closed");
+        assert!(started.elapsed() < Duration::from_secs(4));
+        match event {
+            DbEvent::QueryError { error } => {
+                assert!(
+                    error.to_ascii_lowercase().contains("statement timeout"),
+                    "unexpected cursor timeout error: {error}"
+                );
+            }
+            DbEvent::QueryFinished { .. } => panic!("slow cursor query unexpectedly completed"),
+            _ => panic!("unexpected cursor-timeout event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn classic_result_transform_cursor_rejects_side_effecting_reads() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let sequence = format!("tsql_transform_read_only_{}", uuid::Uuid::new_v4().simple());
+        client
+            .batch_execute(&format!("CREATE SEQUENCE public.\"{sequence}\""))
+            .await
+            .unwrap();
+        let headers = vec!["id".to_string()];
+        let mut transform = ResultTransform::default();
+        transform.set_order(0, OrderDirection::Asc, false);
+        let query = compile_result_transform(
+            &format!("SELECT nextval('public.\"{sequence}\"') AS id"),
+            &headers,
+            &transform,
+        )
+        .unwrap();
+        let (app_tx, app_rx) = mpsc::unbounded_channel();
+        let app = App::new(
+            GridModel::empty(),
+            tokio::runtime::Handle::current(),
+            app_tx,
+            app_rx,
+            None,
+        );
+        let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+        let (_fetch_more_tx, fetch_more_rx) = mpsc::unbounded_channel();
+
+        let shared = Arc::new(Mutex::new(client));
+        app.execute_query_paged(
+            shared.clone(),
+            query,
+            500,
+            500,
+            None,
+            events_tx,
+            fetch_more_rx,
+            5,
+            true,
+            false,
+        );
+
+        let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
+            .await
+            .expect("read-only cursor did not finish")
+            .expect("read-only cursor channel closed");
+        shared
+            .lock()
+            .await
+            .batch_execute(&format!("DROP SEQUENCE public.\"{sequence}\""))
+            .await
+            .unwrap();
+        match event {
+            DbEvent::QueryError { error } => assert!(
+                error.to_ascii_lowercase().contains("read-only transaction"),
+                "unexpected read-only cursor error: {error}"
+            ),
+            DbEvent::QueryFinished { .. } => {
+                panic!("side-effecting transform unexpectedly completed")
+            }
+            _ => panic!("unexpected read-only cursor event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn classic_result_transform_refresh_after_failed_first_transform_uses_base_query() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let token = client.cancel_token();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut app = App::new(
+            GridModel::new(vec!["amount".to_string()], vec![vec!["1".to_string()]]),
+            tokio::runtime::Handle::current(),
+            tx,
+            rx,
+            None,
+        );
+        let base = "SELECT 1 AS amount";
+        app.connection_picker = None;
+        app.connection_manager = None;
+        app.db.kind = Some(DbKind::Postgres);
+        app.db.status = DbStatus::Connected;
+        app.db.transaction_state = TransactionState::Idle;
+        app.db.client = Some(Arc::new(Mutex::new(client)));
+        app.db.cancel_token = Some(token);
+        app.classic_result_base_query = Some(base.to_string());
+        app.classic_result_base_headers = vec!["amount".to_string()];
+        app.last_executed_query =
+            Some("SELECT amount FROM (SELECT 1 AS amount) r WHERE amount = 'not-a-number'".into());
+
+        app.apply_db_event(DbEvent::QueryError {
+            error: "invalid input syntax".into(),
+        });
+        app.refresh_last_query();
+
+        assert_eq!(app.last_executed_query.as_deref(), Some(base));
+    }
+
+    #[test]
+    fn notebook_multiple_result_sources_resolve_each_live_snapshot() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1 AS value".to_string());
+        let first = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 2 AS value".to_string());
+        let second = install_notebook_test_snapshot(&mut app, 1, 2, 2);
+
+        let resolved = app
+            .resolve_notebook_result_dependencies(
+                "SELECT a.value, b.value FROM @result_1 a JOIN @result_2 b ON true",
+                Some(first),
+                &[second],
+            )
+            .unwrap();
+
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].1, first);
+        assert_eq!(resolved[1].1, second);
+    }
+
+    #[test]
+    fn notebook_named_result_resolves_and_renders_stable_source_name() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1 AS value".to_string());
+        app.notebook.cells[0].result_name = Some("recent_users".to_string());
+        let source = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT value FROM @result_recent_users".to_string());
+
+        let resolved = app
+            .resolve_notebook_result_dependencies(
+                "SELECT value FROM @result_recent_users",
+                None,
+                &[],
+            )
+            .unwrap();
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].1, source);
+        assert_eq!(
+            resolved[0].0,
+            LogicalResultReference::Named("recent_users".to_string())
+        );
+        let text = buffer_text(&notebook_buffer(&mut app, 120, 30));
+        assert!(text.contains("@result_recent_users"), "{text}");
+    }
+
+    #[test]
+    fn notebook_name_outline_and_jump_commands_preserve_unique_names() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+
+        assert!(!app.execute_command("name Recent_Users"));
+        assert_eq!(
+            app.notebook.cells[0].result_name.as_deref(),
+            Some("recent_users")
+        );
+        assert!(app.notebook_document_dirty);
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 2".to_string());
+
+        assert!(!app.execute_command("name recent_users"));
+        assert!(app
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("already used by cell 1")));
+        app.last_error = None;
+        assert!(!app.execute_command("outline"));
+        assert!(app
+            .last_status
+            .as_deref()
+            .is_some_and(|status| status.contains("1:@result_recent_users, 2")));
+        assert!(!app.execute_command("cell @result_recent_users"));
+        assert_eq!(app.notebook.selected, CellId(1));
+        assert!(!app.execute_command("name clear"));
+        assert!(app.notebook.cells[0].result_name.is_none());
+    }
+
+    #[test]
+    fn notebook_source_collapse_renders_summary_and_expands_on_edit() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0]
+            .replace_source("SELECT id, name\nFROM users\nWHERE active = true".to_string());
+
+        assert!(!app.execute_command("collapse-source"));
+        assert!(app.notebook.cells[0].source_collapsed);
+        let text = buffer_text(&notebook_buffer(&mut app, 100, 20));
+        assert!(
+            text.contains("SELECT id, name FROM users WHERE active = true"),
+            "{text}"
+        );
+        assert!(text.contains("Source collapsed"), "{text}");
+
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(!app.notebook.cells[0].source_collapsed);
+        assert_eq!(app.notebook.focus, NotebookFocus::Editor);
+    }
+
+    #[test]
+    fn notebook_result_completion_lists_only_live_postgres_results() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.db.kind = Some(DbKind::Postgres);
+        app.notebook.cells[0].replace_source("SELECT 1 AS value".to_string());
+        app.notebook.cells[0].result_name = Some("recent_users".to_string());
+        install_notebook_test_snapshot(&mut app, 0, 7, 1);
+
+        let items = app.notebook_result_completion_items();
+        let labels = items
+            .iter()
+            .map(|item| item.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(labels, ["@result", "@result_1", "@result_recent_users"]);
+        assert!(items.iter().all(|item| item.kind == CompletionKind::Result));
+        assert_eq!(
+            items[0].detail.as_deref(),
+            Some("latest · cell 1 · run 7 · 1 row")
+        );
+        assert_eq!(items[1].detail.as_deref(), Some("cell 1 · run 7 · 1 row"));
+
+        app.pg_snapshots
+            .get_mut(&RetainedResultHandle(1))
+            .unwrap()
+            .connection_generation += 1;
+        assert!(app.notebook_result_completion_items().is_empty());
+    }
+
+    #[test]
+    fn notebook_result_completion_replaces_the_at_prefix_and_stays_postgres_only() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.db.kind = Some(DbKind::Postgres);
+        app.notebook.cells[0].replace_source("SELECT 1 AS value".to_string());
+        app.notebook.cells[0].result_name = Some("recent_users".to_string());
+        install_notebook_test_snapshot(&mut app, 0, 7, 1);
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT * FROM @result_rec".to_string());
+        app.notebook
+            .selected_cell_mut()
+            .editor
+            .textarea
+            .move_cursor(CursorMove::End);
+        app.notebook.focus = NotebookFocus::Editor;
+        app.mode = Mode::Insert;
+
+        app.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+
+        assert!(app.completion.active);
+        assert_eq!(app.completion.filtered_count(), 1);
+        assert_eq!(
+            app.completion
+                .selected_item()
+                .map(|item| item.label.as_str()),
+            Some("@result_recent_users")
+        );
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(
+            app.notebook.selected_cell().source(),
+            "SELECT * FROM @result_recent_users"
+        );
+        assert!(!app.completion.active);
+
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT * FROM @res".to_string());
+        app.notebook
+            .selected_cell_mut()
+            .editor
+            .textarea
+            .move_cursor(CursorMove::End);
+        app.mode = Mode::Insert;
+        app.db.kind = Some(DbKind::Mongo);
+        app.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert!(!app.completion.active);
+    }
+
+    #[test]
+    fn notebook_error_commands_expose_failed_cell_diagnostics() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.config.clipboard.backend = ClipboardBackend::Disabled;
+        app.notebook.cells[0].failure =
+            Some("syntax error [42601]\nPOSITION: 8\nHINT: check the query".to_string());
+
+        assert!(!app.execute_command("error"));
+        let error = app.last_error.as_deref().unwrap();
+        assert!(error.contains("Cell 1 error"), "{error}");
+        assert!(error.contains("[42601]"), "{error}");
+        assert!(error.contains("POSITION: 8"), "{error}");
+        assert!(error.contains("HINT: check the query"), "{error}");
+
+        app.on_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        assert_eq!(app.last_status.as_deref(), Some("Clipboard disabled"));
+        assert!(app.last_error.is_none());
+
+        assert!(!app.execute_command("copy-error"));
+        assert_eq!(app.last_status.as_deref(), Some("Clipboard disabled"));
+
+        app.notebook.cells[0].failure = None;
+        assert!(!app.execute_command("error"));
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Selected notebook cell has no error")
+        );
+    }
+
+    #[test]
+    fn notebook_explain_source_accepts_one_statement_and_rejects_ambiguous_input() {
+        assert_eq!(
+            notebook_explain_source("SELECT value FROM @result_1; -- source rows").unwrap(),
+            "EXPLAIN\nSELECT value FROM @result_1"
+        );
+        assert!(notebook_explain_source("SELECT 1; SELECT 2")
+            .unwrap_err()
+            .contains("one valid SQL statement"));
+        assert!(notebook_explain_source("EXPLAIN SELECT 1")
+            .unwrap_err()
+            .contains("already contains EXPLAIN"));
+        assert!(notebook_explain_source("   ")
+            .unwrap_err()
+            .contains("one valid SQL statement"));
+    }
+
+    #[test]
+    fn notebook_queued_rerun_rebases_only_sources_in_the_run_graph() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        let first_older = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let first_latest = install_notebook_test_snapshot(&mut app, 0, 2, 2);
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 2".to_string());
+        let second = install_notebook_test_snapshot(&mut app, 1, 3, 3);
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT * FROM @result_1 a JOIN @result_2 b ON true".to_string());
+        let child = app.notebook.selected;
+        app.notebook.selected_cell_mut().dependency = Some(first_older);
+        app.notebook.selected_cell_mut().additional_dependencies = vec![second];
+        app.notebook_run_rebind_sources.insert(CellId(1));
+
+        app.rebase_queued_notebook_cell(child);
+
+        let cell = app.notebook.selected_cell();
+        assert_eq!(cell.dependency, Some(first_latest));
+        assert_eq!(cell.additional_dependencies, [second]);
+    }
+
+    #[test]
+    fn notebook_page_event_appends_rows_and_completes_a_retained_result() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        let version = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let output = app.notebook.cells[0].output.as_mut().unwrap();
+        if let RefinementAvailability::Available(retained) = &mut output.refinement {
+            retained.rows = 3;
+        }
+        output.retained.as_mut().unwrap().rows = 3;
+        output.truncated = true;
+        app.notebook_page_loading = Some(NotebookPageLoad {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(1),
+            connection_generation: app.connect_generation,
+        });
+        app.notebook_page_to_end = true;
+
+        app.apply_db_event(DbEvent::NotebookRowsAppended {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(1),
+            connection_generation: app.connect_generation,
+            offset: 1,
+            rows: vec![vec!["2".to_string()], vec!["3".to_string()]],
+            null_cells: Vec::new(),
+            truncated_by_bytes: false,
+        });
+
+        let output = app.notebook.cells[0].output.as_ref().unwrap();
+        assert_eq!(output.grid.rows.len(), 3);
+        assert_eq!(output.grid_state.cursor_row, 2);
+        assert!(!output.truncated);
+        assert!(app.notebook_page_loading.is_none());
+        assert!(!app.notebook_page_to_end);
+    }
+
+    #[test]
+    fn notebook_page_events_are_scoped_and_invalidation_cancels_pending_load() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        let version = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let output = app.notebook.cells[0].output.as_mut().unwrap();
+        if let RefinementAvailability::Available(retained) = &mut output.refinement {
+            retained.rows = 2;
+        }
+        output.retained.as_mut().unwrap().rows = 2;
+        output.truncated = true;
+        app.notebook_page_loading = Some(NotebookPageLoad {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(1),
+            connection_generation: app.connect_generation,
+        });
+        app.notebook_page_to_end = true;
+        let cancelled = Arc::new(AtomicBool::new(false));
+        app.notebook_page_cancelled = Some(cancelled.clone());
+
+        app.apply_db_event(DbEvent::NotebookRowsAppended {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(99),
+            connection_generation: app.connect_generation,
+            offset: 1,
+            rows: vec![vec!["stale".to_string()]],
+            null_cells: Vec::new(),
+            truncated_by_bytes: false,
+        });
+        assert_eq!(
+            app.notebook.cells[0]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid
+                .rows
+                .len(),
+            1
+        );
+        assert!(app.notebook_page_loading.is_some());
+
+        app.notebook_page_loading = Some(NotebookPageLoad {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(1),
+            connection_generation: app.connect_generation,
+        });
+        app.notebook_page_to_end = true;
+        app.notebook_page_cancelled = Some(cancelled.clone());
+        app.invalidate_pg_snapshots(false);
+
+        assert!(app.notebook_page_loading.is_none());
+        assert!(!app.notebook_page_to_end);
+        assert!(cancelled.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn notebook_page_byte_limit_keeps_result_marked_incomplete() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        let version = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let output = app.notebook.cells[0].output.as_mut().unwrap();
+        if let RefinementAvailability::Available(retained) = &mut output.refinement {
+            retained.rows = 2;
+        }
+        output.retained.as_mut().unwrap().rows = 2;
+        output.truncated = true;
+        app.notebook_page_loading = Some(NotebookPageLoad {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(1),
+            connection_generation: app.connect_generation,
+        });
+        app.notebook_page_to_end = true;
+
+        app.apply_db_event(DbEvent::NotebookRowsAppended {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(1),
+            connection_generation: app.connect_generation,
+            offset: 1,
+            rows: vec![vec!["partial…".to_string()]],
+            null_cells: Vec::new(),
+            truncated_by_bytes: true,
+        });
+
+        assert!(app.notebook.cells[0].output.as_ref().unwrap().truncated);
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Loaded 2 of 2 retained rows; notebook display byte limit reached")
+        );
+        assert!(!app.notebook_page_to_end);
+    }
+
+    #[test]
+    fn notebook_search_refuses_incomplete_results_and_export_requires_live_snapshot() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        let _version = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let output = app.notebook.cells[0].output.as_mut().unwrap();
+        if let RefinementAvailability::Available(retained) = &mut output.refinement {
+            retained.rows = 20;
+        }
+        output.retained.as_mut().unwrap().rows = 20;
+        output.truncated = true;
+
+        app.handle_grid_search("needle".to_string());
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Grid search covers only 1 of 20 retained rows; focus the result and press G to load more")
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("partial.csv");
+        app.handle_export_command(&format!("csv {}", path.display()));
+        assert!(app
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("Not connected; cannot export snapshot")));
+        assert!(!path.exists());
+
+        app.last_error = None;
+        app.notebook.cells[0]
+            .output
+            .as_mut()
+            .unwrap()
+            .grid_state
+            .selected_rows
+            .insert(0);
+        app.handle_export_command(&format!("csv {}", path.display()));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "value\n1");
+        assert!(app
+            .last_status
+            .as_deref()
+            .is_some_and(|status| status.contains("Exported 1 selected row")));
+    }
+
+    #[test]
+    fn notebook_action_palette_opens_filters_switches_workspace_and_esc_closes() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        app.notebook.focus = NotebookFocus::Cell;
+
+        app.on_key(KeyEvent::new(
+            KeyCode::Char('P'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        ));
+        assert!(app.action_palette.is_some());
+        app.on_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(app.action_palette.is_none());
+        assert!(app.confirm_prompt.is_none());
+
+        assert!(!app.execute_command("actions"));
+        let picker = app.action_palette.as_mut().unwrap();
+        picker.set_query("classic".to_string());
+        assert_eq!(picker.filtered_count(), 1);
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(app.action_palette.is_none());
+        assert_eq!(app.workspace_mode, WorkspaceMode::Classic);
+    }
+
+    #[test]
+    fn notebook_bracketed_paste_keeps_complete_multiline_sql_and_marks_source_dirty() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.focus = NotebookFocus::Editor;
+        app.mode = Mode::Insert;
+        let query = "SELECT * FROM @result_source\r\nWHERE value > 1";
+
+        app.on_paste(query);
+
+        assert_eq!(
+            app.notebook.selected_cell().source(),
+            "SELECT * FROM @result_source\nWHERE value > 1"
+        );
+        assert!(app.notebook_document_dirty);
+        assert_eq!(app.notebook.selected_cell().revision, 1);
+    }
+
+    #[test]
+    fn classic_and_command_bracketed_paste_preserve_text_without_key_loss() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut app = App::new(GridModel::empty(), runtime.handle().clone(), tx, rx, None);
+
+        app.on_paste("SELECT 1\nUNION ALL SELECT 2");
+        assert_eq!(app.editor.text(), "SELECT 1\nUNION ALL SELECT 2");
+
+        app.command.open();
+        app.on_paste("export csv\r\n/tmp/result.csv");
+        assert_eq!(app.command.text(), "export csv /tmp/result.csv");
+    }
+
+    #[test]
+    fn action_palette_bracketed_paste_filters_instead_of_editing_the_query() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        app.open_action_palette();
+
+        app.on_paste("classic");
+
+        assert_eq!(app.notebook.cells[0].source(), "SELECT 1");
+        assert_eq!(app.action_palette.as_ref().unwrap().query(), "classic");
+        assert_eq!(app.action_palette.as_ref().unwrap().filtered_count(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn notebook_snippet_commands_save_load_and_delete_named_queries() {
+        let _guard = ConfigDirGuard::new();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 42 AS answer".to_string());
+
+        app.execute_command("snippet-save answer");
+        assert_eq!(app.history.snippets().len(), 1);
+        assert_eq!(app.history.snippets()[0].name, "answer");
+        assert_eq!(app.last_status.as_deref(), Some("Saved snippet 'answer'"));
+
+        app.notebook.cells[0].replace_source("SELECT 0".to_string());
+        app.execute_command("snippets");
+        assert!(app.snippet_picker.is_some());
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.notebook.cells[0].source(), "SELECT 42 AS answer");
+        assert_eq!(app.notebook.focus, NotebookFocus::Editor);
+
+        app.execute_command("snippet delete answer");
+        assert!(app.history.snippets().is_empty());
+        assert_eq!(app.last_status.as_deref(), Some("Deleted snippet 'answer'"));
+    }
+
+    #[test]
+    fn notebook_cell_history_picker_restores_a_previous_execution_source() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 2 AS value".to_string());
+        app.notebook.cells[0].push_run(
+            NotebookRunRecord::new(
+                7,
+                0,
+                "SELECT 1 AS value".to_string(),
+                NotebookRunStatus::Succeeded,
+            )
+            .with_output(
+                Duration::from_millis(12),
+                1,
+                &["value".to_string()],
+                &[vec!["1".to_string()]],
+                false,
+            ),
+        );
+
+        app.execute_command("cell-history");
+        assert!(app.cell_history_picker.is_some());
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.notebook.cells[0].source(), "SELECT 1 AS value");
+        assert_eq!(app.notebook.focus, NotebookFocus::Editor);
+        assert!(app
+            .last_status
+            .as_deref()
+            .is_some_and(|status| status.contains("Restored cell source from run 7")));
+    }
+
+    #[test]
+    fn notebook_error_jump_uses_unicode_position_and_expands_source() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        let source = "SELECT 'é'\n  FROM missing_table";
+        app.notebook.cells[0].replace_source(source.to_string());
+        app.notebook.cells[0].source_collapsed = true;
+        let position = source[..source.find("missing_table").unwrap()]
+            .chars()
+            .count()
+            + 1;
+        app.notebook.cells[0].failure = Some(format!(
+            "relation does not exist [42P01]\nPOSITION: {position} (line 2, column 8)"
+        ));
+
+        app.execute_command("error-jump");
+
+        assert_eq!(app.notebook.cells[0].editor.textarea.cursor(), (1, 7));
+        assert!(!app.notebook.cells[0].source_collapsed);
+        assert_eq!(app.notebook.focus, NotebookFocus::Editor);
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Error at line 2, column 8")
+        );
+    }
+
+    #[test]
+    fn notebook_offscreen_activity_is_notified_and_jumpable() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook = NotebookState::from_sources_with_ids(
+            vec![
+                (Some(CellId(1)), "SELECT 1".to_string(), false, None),
+                (Some(CellId(2)), "SELECT 2".to_string(), false, None),
+            ],
+            0,
+        );
+        app.render_notebook_cells = vec![NotebookCellRenderArea {
+            cell_id: CellId(1),
+            composer: Rect::new(0, 0, 80, 4),
+            output_toggle: None,
+            output: None,
+            grid: None,
+            compact: false,
+        }];
+
+        app.note_notebook_activity(CellId(1), false);
+        assert!(app.notebook_activity.is_empty());
+        app.note_notebook_activity(CellId(2), true);
+        assert_eq!(app.notebook_activity.len(), 1);
+        assert!(app
+            .last_status
+            .as_deref()
+            .is_some_and(|status| status.contains("Cell 2 failed off-screen")));
+        let area = Rect::new(0, 0, 160, 1);
+        let mut buffer = ratatui::buffer::Buffer::empty(area);
+        ratatui::widgets::Widget::render(app.status_line(area.width), area, &mut buffer);
+        assert!(buffer_text(&buffer).contains("1 cell update (1 failed)"));
+
+        app.execute_command("activity");
+        assert_eq!(app.notebook.selected, CellId(2));
+        assert!(app.notebook_activity.is_empty());
+        assert_eq!(app.last_status.as_deref(), Some("Focused cell 2 (failed)"));
+    }
+
+    #[test]
+    fn notebook_generate_insert_uses_selected_result_and_creates_a_new_cell() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].output = Some(NotebookOutput {
+            grid: GridModel::new(
+                vec!["id".to_string(), "name".to_string()],
+                vec![vec!["1".to_string(), "Ada".to_string()]],
+            )
+            .with_source_table(Some("users".to_string())),
+            grid_state: GridState::default(),
+            command_tag: None,
+            elapsed: Duration::ZERO,
+            error: None,
+            refinement: RefinementAvailability::Unavailable(
+                RefinementUnavailableReason::ResultIncomplete,
+            ),
+            retained: None,
+            executed_revision: 0,
+            truncated: false,
+        });
+
+        app.handle_gen_command("insert");
+
+        assert_eq!(app.notebook.focus, NotebookFocus::Editor);
+        assert_eq!(app.notebook.selected_cell().id, CellId(2));
+        assert!(app
+            .notebook
+            .selected_cell()
+            .source()
+            .contains("INSERT INTO users (id, name)"));
+    }
+
+    #[test]
+    fn notebook_palette_generation_without_source_table_prompts_for_destination() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].output = Some(notebook_test_output(1));
+
+        app.run_palette_action(PaletteAction::GenerateInsert);
+
+        assert!(app.command.active);
+        assert_eq!(app.command.text(), "gen insert ");
+        assert!(app.last_error.is_none());
+    }
+
+    #[test]
+    fn notebook_export_events_are_scoped_and_cancellation_clears_pending_export() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.db.kind = Some(DbKind::Postgres);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        let version = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let loading = NotebookPageLoad {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(1),
+            connection_generation: app.connect_generation,
+        };
+        app.notebook_export_loading = Some(loading);
+
+        app.apply_db_event(DbEvent::NotebookExportFinished {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(99),
+            connection_generation: app.connect_generation,
+            rows: 20,
+            path: "stale.csv".into(),
+            format: "CSV".to_string(),
+        });
+        assert!(app.notebook_export_loading.is_some());
+
+        app.apply_db_event(DbEvent::NotebookExportFinished {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(1),
+            connection_generation: app.connect_generation,
+            rows: 20,
+            path: "complete.csv".into(),
+            format: "CSV".to_string(),
+        });
+        assert!(app.notebook_export_loading.is_none());
+        assert!(app
+            .last_status
+            .as_deref()
+            .is_some_and(|status| status.contains("Exported 20 retained rows")));
+
+        let cancelled = Arc::new(AtomicBool::new(false));
+        app.notebook_export_loading = Some(loading);
+        app.notebook_export_cancelled = Some(cancelled.clone());
+        app.on_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(app.notebook_export_loading.is_none());
+        assert!(cancelled.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn notebook_page_cancel_without_token_clears_pending_load() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.db.kind = Some(DbKind::Postgres);
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        let version = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        app.notebook_page_loading = Some(NotebookPageLoad {
+            cell_id: CellId(1),
+            version,
+            handle: RetainedResultHandle(1),
+            connection_generation: app.connect_generation,
+        });
+        app.notebook_page_to_end = true;
+        let cancelled = Arc::new(AtomicBool::new(false));
+        app.notebook_page_cancelled = Some(cancelled.clone());
+
+        app.on_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+
+        assert!(app.notebook_page_loading.is_none());
+        assert!(!app.notebook_page_to_end);
+        assert!(cancelled.load(Ordering::Acquire));
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("No cancel token available")
+        );
+    }
+
+    #[test]
+    fn mongo_document_collection_honors_row_and_byte_budgets() {
+        let mut docs = Vec::new();
+        let mut bytes = 0;
+        let small = doc! { "value": "small" };
+        let small_bytes = bson::to_vec(&small).unwrap().len();
+        assert!(push_bounded_mongo_document(
+            &mut docs,
+            small,
+            &mut bytes,
+            2,
+            small_bytes
+        ));
+        assert!(!push_bounded_mongo_document(
+            &mut docs,
+            doc! { "value": "second" },
+            &mut bytes,
+            2,
+            small_bytes
+        ));
+        assert_eq!(docs.len(), 1);
+        assert_eq!(bytes, small_bytes);
+    }
+
+    #[test]
+    fn notebook_display_budget_compacts_only_reloadable_older_results() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.config.notebook.snapshot_total_bytes = 60;
+        app.config.notebook.output_preview_rows = 1;
+        app.notebook.cells[0].replace_source("SELECT old_value".to_string());
+        let _older = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        app.notebook.cells[0].output.as_mut().unwrap().grid.rows = vec![
+            vec!["old-row-one-xxxxxxxx".to_string()],
+            vec!["old-row-two-xxxxxxxx".to_string()],
+        ];
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT newest_value".to_string());
+        let _newest = install_notebook_test_snapshot(&mut app, 1, 2, 2);
+        app.notebook.cells[1].output.as_mut().unwrap().grid.rows = vec![
+            vec!["new-row-one-xxxxxxxx".to_string()],
+            vec!["new-row-two-xxxxxxxx".to_string()],
+        ];
+
+        app.enforce_notebook_display_budget(CellId(2));
+
+        assert_eq!(
+            app.notebook.cells[0]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid
+                .rows
+                .len(),
+            1
+        );
+        assert!(app.notebook.cells[0].output_collapsed);
+        assert!(app.notebook.cells[0].output.as_ref().unwrap().truncated);
+        assert_eq!(
+            app.notebook.cells[1]
+                .output
+                .as_ref()
+                .unwrap()
+                .grid
+                .rows
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn stale_classic_execution_event_cannot_overwrite_current_notebook_state() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.grid = GridModel::new(vec!["current".to_string()], vec![vec!["keep".to_string()]]);
+        app.db.running = true;
+        let stale = ExecutionContext {
+            id: ExecutionId(2),
+            target: ExecutionTarget::Classic,
+            source_revision: 0,
+            connection_generation: app.connect_generation,
+        };
+        app.active_classic_execution = Some(ExecutionContext {
+            id: ExecutionId(3),
+            ..stale
+        });
+
+        app.apply_db_event(DbEvent::ClassicExecution {
+            context: stale,
+            event: Box::new(DbEvent::QueryFinished {
+                result: QueryResult {
+                    null_cells: Vec::new(),
+                    headers: vec!["stale".to_string()],
+                    rows: vec![vec!["replace".to_string()]],
+                    command_tag: Some("SELECT 1".to_string()),
+                    truncated: false,
+                    elapsed: Duration::ZERO,
+                    source_table: None,
+                    primary_keys: Vec::new(),
+                    col_types: Vec::new(),
+                },
+            }),
+        });
+
+        assert!(app.db.running);
+        assert_eq!(app.grid.headers, ["current"]);
+        assert_eq!(app.grid.rows, [["keep"]]);
+    }
+
+    #[test]
+    fn notebook_document_commands_round_trip_without_restoring_runtime_output() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("investigation.json");
+        app.notebook.cells[0].replace_source("SELECT 123 AS saved_value".to_string());
+        app.notebook.cells[0].output = Some(notebook_test_output(1));
+
+        assert!(!app.execute_command(&format!("save-notebook {}", path.display())));
+        app.notebook.cells[0].replace_source("SELECT 999 AS changed".to_string());
+        assert!(!app.execute_command(&format!("open-notebook {}", path.display())));
+
+        assert_eq!(app.notebook.cells[0].source(), "SELECT 999 AS changed");
+        let context = app.confirm_prompt.take().unwrap().context().clone();
+        assert!(matches!(
+            &context,
+            ConfirmContext::OpenNotebook { path: pending } if pending == &path
+        ));
+        assert!(!app.handle_confirm_confirmed(context));
+
+        assert_eq!(app.notebook.cells[0].source(), "SELECT 123 AS saved_value");
+        assert!(app.notebook.cells[0].output.is_none());
+        assert!(!app.notebook.cells[0].editor.is_modified());
+        assert_eq!(app.notebook_document_path.as_deref(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn cancelling_notebook_open_keeps_unsaved_source() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("other.json");
+        save_notebook_to_path(
+            &NotebookSession {
+                cells: vec![NotebookCellSession {
+                    cell_id: Some(1),
+                    source: "SELECT 'other'".to_string(),
+                    ..NotebookCellSession::default()
+                }],
+                selected_index: 0,
+            },
+            &path,
+        )
+        .unwrap();
+        app.notebook.cells[0].replace_source("SELECT 'keep me'".to_string());
+
+        assert!(!app.execute_command(&format!("open-notebook {}", path.display())));
+        let context = app.confirm_prompt.take().unwrap().context().clone();
+        app.handle_confirm_cancelled(context);
+
+        assert_eq!(app.notebook.cells[0].source(), "SELECT 'keep me'");
+        assert_eq!(app.last_status.as_deref(), Some("Notebook open cancelled"));
     }
 
     fn notebook_buffer(app: &mut App, width: u16, height: u16) -> ratatui::buffer::Buffer {
@@ -13924,6 +19854,223 @@ mod tests {
         let text = buffer_text(&buffer);
         assert!(text.contains("SCHEMA"));
         assert!(text.contains("Esc notebook"));
+    }
+
+    #[test]
+    fn notebook_hiding_either_sidebar_section_restores_notebook_focus() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        for section in [SidebarSection::Connections, SidebarSection::Schema] {
+            let mut app = notebook_test_app(&runtime);
+            app.sidebar_visible = true;
+            app.focus = Focus::Sidebar(section);
+            app.sidebar_focus = section;
+            app.notebook.focus = NotebookFocus::Result;
+
+            app.toggle_sidebar();
+
+            assert!(!app.sidebar_visible);
+            assert_eq!(app.focus, Focus::Notebook);
+            assert_eq!(app.notebook.focus, NotebookFocus::Result);
+        }
+    }
+
+    #[test]
+    fn notebook_mode_command_repairs_invisible_classic_focus() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.focus = Focus::Grid;
+
+        app.switch_workspace(WorkspaceMode::Notebook);
+
+        assert_eq!(app.focus, Focus::Notebook);
+    }
+
+    #[test]
+    fn restored_notebook_without_edits_is_not_unsaved() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook = NotebookState::from_sources_with_ids(
+            vec![(Some(CellId(4)), "SELECT 1".to_string(), false, None)],
+            0,
+        );
+
+        assert!(!app.workspace_has_unsaved_changes());
+
+        app.notebook.cells[0].replace_source("SELECT 2".to_string());
+        assert!(app.workspace_has_unsaved_changes());
+    }
+
+    #[test]
+    fn notebook_execution_does_not_mark_edited_source_saved() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook = NotebookState::from_sources_with_ids(
+            vec![(Some(CellId(1)), "SELECT 1".to_string(), false, None)],
+            0,
+        );
+        app.notebook.cells[0].replace_source("SELECT 2".to_string());
+        let context = ExecutionContext {
+            id: ExecutionId(3),
+            target: ExecutionTarget::Notebook(CellId(1)),
+            source_revision: app.notebook.cells[0].revision,
+            connection_generation: app.connect_generation,
+        };
+        app.active_execution = Some(ActiveExecution {
+            context,
+            kind: QueryExecutionKind::New,
+            cancelling: false,
+        });
+        app.active_notebook_sql = Some("SELECT 2".to_string());
+        app.db.running = true;
+
+        app.apply_db_event(DbEvent::NotebookQueryFinished {
+            context,
+            result: QueryResult {
+                null_cells: Vec::new(),
+                headers: vec!["value".to_string()],
+                rows: vec![vec!["2".to_string()]],
+                command_tag: Some("SELECT 1".to_string()),
+                truncated: false,
+                elapsed: Duration::ZERO,
+                source_table: None,
+                primary_keys: Vec::new(),
+                col_types: Vec::new(),
+            },
+            retained: None,
+            snapshot: None,
+        });
+
+        assert!(app.notebook.cells[0].editor.is_modified());
+        assert!(!app.notebook.cells[0].is_dirty());
+        assert!(app.workspace_has_unsaved_changes());
+        let history = &app.notebook.cells[0].execution_history;
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].execution_id, 3);
+        assert_eq!(history[0].status, NotebookRunStatus::Succeeded);
+        assert_eq!(history[0].row_count, 1);
+        assert_eq!(history[0].rows, vec![vec!["2".to_string()]]);
+    }
+
+    #[test]
+    fn notebook_cell_escape_does_not_cancel_running_execution_or_prompt_to_quit() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.db.running = true;
+        app.notebook.focus = NotebookFocus::Cell;
+
+        app.on_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert!(app.db.running);
+        assert!(app.confirm_prompt.is_none());
+    }
+
+    #[test]
+    fn notebook_custom_editor_result_binding_targets_selected_output() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.focus = NotebookFocus::Editor;
+        app.notebook.cells[0].output = Some(notebook_test_output(1));
+        app.notebook.cells[0].output_collapsed = true;
+        let key = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL);
+        app.editor_normal_keymap.bind(
+            KeyBinding::new(key.code, key.modifiers),
+            Action::GotoResults,
+        );
+
+        app.on_key(key);
+
+        assert_eq!(app.focus, Focus::Notebook);
+        assert_eq!(app.notebook.focus, NotebookFocus::Result);
+        assert!(!app.notebook.cells[0].output_collapsed);
+    }
+
+    #[test]
+    fn notebook_maximize_keeps_result_visible_and_restores_editor_focus() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.focus = NotebookFocus::Editor;
+        app.notebook.cells[0].output = Some(notebook_test_output(1));
+        app.sidebar_visible = true;
+
+        app.toggle_results_maximized();
+
+        assert!(app.maximized_results_restore.is_some());
+        assert_eq!(app.focus, Focus::Notebook);
+        assert_eq!(app.notebook.focus, NotebookFocus::Result);
+        assert!(!app.sidebar_visible);
+
+        app.toggle_results_maximized();
+
+        assert!(app.maximized_results_restore.is_none());
+        assert_eq!(app.focus, Focus::Notebook);
+        assert_eq!(app.notebook.focus, NotebookFocus::Editor);
+        assert!(app.sidebar_visible);
+    }
+
+    #[test]
+    fn notebook_maximize_without_output_keeps_cell_focus() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.focus = NotebookFocus::Editor;
+
+        app.toggle_results_maximized();
+
+        assert_eq!(app.focus, Focus::Notebook);
+        assert_eq!(app.notebook.focus, NotebookFocus::Cell);
+    }
+
+    #[test]
+    fn classic_status_identifies_a_running_notebook_cell() {
+        use ratatui::widgets::Widget;
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.switch_workspace(WorkspaceMode::Classic);
+        app.db.running = true;
+        app.active_execution = Some(ActiveExecution {
+            context: ExecutionContext {
+                id: ExecutionId(2),
+                target: ExecutionTarget::Notebook(CellId(7)),
+                source_revision: 1,
+                connection_generation: 0,
+            },
+            kind: QueryExecutionKind::New,
+            cancelling: false,
+        });
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buffer = ratatui::buffer::Buffer::empty(area);
+
+        app.status_line(area.width).render(area, &mut buffer);
+
+        assert!(buffer_text(&buffer).contains("cell 7 running"));
     }
 
     #[test]
@@ -14057,6 +20204,190 @@ mod tests {
         app.handle_mouse_click(toggle.x, toggle.y);
         assert!(!app.notebook.cells[0].output_collapsed);
         assert_eq!(app.notebook.focus, NotebookFocus::Cell);
+    }
+
+    #[test]
+    fn notebook_ascii_fallback_uses_simple_disclosure_and_rail_glyphs() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook_ascii = true;
+        app.notebook.cells[0].replace_source("SELECT value".to_string());
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].output = Some(notebook_test_output(5));
+
+        let buffer = notebook_buffer(&mut app, 60, 20);
+        let rendered = app.render_notebook_cells[0];
+        let toggle = rendered.output_toggle.unwrap();
+        assert_eq!(buffer.cell((toggle.x, toggle.y)).unwrap().symbol(), "v");
+        assert_eq!(
+            buffer
+                .cell((rendered.composer.x, rendered.composer.y))
+                .unwrap()
+                .symbol(),
+            "|"
+        );
+
+        app.handle_mouse_click(toggle.x, toggle.y);
+        let buffer = notebook_buffer(&mut app, 60, 20);
+        let toggle = app.render_notebook_cells[0].output_toggle.unwrap();
+        assert_eq!(buffer.cell((toggle.x, toggle.y)).unwrap().symbol(), ">");
+    }
+
+    #[test]
+    fn notebook_evicted_pinned_dependency_renders_source_unavailable() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1 AS value".to_string());
+        let evicted = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let _latest = install_notebook_test_snapshot(&mut app, 0, 2, 2);
+        app.evicted_versions.insert(evicted);
+        app.notebook.ensure_trailing_draft();
+        let child = app.notebook.insert_refinement(evicted);
+        app.notebook.selected = child;
+
+        let text = buffer_text(&notebook_buffer(&mut app, 110, 30));
+
+        assert!(text.contains("SOURCE UNAVAILABLE"));
+    }
+
+    #[test]
+    fn notebook_composer_renders_syntax_logical_reference_and_visual_selection() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT * FROM @result_recent_users".to_string());
+        app.notebook.focus = NotebookFocus::Editor;
+        app.mode = Mode::Visual;
+        let editor = &mut app.notebook.cells[0].editor.textarea;
+        editor.move_cursor(CursorMove::Jump(0, 0));
+        editor.start_selection();
+        editor.move_cursor(CursorMove::Jump(0, 5));
+
+        let buffer = notebook_buffer(&mut app, 90, 16);
+        let composer = app.render_notebook_cells[0].composer;
+        let source_y = composer.y + 1;
+        let row = buffer_text(&buffer);
+        let logical_x = row
+            .lines()
+            .nth(source_y as usize)
+            .and_then(|line| line.find("@result_recent_users"))
+            .expect("logical reference should be visible") as u16;
+
+        assert_eq!(
+            buffer.cell((logical_x, source_y)).unwrap().fg,
+            app.ui_theme.accent
+        );
+        assert_eq!(
+            buffer.cell((composer.x + 3, source_y)).unwrap().bg,
+            app.ui_theme.editor_selection.bg.unwrap()
+        );
+    }
+
+    #[test]
+    fn notebook_composer_and_errors_expose_clipping_at_narrow_widths() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.config.notebook.composer_max_rows = 2;
+        app.notebook.cells[0].replace_source(
+            "SELECT this_is_a_very_long_column_name_that_will_clip\nFROM example\nWHERE value = 1\nORDER BY value"
+                .to_string(),
+        );
+        app.notebook.cells[0].failure = Some(
+            "syntax error near a very long expression with useful detail after wrapping"
+                .to_string(),
+        );
+        app.notebook.cells[0].execution = CellExecutionState::Failed;
+
+        let text = buffer_text(&notebook_buffer(&mut app, 42, 18));
+
+        assert!(text.contains("↓2"));
+        assert!(text.contains('›'));
+        assert!(text.contains("ERROR · syntax error"));
+        assert!(text.contains("expression"), "{text}");
+    }
+
+    #[test]
+    fn notebook_cell_focus_does_not_horizontally_scroll_source_for_hidden_editor_cursor() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook_ascii = true;
+        app.notebook.cells[0]
+            .replace_source("SELECT value FROM generate_series(1, 250000) value".to_string());
+        app.notebook.cells[0]
+            .editor
+            .textarea
+            .move_cursor(CursorMove::End);
+        app.notebook.cells[0].execution = CellExecutionState::Succeeded;
+        app.notebook.cells[0].output = Some(notebook_test_output(5));
+        app.notebook.focus = NotebookFocus::Cell;
+
+        let text = buffer_text(&notebook_buffer(&mut app, 60, 20));
+
+        assert!(
+            text.contains("|  SELECT value FROM generate_series"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn notebook_compact_source_summary_is_bounded() {
+        let lines = vec!["x".repeat(300), "never reached".to_string()];
+
+        let summary = notebook_source_summary(&lines);
+
+        assert_eq!(summary.chars().count(), 161);
+        assert!(summary.ends_with('…'));
+        assert!(!summary.contains("never reached"));
+    }
+
+    #[test]
+    fn notebook_hundred_long_cells_keep_focused_result_render_window_bounded() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        let payload = "x".repeat(4096);
+        for index in 1..=100 {
+            app.notebook
+                .selected_cell_mut()
+                .replace_source(format!("SELECT {index} AS value, '{payload}' AS payload"));
+            app.notebook.select_or_create_draft();
+        }
+        app.notebook.selected = app.notebook.cells[49].id;
+        app.notebook.focus = NotebookFocus::Result;
+        app.notebook.cells[49].execution = CellExecutionState::Succeeded;
+        let mut output = notebook_test_output(40);
+        output.executed_revision = app.notebook.cells[49].revision;
+        app.notebook.cells[49].output = Some(output);
+
+        let text = buffer_text(&notebook_buffer(&mut app, 140, 42));
+
+        assert!(
+            text.contains("CELL 50 · SQL · SUCCEEDED · RESULT"),
+            "{text}"
+        );
+        assert!(
+            app.render_notebook_cells.len() <= 7,
+            "rendered {} cells",
+            app.render_notebook_cells.len()
+        );
+        assert!(text.contains("CELL 47"), "{text}");
+        assert!(text.contains("CELL 53"), "{text}");
     }
 
     #[test]
@@ -14659,7 +20990,7 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let app = notebook_test_app(&runtime);
+        let mut app = notebook_test_app(&runtime);
 
         assert_eq!(
             app.resolve_notebook_result_dependency("SELECT * FROM @result", None)
@@ -14670,6 +21001,365 @@ mod tests {
             app.resolve_notebook_result_dependency("SELECT * FROM @result_1", None)
                 .unwrap_err(),
             "Result for cell 1 is unavailable. Run cell 1 first"
+        );
+    }
+
+    #[test]
+    fn notebook_numbered_reference_rejects_an_evicted_immutable_binding() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        let older = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let _latest = install_notebook_test_snapshot(&mut app, 0, 2, 2);
+        app.retained_versions.remove(&older);
+        app.pg_snapshots.remove(&RetainedResultHandle(1));
+        app.pg_snapshot_order
+            .retain(|handle| *handle != RetainedResultHandle(1));
+        app.pg_snapshot_lru
+            .retain(|handle| *handle != RetainedResultHandle(1));
+        app.evicted_versions.insert(older);
+
+        assert_eq!(
+            app.resolve_notebook_result_dependency("SELECT * FROM @result_1", Some(older))
+                .unwrap_err(),
+            "Result for cell 1 was evicted. Use :rebase or rerun the source cell"
+        );
+    }
+
+    #[test]
+    fn notebook_dependency_is_detached_when_source_no_longer_mentions_a_result() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        let dependency = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(1),
+            source_revision: 1,
+        };
+
+        assert!(app
+            .resolve_notebook_result_dependency("SELECT 42 AS standalone", Some(dependency))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn notebook_snapshot_lru_access_preserves_recently_used_result() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.config.notebook.max_retained_snapshots = 2;
+        app.config.notebook.snapshot_total_bytes = u64::MAX;
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        let first = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let second = install_notebook_test_snapshot(&mut app, 0, 2, 2);
+        assert!(app.notebook_snapshot_for_version(first).is_some());
+
+        let third = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(3),
+            source_revision: app.notebook.cells[0].revision,
+        };
+        let retained = super::super::refinement::RetainedResult {
+            provider: super::super::refinement::RefinementProviderId::PostgresTemp,
+            handle: RetainedResultHandle(3),
+            version: third,
+            rows: 1,
+            retained_bytes: 16,
+            connection_generation: app.connect_generation,
+        };
+        let survived = app.register_pg_snapshot(
+            &retained,
+            PgTempSnapshot {
+                physical_name: "snapshot_3".to_string(),
+                public_columns: vec!["value".to_string()],
+                relation_oid: 3,
+                connection_generation: app.connect_generation,
+                backend_pid: 1,
+                row_count: 1,
+                byte_size: 16,
+            },
+        );
+
+        assert!(survived);
+        assert!(app.retained_versions.contains_key(&first));
+        assert!(!app.retained_versions.contains_key(&second));
+        assert!(app.evicted_versions.contains(&second));
+        assert!(app.retained_versions.contains_key(&third));
+        assert_eq!(app.latest_notebook_result_version(None), Some(third));
+    }
+
+    #[test]
+    fn notebook_zero_snapshot_limit_does_not_publish_an_available_result() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.config.notebook.max_retained_snapshots = 0;
+        let version = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(1),
+            source_revision: 1,
+        };
+        let retained = super::super::refinement::RetainedResult {
+            provider: super::super::refinement::RefinementProviderId::PostgresTemp,
+            handle: RetainedResultHandle(1),
+            version,
+            rows: 1,
+            retained_bytes: 16,
+            connection_generation: app.connect_generation,
+        };
+
+        assert!(!app.register_pg_snapshot(
+            &retained,
+            PgTempSnapshot {
+                physical_name: "snapshot_1".to_string(),
+                public_columns: vec!["value".to_string()],
+                relation_oid: 1,
+                connection_generation: app.connect_generation,
+                backend_pid: 1,
+                row_count: 1,
+                byte_size: 16,
+            },
+        ));
+        assert!(app.pg_snapshots.is_empty());
+        assert!(app.retained_versions.is_empty());
+        assert!(app.pg_snapshot_order.is_empty());
+        assert!(app.pg_snapshot_lru.is_empty());
+        assert!(app.evicted_versions.contains(&version));
+    }
+
+    #[test]
+    fn notebook_delete_prompt_uses_stable_cell_id_and_counts_textual_dependents() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 0".to_string());
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 1".to_string());
+        let source = app.notebook.selected;
+        app.notebook.ensure_trailing_draft();
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source(format!("SELECT * FROM @result_{}", source.0));
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source(format!("SELECT * FROM @result_{}", source.0));
+        app.notebook.remove_cell(CellId(1));
+        app.notebook.selected = source;
+
+        app.request_delete_notebook_cell();
+
+        assert!(matches!(
+            app.confirm_prompt.as_ref().map(ConfirmPrompt::context),
+            Some(ConfirmContext::DeleteNotebookCell { cell_id }) if *cell_id == source.0
+        ));
+        let mut terminal = Terminal::new(ratatui::backend::TestBackend::new(100, 20)).unwrap();
+        terminal
+            .draw(|frame| {
+                app.confirm_prompt
+                    .as_mut()
+                    .unwrap()
+                    .render(frame, frame.area(), &app.ui_theme)
+            })
+            .unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(
+            text.contains(&format!(
+                "Delete cell {}? 2 dependent cell(s) will lose their source snapshot.",
+                source.0
+            )),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn notebook_delete_removes_every_retained_version_for_a_rerun_source() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        let older = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+        let latest = install_notebook_test_snapshot(&mut app, 0, 2, 2);
+        app.notebook.select_or_create_draft();
+        app.notebook
+            .selected_cell_mut()
+            .replace_source("SELECT 99".to_string());
+        let unrelated = install_notebook_test_snapshot(&mut app, 1, 3, 3);
+
+        app.delete_notebook_cell(CellId(1));
+
+        for version in [older, latest] {
+            assert!(!app.retained_versions.contains_key(&version));
+            assert!(app.evicted_versions.contains(&version));
+        }
+        for handle in [RetainedResultHandle(1), RetainedResultHandle(2)] {
+            assert!(!app.pg_snapshots.contains_key(&handle));
+            assert!(!app.pg_snapshot_order.contains(&handle));
+            assert!(!app.pg_snapshot_lru.contains(&handle));
+        }
+        assert!(app.retained_versions.contains_key(&unrelated));
+        assert!(app.pg_snapshots.contains_key(&RetainedResultHandle(3)));
+    }
+
+    #[test]
+    fn notebook_edited_completion_discards_snapshot_and_reduces_submitted_transaction() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.db.kind = Some(DbKind::Postgres);
+        app.db.transaction_state = TransactionState::Idle;
+        app.notebook.cells[0].replace_source("BEGIN".to_string());
+        let context = ExecutionContext {
+            id: ExecutionId(1),
+            target: ExecutionTarget::Notebook(CellId(1)),
+            source_revision: app.notebook.cells[0].revision,
+            connection_generation: app.connect_generation,
+        };
+        app.active_execution = Some(ActiveExecution {
+            context,
+            kind: QueryExecutionKind::New,
+            cancelling: false,
+        });
+        app.active_notebook_sql = Some("BEGIN".to_string());
+        app.db.running = true;
+        app.notebook.cells[0].mark_edited();
+        let version = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(1),
+            source_revision: context.source_revision,
+        };
+        let retained = super::super::refinement::RetainedResult {
+            provider: super::super::refinement::RefinementProviderId::PostgresTemp,
+            handle: RetainedResultHandle(1),
+            version,
+            rows: 1,
+            retained_bytes: 16,
+            connection_generation: app.connect_generation,
+        };
+
+        app.apply_db_event(DbEvent::NotebookQueryFinished {
+            context,
+            result: QueryResult {
+                null_cells: Vec::new(),
+                headers: vec!["value".to_string()],
+                rows: vec![vec!["1".to_string()]],
+                command_tag: Some("SELECT 1".to_string()),
+                truncated: false,
+                elapsed: Duration::ZERO,
+                source_table: None,
+                primary_keys: Vec::new(),
+                col_types: vec!["int4".to_string()],
+            },
+            retained: Some(retained),
+            snapshot: Some(PgTempSnapshot {
+                physical_name: "snapshot_1".to_string(),
+                public_columns: vec!["value".to_string()],
+                relation_oid: 1,
+                connection_generation: app.connect_generation,
+                backend_pid: 1,
+                row_count: 1,
+                byte_size: 16,
+            }),
+        });
+
+        assert_eq!(app.db.transaction_state, TransactionState::Active);
+        assert!(app.active_notebook_sql.is_none());
+        assert!(app.pg_snapshots.is_empty());
+        assert!(app.retained_versions.is_empty());
+        assert!(app.notebook.cells[0].output.is_none());
+        assert_eq!(
+            app.notebook.cells[0].execution,
+            CellExecutionState::NeverRun
+        );
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Cell 1 finished, but its source changed; output was ignored")
+        );
+    }
+
+    #[test]
+    fn notebook_edited_error_reduces_submitted_transaction_even_when_revision_changes() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.db.kind = Some(DbKind::Postgres);
+        app.db.transaction_state = TransactionState::Active;
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        let context = ExecutionContext {
+            id: ExecutionId(1),
+            target: ExecutionTarget::Notebook(CellId(1)),
+            source_revision: app.notebook.cells[0].revision,
+            connection_generation: app.connect_generation,
+        };
+        app.active_execution = Some(ActiveExecution {
+            context,
+            kind: QueryExecutionKind::New,
+            cancelling: false,
+        });
+        app.active_notebook_sql = Some("SELECT 1".to_string());
+        app.db.running = true;
+        app.notebook.cells[0].mark_edited();
+
+        app.apply_db_event(DbEvent::NotebookQueryError {
+            context,
+            error: "query failed".to_string(),
+        });
+
+        assert_eq!(app.db.transaction_state, TransactionState::Failed);
+        assert!(app.active_notebook_sql.is_none());
+        assert!(!app.db.running);
+    }
+
+    #[test]
+    fn notebook_output_summary_uses_live_availability_and_exact_retained_row_count() {
+        let version = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(1),
+            source_revision: 1,
+        };
+        let retained = super::super::refinement::RetainedResult {
+            provider: super::super::refinement::RefinementProviderId::PostgresTemp,
+            handle: RetainedResultHandle(1),
+            version,
+            rows: 20,
+            retained_bytes: 16,
+            connection_generation: 0,
+        };
+        let mut output = notebook_test_output(5);
+        output.truncated = true;
+        output.retained = Some(retained.clone());
+        output.refinement = RefinementAvailability::Available(retained);
+
+        assert_eq!(
+            notebook_output_summary(&output, false, false),
+            "SESSION SNAPSHOT · COMPLETE · 5 fetched · 20 total · 4ms"
+        );
+        output.refinement =
+            RefinementAvailability::Unavailable(RefinementUnavailableReason::SnapshotEvicted);
+        assert_eq!(
+            notebook_output_summary(&output, false, false),
+            "PREVIEW · NO SNAPSHOT · 5 fetched · at least 6 total · 4ms"
         );
     }
 
@@ -14852,6 +21542,29 @@ mod tests {
         assert!(!text.contains("CLASSIC SELECT 1"));
         assert!(!text.contains("9000ms"));
         assert!(!text.contains("1 sel"));
+    }
+
+    #[test]
+    fn notebook_status_marks_non_snapshot_preview_row_count_as_a_lower_bound() {
+        use ratatui::widgets::Widget;
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook_ascii = true;
+        let mut output = notebook_test_output(5);
+        output.command_tag = Some("6 rows".to_string());
+        output.truncated = true;
+        app.notebook.cells[0].output = Some(output);
+        let area = Rect::new(0, 0, 180, 1);
+        let mut buffer = ratatui::buffer::Buffer::empty(area);
+
+        app.status_line(area.width).render(area, &mut buffer);
+        let text = buffer_text(&buffer);
+
+        assert!(text.contains(">=6 rows (4ms)"), "{text}");
     }
 
     #[test]
@@ -15885,6 +22598,7 @@ mod tests {
 
         // Simulate a query finishing with results
         let result = QueryResult {
+            null_cells: Vec::new(),
             headers: vec!["id".to_string(), "name".to_string()],
             rows: vec![vec!["1".to_string(), "Alice".to_string()]],
             command_tag: Some("SELECT 1".to_string()),
@@ -16696,6 +23410,7 @@ mod tests {
 
         app.apply_db_event(DbEvent::QueryFinished {
             result: QueryResult {
+                null_cells: Vec::new(),
                 headers: vec!["value".to_string()],
                 rows: vec![vec!["1".to_string()]],
                 command_tag: Some("SELECT 1".to_string()),

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -4594,7 +4594,7 @@ impl App {
                 self.grid_state.selected_rows.clear();
             } else {
                 // Nothing open - behave like 'q' and show quit confirmation
-                if self.workspace_has_unsaved_changes() {
+                if self.app_has_unsaved_changes() {
                     self.confirm_prompt = Some(ConfirmPrompt::new(
                         "You have unsaved changes. Quit anyway?",
                         ConfirmContext::QuitApp,
@@ -4839,7 +4839,7 @@ impl App {
                 }
                 (KeyCode::Char('q'), KeyModifiers::NONE) => {
                     // Always show confirmation prompt, with different message based on unsaved changes
-                    if self.workspace_has_unsaved_changes() {
+                    if self.app_has_unsaved_changes() {
                         self.confirm_prompt = Some(ConfirmPrompt::new(
                             "You have unsaved changes. Quit anyway?",
                             ConfirmContext::QuitApp,
@@ -10949,6 +10949,10 @@ impl App {
             WorkspaceMode::Classic => self.editor.is_modified(),
             WorkspaceMode::Notebook => self.notebook_has_unsaved_changes(),
         }
+    }
+
+    fn app_has_unsaved_changes(&self) -> bool {
+        self.editor.is_modified() || self.notebook_has_unsaved_changes()
     }
 
     fn notebook_has_unsaved_changes(&self) -> bool {
@@ -20126,6 +20130,35 @@ mod tests {
         }
     }
 
+    #[test]
+    fn quitting_from_classic_warns_about_hidden_unsaved_notebook_changes() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        for document_dirty in [false, true] {
+            for key in [KeyCode::Char('q'), KeyCode::Esc] {
+                let mut app = notebook_test_app(&runtime);
+                if document_dirty {
+                    app.notebook_document_dirty = true;
+                } else {
+                    app.notebook.cells[0].replace_source("SELECT 'keep me'".to_string());
+                }
+                app.switch_workspace(WorkspaceMode::Classic);
+
+                assert!(!app.workspace_has_unsaved_changes());
+                assert!(app.notebook_has_unsaved_changes());
+                assert!(app.app_has_unsaved_changes());
+                assert!(!app.on_key(KeyEvent::new(key, KeyModifiers::NONE)));
+                assert!(matches!(
+                    app.confirm_prompt.as_ref().map(ConfirmPrompt::context),
+                    Some(ConfirmContext::QuitApp)
+                ));
+            }
+        }
+    }
+
     fn notebook_buffer(app: &mut App, width: u16, height: u16) -> ratatui::buffer::Buffer {
         let mut terminal =
             Terminal::new(ratatui::backend::TestBackend::new(width, height)).unwrap();
@@ -20310,6 +20343,15 @@ mod tests {
         assert!(app.notebook.cells[0].output_is_stale());
         assert!(!app.notebook_has_unsaved_changes());
         assert!(!app.workspace_has_unsaved_changes());
+        app.switch_workspace(WorkspaceMode::Classic);
+        for key in [KeyCode::Char('q'), KeyCode::Esc] {
+            assert!(!app.on_key(KeyEvent::new(key, KeyModifiers::NONE)));
+            assert!(matches!(
+                app.confirm_prompt.as_ref().map(ConfirmPrompt::context),
+                Some(ConfirmContext::QuitAppClean)
+            ));
+            app.confirm_prompt = None;
+        }
         assert!(!app.execute_command(&format!("open-notebook {}", path.display())));
         assert!(app.confirm_prompt.is_none());
     }

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -8271,7 +8271,10 @@ impl App {
                 })
         });
         let retained = retained.flatten();
-        if grid.rows.is_empty() && retained.as_ref().is_none_or(|retained| retained.rows == 0) {
+        if grid.headers.is_empty()
+            && grid.rows.is_empty()
+            && retained.as_ref().is_none_or(|retained| retained.rows == 0)
+        {
             self.last_error = Some("No data to export".to_string());
             return;
         }
@@ -16077,7 +16080,7 @@ impl App {
                 (
                     cell.output
                         .as_ref()
-                        .is_some_and(|output| !output.grid.rows.is_empty()),
+                        .is_some_and(|output| !output.grid.headers.is_empty()),
                     cell.output.as_ref().is_some_and(|output| {
                         matches!(output.refinement, RefinementAvailability::Available(_))
                     }),
@@ -16121,6 +16124,15 @@ impl App {
             notebook,
             has_query: self.query_editor_has_content(),
             has_result,
+            has_rows: if notebook {
+                self.notebook
+                    .selected_cell()
+                    .output
+                    .as_ref()
+                    .is_some_and(|output| !output.grid.rows.is_empty())
+            } else {
+                !self.grid.rows.is_empty()
+            },
             has_refinable_result,
             has_selection,
             has_error,
@@ -19537,6 +19549,145 @@ mod tests {
             .last_status
             .as_deref()
             .is_some_and(|status| status.contains("Exported 1 selected row")));
+    }
+
+    #[test]
+    fn notebook_zero_row_results_export_all_formats() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        for retained in [false, true] {
+            let mut app = notebook_test_app(&runtime);
+            if retained {
+                let version = install_notebook_test_snapshot(&mut app, 0, 1, 1);
+                let handle = app.retained_versions[&version];
+                let output = app.notebook.cells[0].output.as_mut().unwrap();
+                output.grid.rows.clear();
+                if let RefinementAvailability::Available(result) = &mut output.refinement {
+                    result.rows = 0;
+                }
+                output.retained.as_mut().unwrap().rows = 0;
+                app.pg_snapshots.get_mut(&handle).unwrap().row_count = 0;
+            } else {
+                app.notebook.cells[0].output = Some(notebook_test_output(0));
+            }
+
+            for (format, expected) in [
+                ("csv", "value"),
+                ("tsv", "value"),
+                ("json", "[\n\n]"),
+                ("sql", ""),
+            ] {
+                let path = dir.path().join(format!("{retained}.{format}"));
+                app.last_error = None;
+
+                app.handle_export_command(&format!("{format} {}", path.display()));
+
+                assert_eq!(std::fs::read_to_string(&path).unwrap(), expected);
+                assert!(app.last_error.is_none());
+                assert!(app
+                    .last_status
+                    .as_deref()
+                    .is_some_and(|status| status.contains("Exported 0 rows")));
+            }
+        }
+    }
+
+    #[test]
+    fn notebook_zero_row_export_still_rejects_missing_or_incomplete_results() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        let dir = tempfile::tempdir().unwrap();
+        let missing_path = dir.path().join("missing.csv");
+
+        app.handle_export_command(&format!("csv {}", missing_path.display()));
+
+        assert_eq!(app.last_error.as_deref(), Some("No data to export"));
+        assert!(!missing_path.exists());
+
+        let mut output = notebook_test_output(0);
+        output.truncated = true;
+        output.refinement =
+            RefinementAvailability::Unavailable(RefinementUnavailableReason::SnapshotDisabled);
+        app.notebook.cells[0].output = Some(output);
+        app.last_error = None;
+        let incomplete_path = dir.path().join("incomplete.csv");
+
+        app.handle_export_command(&format!("csv {}", incomplete_path.display()));
+
+        assert!(app
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("truncated") && error.contains("snapshot")));
+        assert!(!incomplete_path.exists());
+    }
+
+    #[test]
+    fn notebook_zero_row_palette_keeps_result_actions_available() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.notebook.cells[0].output = Some(notebook_test_output(0));
+
+        app.open_action_palette();
+
+        let picker = app.action_palette.as_mut().unwrap();
+        for action in [
+            "Export CSV",
+            "Export JSON",
+            "Export TSV",
+            "Export SQL inserts",
+            "Expand or collapse result",
+            "Explain cell query",
+        ] {
+            picker.set_query(action.to_string());
+            assert!(
+                picker.filtered_count() > 0,
+                "missing zero-row action: {action}"
+            );
+        }
+        picker.set_query("Refine result in new cell".to_string());
+        assert_eq!(picker.filtered_count(), 0);
+        for action in [
+            "Generate INSERT template",
+            "Generate UPDATE template",
+            "Generate DELETE template",
+        ] {
+            picker.set_query(action.to_string());
+            assert_eq!(
+                picker.filtered_count(),
+                0,
+                "unexpected zero-row action: {action}"
+            );
+        }
+
+        app.action_palette = None;
+        app.notebook.cells[0].output = None;
+        app.open_action_palette();
+        let picker = app.action_palette.as_mut().unwrap();
+        for action in [
+            "Export CSV",
+            "Export JSON",
+            "Export TSV",
+            "Export SQL inserts",
+            "Expand or collapse result",
+            "Explain cell query",
+        ] {
+            picker.set_query(action.to_string());
+            assert_eq!(
+                picker.filtered_count(),
+                0,
+                "unexpected no-output action: {action}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -14319,6 +14319,17 @@ impl App {
             }
             DbEvent::QueryFinished { result } => {
                 let query_kind = self.active_query_kind.take();
+                if query_kind.is_none() {
+                    self.last_executed_query = None;
+                    self.classic_result_base_query = None;
+                    self.classic_result_base_headers.clear();
+                    self.classic_result_transform.reset();
+                    self.classic_result_applied_transform.reset();
+                    self.result_columns_picker = None;
+                    self.result_columns_draft.clear();
+                    self.paged_query = None;
+                    self.active_classic_execution = None;
+                }
                 // Always clear running state after first page loads - the "Executing..."
                 // dialog should only show during initial query, not while waiting for
                 // on-demand scroll fetches. Subsequent page fetches show status line only.
@@ -14337,7 +14348,7 @@ impl App {
                     }
                 }
 
-                if self.classic_result_transform.is_empty() {
+                if query_kind.is_some() && self.classic_result_transform.is_empty() {
                     self.classic_result_base_headers = result.headers.clone();
                 }
                 self.classic_result_applied_transform = self.classic_result_transform.clone();
@@ -14558,6 +14569,31 @@ impl App {
                 let ExecutionTarget::Notebook(cell_id) = context.target else {
                     return;
                 };
+                let destination_matches = self
+                    .notebook
+                    .cells
+                    .iter()
+                    .any(|cell| cell.id == cell_id && cell.revision == context.source_revision);
+                if !destination_matches {
+                    if let Some(cell) = self.notebook.cell_mut(cell_id) {
+                        cell.execution = CellExecutionState::NeverRun;
+                    }
+                    self.last_status = Some(format!(
+                        "Cell {} {}, but its source changed; error was ignored",
+                        cell_id.0,
+                        if was_cancelled {
+                            "was cancelled"
+                        } else {
+                            "failed"
+                        }
+                    ));
+                    if self.notebook_run_total > 0 {
+                        self.notebook_run_queue.clear();
+                        self.notebook_run_total = 0;
+                        self.notebook_run_rebind_sources.clear();
+                    }
+                    return;
+                }
                 if let Some(cell) = self.notebook.cell_mut(cell_id) {
                     let history = NotebookRunRecord::new(
                         context.id.0,
@@ -18038,6 +18074,88 @@ mod tests {
     }
 
     #[test]
+    fn classic_result_transform_direct_result_clears_previous_source_and_paging() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = classic_result_transform_test_app(&runtime);
+        app.classic_result_transform.add_filter(ResultFilter {
+            ordinal: 1,
+            op: FilterOp::Gt,
+            value: FilterValue::Integer(0),
+        });
+        app.classic_result_transform
+            .set_order(0, OrderDirection::Desc, false);
+        app.classic_result_applied_transform = app.classic_result_transform.clone();
+        app.last_executed_query = Some("SELECT transformed_result".to_string());
+        app.paged_query = Some(PagedQueryState::new(
+            "SELECT transformed_result".to_string(),
+            1500,
+            DEFAULT_PAGE_SIZE,
+            Some("source_rows".to_string()),
+        ));
+        app.active_classic_execution = Some(ExecutionContext {
+            id: ExecutionId(8),
+            target: ExecutionTarget::Classic,
+            source_revision: 0,
+            connection_generation: app.connect_generation,
+        });
+        app.open_result_columns_picker();
+        assert!(app.result_columns_picker.is_some());
+
+        app.apply_db_event(DbEvent::QueryFinished {
+            result: QueryResult {
+                null_cells: Vec::new(),
+                headers: vec!["schema".to_string(), "table".to_string()],
+                rows: vec![vec!["public".to_string(), "users".to_string()]],
+                command_tag: None,
+                truncated: false,
+                elapsed: Duration::ZERO,
+                source_table: None,
+                primary_keys: Vec::new(),
+                col_types: Vec::new(),
+            },
+        });
+
+        assert_eq!(app.grid.headers, ["schema", "table"]);
+        assert_eq!(app.grid.rows, [["public", "users"]]);
+        assert!(app.last_executed_query.is_none());
+        assert!(app.classic_result_base_query.is_none());
+        assert!(app.classic_result_base_headers.is_empty());
+        assert!(app.classic_result_transform.is_empty());
+        assert!(app.classic_result_applied_transform.is_empty());
+        assert!(app.result_columns_picker.is_none());
+        assert!(app.result_columns_draft.is_empty());
+        assert!(app.paged_query.is_none());
+        assert!(app.active_classic_execution.is_none());
+        assert_eq!(app.last_status.as_deref(), Some("Ready"));
+
+        app.open_action_palette();
+        let picker = app.action_palette.as_mut().unwrap();
+        for action in [
+            "Clear result filters",
+            "Clear result sorting",
+            "Reset result transformations",
+            "Copy transformed SQL",
+            "Open transformed SQL in editor",
+        ] {
+            picker.set_query(action.to_string());
+            assert_eq!(
+                picker.filtered_count(),
+                0,
+                "unexpected meta action: {action}"
+            );
+        }
+        app.action_palette = None;
+        app.refresh_last_query();
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("No previous query to refresh")
+        );
+    }
+
+    #[test]
     fn classic_result_transform_rejects_mutations_while_query_is_running() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -21372,7 +21490,8 @@ mod tests {
         });
         app.active_notebook_sql = Some("SELECT 1".to_string());
         app.db.running = true;
-        app.notebook.cells[0].mark_edited();
+        app.notebook.cells[0].execution = CellExecutionState::Running(context);
+        app.notebook.cells[0].replace_source("SELECT changed".to_string());
 
         app.apply_db_event(DbEvent::NotebookQueryError {
             context,
@@ -21382,6 +21501,70 @@ mod tests {
         assert_eq!(app.db.transaction_state, TransactionState::Failed);
         assert!(app.active_notebook_sql.is_none());
         assert!(!app.db.running);
+        assert_eq!(app.notebook.cells[0].source(), "SELECT changed");
+        assert_eq!(
+            app.notebook.cells[0].execution,
+            CellExecutionState::NeverRun
+        );
+        assert!(app.notebook.cells[0].failure.is_none());
+        assert!(app.notebook.cells[0].execution_history.is_empty());
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Cell 1 failed, but its source changed; error was ignored")
+        );
+    }
+
+    #[test]
+    fn notebook_edited_cancel_does_not_overwrite_source_or_leave_a_run_queued() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let mut app = notebook_test_app(&runtime);
+        app.db.kind = Some(DbKind::Postgres);
+        app.db.transaction_state = TransactionState::Active;
+        app.notebook.cells[0].replace_source("SELECT 1".to_string());
+        let context = ExecutionContext {
+            id: ExecutionId(1),
+            target: ExecutionTarget::Notebook(CellId(1)),
+            source_revision: app.notebook.cells[0].revision,
+            connection_generation: app.connect_generation,
+        };
+        app.active_execution = Some(ActiveExecution {
+            context,
+            kind: QueryExecutionKind::New,
+            cancelling: true,
+        });
+        app.active_notebook_sql = Some("SELECT 1".to_string());
+        app.db.running = true;
+        app.notebook.cells[0].execution = CellExecutionState::Running(context);
+        app.notebook.cells[0].replace_source("SELECT changed".to_string());
+        app.notebook_run_queue.push_back(CellId(2));
+        app.notebook_run_total = 2;
+        app.notebook_run_rebind_sources.insert(CellId(1));
+
+        app.apply_db_event(DbEvent::NotebookQueryError {
+            context,
+            error: "cancelled".to_string(),
+        });
+
+        assert_eq!(app.db.transaction_state, TransactionState::Failed);
+        assert!(app.active_notebook_sql.is_none());
+        assert!(!app.db.running);
+        assert_eq!(app.notebook.cells[0].source(), "SELECT changed");
+        assert_eq!(
+            app.notebook.cells[0].execution,
+            CellExecutionState::NeverRun
+        );
+        assert!(app.notebook.cells[0].failure.is_none());
+        assert!(app.notebook.cells[0].execution_history.is_empty());
+        assert!(app.notebook_run_queue.is_empty());
+        assert_eq!(app.notebook_run_total, 0);
+        assert!(app.notebook_run_rebind_sources.is_empty());
+        assert_eq!(
+            app.last_status.as_deref(),
+            Some("Cell 1 was cancelled, but its source changed; error was ignored")
+        );
     }
 
     #[test]

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -8282,7 +8282,8 @@ impl App {
             return;
         }
 
-        let format_name = parts[0].to_lowercase();
+        let format_token = parts[0];
+        let format_name = format_token.to_ascii_lowercase();
         let path = parts.get(1).map(|s| s.trim()).unwrap_or("");
 
         if path.is_empty() {
@@ -8300,7 +8301,10 @@ impl App {
             "tsv" => NotebookExportFormat::Tsv,
             "sql" => NotebookExportFormat::Sql { table: sql_table },
             token if token.starts_with("sql:") => {
-                let table = token.trim_start_matches("sql:").trim();
+                let table = format_token
+                    .split_once(':')
+                    .map_or("", |(_, table)| table)
+                    .trim();
                 if table.is_empty() {
                     self.last_error = Some("SQL export table name cannot be empty".to_string());
                     return;
@@ -19422,6 +19426,48 @@ mod tests {
         assert!(selected[0]["actual_null"].is_null());
         assert_eq!(selected[0]["literal_null"], "NULL");
         assert_eq!(selected[0]["empty"], "");
+    }
+
+    #[test]
+    fn sql_export_preserves_explicit_table_case_in_classic_and_notebook_workspaces() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        for notebook in [false, true] {
+            let mut app = if notebook {
+                let mut app = notebook_test_app(&runtime);
+                app.notebook.cells[0].output = Some(notebook_test_output(1));
+                app
+            } else {
+                classic_result_transform_test_app(&runtime)
+            };
+            let path = dir.path().join(if notebook {
+                "notebook.sql"
+            } else {
+                "classic.sql"
+            });
+
+            app.handle_export_command(&format!("SqL:MySchema.MyTable {}", path.display()));
+
+            let exported = std::fs::read_to_string(&path).unwrap();
+            assert!(!exported.is_empty());
+            assert!(exported
+                .lines()
+                .all(|line| line.starts_with("INSERT INTO \"MySchema\".\"MyTable\" ")));
+        }
+
+        let mut app = classic_result_transform_test_app(&runtime);
+        let invalid_path = dir.path().join("invalid.sql");
+        app.handle_export_command(&format!("SQL: {}", invalid_path.display()));
+
+        assert_eq!(
+            app.last_error.as_deref(),
+            Some("SQL export table name cannot be empty")
+        );
+        assert!(!invalid_path.exists());
     }
 
     #[test]

--- a/crates/tsql/src/app/app.rs
+++ b/crates/tsql/src/app/app.rs
@@ -19,9 +19,7 @@ use ratatui::layout::Alignment;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{
-    Block, BorderType, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-};
+use ratatui::widgets::{Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState};
 use ratatui::Terminal;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
@@ -45,16 +43,16 @@ use crate::history::{History, HistoryEntry};
 use crate::session::SessionState;
 use crate::ui::{
     create_sql_highlighter, determine_context, escape_sql_value, get_word_before_cursor, is_inside,
-    load_theme, quote_identifier, zone_block, zone_inner, zone_label, zone_scrollbar_area,
-    AiQueryModal, AiQueryModalAction, ColumnInfo, CommandPrompt, CompletionKind, CompletionPopup,
-    ConfirmContext, ConfirmPrompt, ConfirmResult, ConnectionFormAction, ConnectionFormModal,
-    ConnectionInfo, ConnectionManagerAction, ConnectionManagerModal, CursorShape, DataGrid,
-    FuzzyPicker, GridKeyResult, GridModel, GridState, HelpAction, HelpPopup, HighlightedTextArea,
-    JsonEditorAction, JsonEditorModal, KeyHintPopup, KeySequenceAction, KeySequenceCompletion,
-    KeySequenceHandlerWithContext, KeySequenceResult, PasswordPrompt, PasswordPromptResult,
-    PendingKey, PickerAction, Priority, QueryEditor, ResizeAction, RowDetailAction, RowDetailModal,
-    SchemaCache, SearchPrompt, Sidebar, SidebarAction, StatusLineBuilder, StatusSegment, TableInfo,
-    UiTheme, YankFormat,
+    load_theme, overlay_block, quote_identifier, zone_block, zone_inner, zone_label,
+    zone_scrollbar_area, AiQueryModal, AiQueryModalAction, ColumnInfo, CommandPrompt,
+    CompletionKind, CompletionPopup, ConfirmContext, ConfirmPrompt, ConfirmResult,
+    ConnectionFormAction, ConnectionFormModal, ConnectionInfo, ConnectionManagerAction,
+    ConnectionManagerModal, CursorShape, DataGrid, FuzzyPicker, GridKeyResult, GridModel,
+    GridState, HelpAction, HelpPopup, HighlightedTextArea, JsonEditorAction, JsonEditorModal,
+    KeyHintPopup, KeySequenceAction, KeySequenceCompletion, KeySequenceHandlerWithContext,
+    KeySequenceResult, PasswordPrompt, PasswordPromptResult, PendingKey, PickerAction, Priority,
+    QueryEditor, ResizeAction, RowDetailAction, RowDetailModal, SchemaCache, SearchPrompt, Sidebar,
+    SidebarAction, StatusLineBuilder, StatusSegment, TableInfo, UiTheme, YankFormat,
 };
 use crate::update::{
     apply_update, check_for_update, current_target_triple, detect_current_install_method,
@@ -837,24 +835,27 @@ fn is_row_returning_query(query: &str) -> bool {
         || first.eq_ignore_ascii_case("explain")
 }
 
+/// Compute the query panel height from the main-column content height.
+///
+/// `main_height` excludes the full-width status strip, which is split off
+/// before the sidebar/main division.
 fn compute_query_panel_height(
     main_height: u16,
     mode: Mode,
     non_insert_mode: QueryHeightMode,
     editor_line_count: usize,
 ) -> u16 {
-    let available_for_query = main_height.saturating_sub(STATUS_HEIGHT);
-    if available_for_query == 0 {
+    if main_height == 0 {
         return 0;
     }
 
-    // Preserve space for the status line and (when possible) a minimal grid.
+    // Preserve space for a minimal grid when possible.
     let layout_safe_max = {
-        let max_with_min_grid = main_height.saturating_sub(STATUS_HEIGHT + MIN_GRID_HEIGHT);
+        let max_with_min_grid = main_height.saturating_sub(MIN_GRID_HEIGHT);
         if max_with_min_grid > 0 {
             max_with_min_grid
         } else {
-            available_for_query
+            main_height
         }
     };
 
@@ -2437,6 +2438,9 @@ pub struct App {
     /// Resolved theme for UI chrome.
     pub ui_theme: UiTheme,
 
+    /// Loaded syntax theme, shared with modal-local highlighters.
+    pub syntax_theme: tui_syntax::Theme,
+
     /// Diagnostics produced while constructing the application.
     startup_warnings: Vec<String>,
 
@@ -2705,7 +2709,8 @@ impl App {
             connection_form_keymap,
 
             editor,
-            highlighter: create_sql_highlighter(syntax_theme),
+            highlighter: create_sql_highlighter(syntax_theme.clone()),
+            syntax_theme,
             search: SearchPrompt::new(),
             search_target: SearchTarget::Editor,
             command: CommandPrompt::new(),
@@ -3011,7 +3016,15 @@ impl App {
             terminal.draw(|frame| {
                 let size = frame.area();
 
-                // Split horizontally for sidebar + main content
+                // Reserve the bottom row for a full-width status strip, then
+                // split the remaining content into sidebar + main.
+                let vertical = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(0), Constraint::Length(STATUS_HEIGHT)])
+                    .split(size);
+                let content_area = vertical[0];
+                let status_area = vertical[1];
+
                 let horizontal = Layout::default()
                     .direction(Direction::Horizontal)
                     .constraints([
@@ -3022,7 +3035,7 @@ impl App {
                         }),
                         Constraint::Min(60), // Main content minimum width
                     ])
-                    .split(size);
+                    .split(content_area);
 
                 let sidebar_area = horizontal[0];
                 let main_area = horizontal[1];
@@ -3072,13 +3085,11 @@ impl App {
                     .constraints([
                         Constraint::Length(query_height),
                         Constraint::Min(MIN_GRID_HEIGHT),
-                        Constraint::Length(STATUS_HEIGHT),
                     ])
                     .split(main_area);
 
                 let query_area = chunks[0];
                 let grid_area = chunks[1];
-                let status_area = chunks[2];
 
                 // Store rendered areas for mouse click handling
                 self.render_query_area = Some(query_area);
@@ -3253,11 +3264,7 @@ impl App {
                     // Clear the overlay area
                     frame.render_widget(Clear, overlay_area);
 
-                    // Create bordered block
-                    let block = Block::default()
-                        .borders(Borders::ALL)
-                        .border_style(Style::default().fg(Color::Cyan))
-                        .style(Style::default().bg(Color::Black));
+                    let block = overlay_block("", &self.ui_theme);
 
                     let inner = block.inner(overlay_area);
                     frame.render_widget(block, overlay_area);
@@ -3274,10 +3281,10 @@ impl App {
                     // Render spinner with label
                     let throbber = Throbber::default()
                         .label(" Executing...")
-                        .style(Style::default().fg(Color::White))
+                        .style(Style::default().fg(self.ui_theme.text))
                         .throbber_style(
                             Style::default()
-                                .fg(Color::Cyan)
+                                .fg(self.ui_theme.accent)
                                 .add_modifier(Modifier::BOLD),
                         )
                         .throbber_set(BRAILLE_SIX);
@@ -3293,7 +3300,7 @@ impl App {
                         let elapsed = start_time.elapsed();
                         let elapsed_text = format!("{:.1}s elapsed", elapsed.as_secs_f64());
                         let elapsed_widget = Paragraph::new(elapsed_text)
-                            .style(Style::default().fg(Color::DarkGray))
+                            .style(Style::default().fg(self.ui_theme.text_muted))
                             .alignment(Alignment::Center);
                         frame.render_widget(elapsed_widget, chunks[1]);
                     }
@@ -3303,17 +3310,17 @@ impl App {
                 frame.render_widget(self.status_line(status_area.width), status_area);
 
                 if let Some(ref mut help) = self.help_popup {
-                    help.render(frame, size);
+                    help.render(frame, size, &self.ui_theme);
                 }
 
                 // Render history picker if open
                 if let Some(ref mut picker) = self.history_picker {
-                    picker.render(frame, size);
+                    picker.render(frame, size, &self.ui_theme);
                 }
 
                 // Render connection picker if open
                 if let Some(ref mut picker) = self.connection_picker {
-                    picker.render(frame, size);
+                    picker.render(frame, size, &self.ui_theme);
                 }
 
                 if self.search.active {
@@ -3332,12 +3339,12 @@ impl App {
                         SearchTarget::Grid => "/ Search Grid (Enter apply, Esc cancel)",
                     };
 
-                    self.search.textarea.set_block(
-                        Block::default()
-                            .borders(Borders::ALL)
-                            .title(search_title)
-                            .border_style(Style::default().fg(Color::Yellow)),
-                    );
+                    self.search
+                        .textarea
+                        .set_block(overlay_block(search_title, &self.ui_theme));
+                    self.search
+                        .textarea
+                        .set_cursor_style(self.ui_theme.editor_cursor);
 
                     frame.render_widget(Clear, area);
                     frame.render_widget(&self.search.textarea, area);
@@ -3354,12 +3361,13 @@ impl App {
                         height: h,
                     };
 
-                    self.command.textarea.set_block(
-                        Block::default()
-                            .borders(Borders::ALL)
-                            .title(": Command (Enter run, Esc cancel)")
-                            .border_style(Style::default().fg(Color::Magenta)),
-                    );
+                    self.command.textarea.set_block(overlay_block(
+                        ": Command (Enter run, Esc cancel)",
+                        &self.ui_theme,
+                    ));
+                    self.command
+                        .textarea
+                        .set_cursor_style(self.ui_theme.editor_cursor);
 
                     frame.render_widget(Clear, area);
                     frame.render_widget(&self.command.textarea, area);
@@ -3412,24 +3420,22 @@ impl App {
                                     CompletionKind::Function => "F",
                                 };
                                 let style = if is_selected {
-                                    Style::default().bg(Color::Blue).fg(Color::White)
+                                    self.ui_theme.selection
                                 } else {
                                     Style::default()
                                 };
                                 Line::from(vec![
                                     Span::styled(
                                         format!("{} ", prefix),
-                                        Style::default().fg(Color::DarkGray),
+                                        Style::default().fg(self.ui_theme.text_muted),
                                     ),
                                     Span::styled(&item.label, style),
                                 ])
                             })
                             .collect();
 
-                        let completion_block = Block::default()
-                            .borders(Borders::ALL)
-                            .title("Completions (Tab select, Esc cancel)")
-                            .border_style(Style::default().fg(Color::Cyan));
+                        let completion_block =
+                            overlay_block("Completions (Tab select, Esc cancel)", &self.ui_theme);
 
                         let completion_list = Paragraph::new(lines).block(completion_block.clone());
 
@@ -3452,12 +3458,14 @@ impl App {
                                     .end_symbol(Some("▼"))
                                     .thumb_symbol("█")
                                     .track_symbol(Some("░"))
+                                    .style(self.ui_theme.scrollbar)
                             } else {
                                 Scrollbar::new(ScrollbarOrientation::VerticalRight)
                                     .begin_symbol(None)
                                     .end_symbol(None)
                                     .thumb_symbol("█")
                                     .track_symbol(Some("│"))
+                                    .style(self.ui_theme.scrollbar)
                             };
 
                             let scroll_offset = self.completion.scroll_offset(max_visible);
@@ -3519,10 +3527,7 @@ impl App {
                         "Edit: {}{} (Enter confirm, Esc cancel)",
                         col_name, modified_indicator
                     );
-                    let edit_block = Block::default()
-                        .borders(Borders::ALL)
-                        .title(title)
-                        .border_style(Style::default().fg(Color::Yellow));
+                    let edit_block = overlay_block(&title, &self.ui_theme);
 
                     // Get visible text with cursor position
                     let (visible_text, cursor_pos) = self.cell_editor.visible_text(inner_width);
@@ -3540,16 +3545,13 @@ impl App {
                         display_spans.push(Span::raw(before));
                         display_spans.push(Span::styled(
                             cursor_char.to_string(),
-                            Style::default().bg(Color::White).fg(Color::Black),
+                            self.ui_theme.editor_cursor,
                         ));
                         display_spans.push(Span::raw(after));
                     } else {
                         // Cursor is at end
                         display_spans.push(Span::raw(visible_text));
-                        display_spans.push(Span::styled(
-                            " ",
-                            Style::default().bg(Color::White).fg(Color::Black),
-                        ));
+                        display_spans.push(Span::styled(" ", self.ui_theme.editor_cursor));
                     }
 
                     // Show scroll indicators if needed
@@ -3569,9 +3571,7 @@ impl App {
                         ""
                     };
 
-                    let edit_content = Paragraph::new(Line::from(display_spans))
-                        .block(edit_block)
-                        .style(Style::default().fg(Color::White));
+                    let edit_content = Paragraph::new(Line::from(display_spans)).block(edit_block);
 
                     frame.render_widget(Clear, popup_area);
                     frame.render_widget(edit_content, popup_area);
@@ -3592,48 +3592,48 @@ impl App {
                             width: popup_area.width.saturating_sub(2),
                             height: 1,
                         };
-                        let info_widget =
-                            Paragraph::new(info).style(Style::default().fg(Color::DarkGray));
+                        let info_widget = Paragraph::new(info)
+                            .style(Style::default().fg(self.ui_theme.text_muted));
                         frame.render_widget(info_widget, info_area);
                     }
                 }
 
                 // Render JSON editor modal if active
                 if let Some(ref mut json_editor) = self.json_editor {
-                    json_editor.render(frame, size);
+                    json_editor.render(frame, size, &self.ui_theme);
                 }
 
                 // Render row detail modal if active
                 if let Some(ref mut row_detail) = self.row_detail {
-                    row_detail.render(frame, size);
+                    row_detail.render(frame, size, &self.ui_theme);
                 }
 
                 // Render connection manager modal if active
                 if let Some(ref mut manager) = self.connection_manager {
-                    manager.render(frame, size);
+                    manager.render(frame, size, &self.ui_theme);
                 }
 
                 // Render connection form modal if active (on top of manager)
                 if let Some(ref form) = self.connection_form {
-                    form.render(frame, size);
+                    form.render(frame, size, &self.ui_theme);
                 }
 
                 // Render key hint popup if active (shows after timeout when 'g' is pending)
                 if show_key_hint {
                     if let Some(pending_key) = pending_key_for_hint {
                         let hint_popup = KeyHintPopup::new(pending_key);
-                        hint_popup.render(frame, size);
+                        hint_popup.render(frame, size, &self.ui_theme);
                     }
                 }
 
                 // Render password prompt if active
                 if let Some(ref prompt) = self.password_prompt {
-                    prompt.render(frame, size);
+                    prompt.render(frame, size, &self.ui_theme);
                 }
 
                 // Render AI assistant modal.
                 if let Some(ref mut modal) = self.ai_modal {
-                    modal.render(frame, size);
+                    modal.render(frame, size, &self.ui_theme);
                 }
 
                 // Error popup (modal).
@@ -3667,15 +3667,19 @@ impl App {
                             height: popup_height,
                         };
 
-                        let block = Block::default()
-                            .borders(Borders::ALL)
-                            .border_type(BorderType::Rounded)
-                            .title(" Error (Enter/Esc dismiss) ")
-                            .border_style(Style::default().fg(Color::Red));
+                        // Errors keep a red border on purpose — the semantic
+                        // exception to the calm overlay recipe.
+                        let block = overlay_block("", &self.ui_theme)
+                            .title_top(Line::from(Span::styled(
+                                " Error (Enter/Esc dismiss) ",
+                                Style::default()
+                                    .fg(self.ui_theme.error)
+                                    .add_modifier(Modifier::BOLD),
+                            )))
+                            .border_style(Style::default().fg(self.ui_theme.error));
 
                         let text = Paragraph::new(err.as_str())
                             .block(block)
-                            .style(Style::default().fg(Color::White))
                             .wrap(ratatui::widgets::Wrap { trim: false });
 
                         frame.render_widget(Clear, popup_area);
@@ -3685,7 +3689,7 @@ impl App {
 
                 // Render confirmation prompt if active (topmost layer)
                 if let Some(ref mut prompt) = self.confirm_prompt {
-                    prompt.render(frame, size);
+                    prompt.render(frame, size, &self.ui_theme);
                 }
             })?;
 
@@ -3719,10 +3723,8 @@ impl App {
                             break;
                         }
                     }
-                    Event::Mouse(mouse) => {
-                        if self.on_mouse(mouse) {
-                            break;
-                        }
+                    Event::Mouse(mouse) if self.on_mouse(mouse) => {
+                        break;
                     }
                     _ => {}
                 }
@@ -4997,7 +4999,14 @@ impl App {
         // Determine if we should use the multiline JSON editor
         if should_use_multiline_editor(&value) || is_json_column_type(&col_type) {
             // Open JSON editor modal
-            self.json_editor = Some(JsonEditorModal::new(value, col_name, col_type, row, col));
+            self.json_editor = Some(JsonEditorModal::new(
+                value,
+                col_name,
+                col_type,
+                row,
+                col,
+                self.syntax_theme.clone(),
+            ));
         } else {
             // Use inline editor for simple values
             self.cell_editor.open(row, col, value);
@@ -5014,7 +5023,13 @@ impl App {
         let values = self.grid.rows[row].clone();
         let col_types = self.grid.col_types.clone();
 
-        self.row_detail = Some(RowDetailModal::new(headers, values, col_types, row));
+        self.row_detail = Some(RowDetailModal::new(
+            headers,
+            values,
+            col_types,
+            row,
+            self.syntax_theme.clone(),
+        ));
     }
 
     /// Handle key events for the row detail modal.
@@ -10836,6 +10851,8 @@ impl App {
         let status = self.last_status.as_deref().unwrap_or("Ready").to_string();
         let status_style = if self.last_error.is_some() {
             Style::default().fg(self.ui_theme.error)
+        } else if self.last_status.is_none() {
+            Style::default().fg(self.ui_theme.success)
         } else {
             Style::default().fg(self.ui_theme.text_muted)
         };
@@ -10850,12 +10867,13 @@ impl App {
 
         // Build status line with priority-based segments
         let line = StatusLineBuilder::new()
+            .separator(" · ")
             .separator_style(Style::default().fg(self.ui_theme.text_muted))
             // Critical: Mode (always shown)
             .segment(StatusSegment::new(mode_text, Priority::Critical).style(mode_style))
             // Critical: active pane (always shown)
             .segment(
-                StatusSegment::new(format!("[{}]", self.focus.label()), Priority::Critical)
+                StatusSegment::new(self.focus.label().to_string(), Priority::Critical)
                     .style(focus_style),
             )
             // Critical: Connection info
@@ -10878,7 +10896,7 @@ impl App {
             .segment_if(
                 self.db.in_transaction,
                 StatusSegment::new("TXN", Priority::High)
-                    .style(Style::default().fg(self.ui_theme.accent_visual)),
+                    .style(Style::default().fg(self.ui_theme.transaction)),
             )
             // Medium: Row info
             .segment(StatusSegment::new(row_info, Priority::Medium).min_width(50))
@@ -11830,10 +11848,10 @@ mod tests {
 
     #[test]
     fn test_compute_query_panel_height_respects_layout_safety_cap() {
-        // main_height=6 leaves 5 rows after status line.
-        // With min grid reservation (3), query max should be 2.
+        // main_height=6 is the content height (status is split off separately).
+        // With min grid reservation (3), query max should be 3.
         let height = compute_query_panel_height(6, Mode::Insert, QueryHeightMode::Minimized, 50);
-        assert_eq!(height, 2);
+        assert_eq!(height, 3);
     }
 
     #[test]

--- a/crates/tsql/src/app/execution.rs
+++ b/crates/tsql/src/app/execution.rs
@@ -1,0 +1,307 @@
+//! Shared query execution identity and transaction-state tracking.
+//!
+//! Execution identity is intentionally independent from the active workspace.
+//! This lets asynchronous database events prove which editor or notebook cell
+//! they belong to before mutating application state.
+
+/// Stable identity for a notebook cell.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct CellId(pub(crate) u64);
+
+/// Monotonic identity for one database execution.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ExecutionId(pub(crate) u64);
+
+/// Workspace destination for execution output.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ExecutionTarget {
+    Classic,
+    Notebook(CellId),
+}
+
+/// Immutable identity captured when an asynchronous operation starts.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExecutionContext {
+    pub id: ExecutionId,
+    pub target: ExecutionTarget,
+    pub source_revision: u64,
+    pub connection_generation: u64,
+}
+
+/// How a user-visible query was started.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum QueryExecutionKind {
+    New,
+    Refresh,
+}
+
+/// The one database execution allowed to run at a time in the MVP.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ActiveExecution {
+    pub context: ExecutionContext,
+    pub(crate) kind: QueryExecutionKind,
+    pub cancelling: bool,
+}
+
+/// Conservatively inferred PostgreSQL transaction state.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TransactionState {
+    /// The connection is known not to be inside a user transaction.
+    Idle,
+    /// A user transaction is active.
+    Active,
+    /// A statement failed while a user transaction was active.
+    Failed,
+    /// The submitted SQL prevents reliable inference.
+    #[default]
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TransactionControl {
+    Begin,
+    Commit,
+    CommitAndChain,
+    Rollback,
+    RollbackAndChain,
+    Other,
+    Ambiguous,
+}
+
+impl TransactionState {
+    /// Applies the outcome of a user-submitted statement.
+    pub(crate) fn after_execution(self, sql: &str, succeeded: bool) -> Self {
+        let control = classify_transaction_control(sql);
+
+        if !succeeded {
+            return if self == Self::Active || self == Self::Failed {
+                Self::Failed
+            } else if control == TransactionControl::Ambiguous {
+                Self::Unknown
+            } else {
+                self
+            };
+        }
+
+        match control {
+            TransactionControl::Begin => Self::Active,
+            TransactionControl::Commit | TransactionControl::Rollback => Self::Idle,
+            TransactionControl::CommitAndChain | TransactionControl::RollbackAndChain => {
+                Self::Active
+            }
+            TransactionControl::Ambiguous => Self::Unknown,
+            TransactionControl::Other => self,
+        }
+    }
+}
+
+pub(crate) fn classify_transaction_control(sql: &str) -> TransactionControl {
+    let Some(statement) = single_statement(sql) else {
+        return TransactionControl::Ambiguous;
+    };
+    let words: Vec<String> = statement
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+        .filter(|word| !word.is_empty())
+        .take(5)
+        .map(str::to_ascii_uppercase)
+        .collect();
+
+    match words.as_slice() {
+        [first, ..] if first == "BEGIN" => TransactionControl::Begin,
+        [first, second, ..] if first == "START" && second == "TRANSACTION" => {
+            TransactionControl::Begin
+        }
+        [first, rest @ ..] if first == "COMMIT" || first == "END" => {
+            if contains_and_chain(rest) {
+                TransactionControl::CommitAndChain
+            } else {
+                TransactionControl::Commit
+            }
+        }
+        [first, rest @ ..] if first == "ROLLBACK" || first == "ABORT" => {
+            if contains_and_chain(rest) {
+                TransactionControl::RollbackAndChain
+            } else if rest.first().is_some_and(|word| word == "TO") {
+                TransactionControl::Other
+            } else {
+                TransactionControl::Rollback
+            }
+        }
+        [first, ..] if first == "CALL" => TransactionControl::Ambiguous,
+        [] => TransactionControl::Other,
+        _ => TransactionControl::Other,
+    }
+}
+
+fn contains_and_chain(words: &[String]) -> bool {
+    words
+        .windows(2)
+        .any(|pair| pair[0] == "AND" && pair[1] == "CHAIN")
+}
+
+/// Returns one comment-aware statement, or `None` for multiple/unterminated SQL.
+fn single_statement(sql: &str) -> Option<String> {
+    let mut result = String::with_capacity(sql.len());
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut statement_ended = false;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' | b'"' => {
+                if statement_ended {
+                    return None;
+                }
+                let start = index;
+                let delimiter = bytes[index];
+                index += 1;
+                loop {
+                    let offset = sql[index..].find(delimiter as char)?;
+                    index += offset + 1;
+                    if bytes.get(index) == Some(&delimiter) {
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                result.push_str(&sql[start..index]);
+            }
+            b'$' => {
+                let Some(tag_end_offset) = sql[index + 1..].find('$') else {
+                    if statement_ended {
+                        return None;
+                    }
+                    result.push('$');
+                    index += 1;
+                    continue;
+                };
+                let tag_end = index + 1 + tag_end_offset;
+                let tag = &sql[index + 1..tag_end];
+                let mut characters = tag.chars();
+                let valid_tag = characters.next().is_none_or(|character| {
+                    (character.is_ascii_alphabetic() || character == '_')
+                        && characters
+                            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+                });
+                if !valid_tag {
+                    if statement_ended {
+                        return None;
+                    }
+                    result.push('$');
+                    index += 1;
+                    continue;
+                }
+                if statement_ended {
+                    return None;
+                }
+                let delimiter = &sql[index..=tag_end];
+                let content_start = tag_end + 1;
+                let close_offset = sql[content_start..].find(delimiter)?;
+                let end = content_start + close_offset + delimiter.len();
+                result.push_str(&sql[index..end]);
+                index = end;
+            }
+            b'-' if bytes.get(index + 1) == Some(&b'-') => {
+                index = sql[index..]
+                    .find('\n')
+                    .map_or(bytes.len(), |offset| index + offset + 1);
+                result.push(' ');
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index += 2;
+                let mut depth = 1;
+                while index < bytes.len() && depth > 0 {
+                    if bytes.get(index..index + 2) == Some(b"/*") {
+                        depth += 1;
+                        index += 2;
+                    } else if bytes.get(index..index + 2) == Some(b"*/") {
+                        depth -= 1;
+                        index += 2;
+                    } else {
+                        index += sql[index..].chars().next()?.len_utf8();
+                    }
+                }
+                if depth > 0 {
+                    return None;
+                }
+                result.push(' ');
+            }
+            b';' => {
+                statement_ended = true;
+                index += 1;
+            }
+            _ => {
+                let character = sql[index..].chars().next()?;
+                if statement_ended && !character.is_whitespace() {
+                    return None;
+                }
+                result.push(character);
+                index += character.len_utf8();
+            }
+        }
+    }
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_transaction_control_with_comments_and_chain() {
+        assert_eq!(
+            classify_transaction_control("-- hello\n START TRANSACTION"),
+            TransactionControl::Begin
+        );
+        assert_eq!(
+            classify_transaction_control("COMMIT AND CHAIN;"),
+            TransactionControl::CommitAndChain
+        );
+        assert_eq!(
+            classify_transaction_control("rollback /* safe */ and chain"),
+            TransactionControl::RollbackAndChain
+        );
+        assert_eq!(
+            classify_transaction_control("ROLLBACK TO SAVEPOINT checkpoint"),
+            TransactionControl::Other
+        );
+    }
+
+    #[test]
+    fn classifies_ambiguous_statement_shapes_conservatively() {
+        assert_eq!(
+            classify_transaction_control("SELECT 1; SELECT 2"),
+            TransactionControl::Ambiguous
+        );
+        assert_eq!(
+            classify_transaction_control("CALL may_control_transaction()"),
+            TransactionControl::Ambiguous
+        );
+        assert_eq!(
+            classify_transaction_control("SELECT ';' /* ; */;"),
+            TransactionControl::Other
+        );
+        assert_eq!(
+            classify_transaction_control("SELECT $tag$hello;world$tag$ AS value;"),
+            TransactionControl::Other
+        );
+        assert_eq!(
+            classify_transaction_control("SELECT 1 /* outer ; /* nested ; */ still comment */;"),
+            TransactionControl::Other
+        );
+    }
+
+    #[test]
+    fn transaction_state_reducer_is_conservative() {
+        let state = TransactionState::Idle.after_execution("BEGIN", true);
+        assert_eq!(state, TransactionState::Active);
+        let state = state.after_execution("SELECT broken", false);
+        assert_eq!(state, TransactionState::Failed);
+        let state = state.after_execution("ROLLBACK", true);
+        assert_eq!(state, TransactionState::Idle);
+        let state = state.after_execution("CALL unknown()", true);
+        assert_eq!(state, TransactionState::Unknown);
+        let state = TransactionState::Idle.after_execution("SELECT $$hello;world$$ AS value", true);
+        assert_eq!(state, TransactionState::Idle);
+    }
+}

--- a/crates/tsql/src/app/execution.rs
+++ b/crates/tsql/src/app/execution.rs
@@ -96,15 +96,12 @@ impl TransactionState {
 }
 
 pub(crate) fn classify_transaction_control(sql: &str) -> TransactionControl {
-    let Some(statement) = single_statement(sql) else {
+    let Ok(statement) = super::sql_lexer::single_statement(sql) else {
         return TransactionControl::Ambiguous;
     };
-    let words: Vec<String> = statement
-        .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
-        .filter(|word| !word.is_empty())
-        .take(5)
-        .map(str::to_ascii_uppercase)
-        .collect();
+    let Ok(words) = super::sql_lexer::code_words(statement, 6) else {
+        return TransactionControl::Ambiguous;
+    };
 
     match words.as_slice() {
         [first, ..] if first == "BEGIN" => TransactionControl::Begin,
@@ -121,7 +118,7 @@ pub(crate) fn classify_transaction_control(sql: &str) -> TransactionControl {
         [first, rest @ ..] if first == "ROLLBACK" || first == "ABORT" => {
             if contains_and_chain(rest) {
                 TransactionControl::RollbackAndChain
-            } else if rest.first().is_some_and(|word| word == "TO") {
+            } else if is_savepoint_rollback(rest) {
                 TransactionControl::Other
             } else {
                 TransactionControl::Rollback
@@ -133,114 +130,22 @@ pub(crate) fn classify_transaction_control(sql: &str) -> TransactionControl {
     }
 }
 
+fn is_savepoint_rollback(words: &[String]) -> bool {
+    let rest = if words
+        .first()
+        .is_some_and(|word| word == "WORK" || word == "TRANSACTION")
+    {
+        &words[1..]
+    } else {
+        words
+    };
+    rest.first().is_some_and(|word| word == "TO")
+}
+
 fn contains_and_chain(words: &[String]) -> bool {
     words
         .windows(2)
         .any(|pair| pair[0] == "AND" && pair[1] == "CHAIN")
-}
-
-/// Returns one comment-aware statement, or `None` for multiple/unterminated SQL.
-fn single_statement(sql: &str) -> Option<String> {
-    let mut result = String::with_capacity(sql.len());
-    let bytes = sql.as_bytes();
-    let mut index = 0;
-    let mut statement_ended = false;
-
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\'' | b'"' => {
-                if statement_ended {
-                    return None;
-                }
-                let start = index;
-                let delimiter = bytes[index];
-                index += 1;
-                loop {
-                    let offset = sql[index..].find(delimiter as char)?;
-                    index += offset + 1;
-                    if bytes.get(index) == Some(&delimiter) {
-                        index += 1;
-                    } else {
-                        break;
-                    }
-                }
-                result.push_str(&sql[start..index]);
-            }
-            b'$' => {
-                let Some(tag_end_offset) = sql[index + 1..].find('$') else {
-                    if statement_ended {
-                        return None;
-                    }
-                    result.push('$');
-                    index += 1;
-                    continue;
-                };
-                let tag_end = index + 1 + tag_end_offset;
-                let tag = &sql[index + 1..tag_end];
-                let mut characters = tag.chars();
-                let valid_tag = characters.next().is_none_or(|character| {
-                    (character.is_ascii_alphabetic() || character == '_')
-                        && characters
-                            .all(|character| character.is_ascii_alphanumeric() || character == '_')
-                });
-                if !valid_tag {
-                    if statement_ended {
-                        return None;
-                    }
-                    result.push('$');
-                    index += 1;
-                    continue;
-                }
-                if statement_ended {
-                    return None;
-                }
-                let delimiter = &sql[index..=tag_end];
-                let content_start = tag_end + 1;
-                let close_offset = sql[content_start..].find(delimiter)?;
-                let end = content_start + close_offset + delimiter.len();
-                result.push_str(&sql[index..end]);
-                index = end;
-            }
-            b'-' if bytes.get(index + 1) == Some(&b'-') => {
-                index = sql[index..]
-                    .find('\n')
-                    .map_or(bytes.len(), |offset| index + offset + 1);
-                result.push(' ');
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'*') => {
-                index += 2;
-                let mut depth = 1;
-                while index < bytes.len() && depth > 0 {
-                    if bytes.get(index..index + 2) == Some(b"/*") {
-                        depth += 1;
-                        index += 2;
-                    } else if bytes.get(index..index + 2) == Some(b"*/") {
-                        depth -= 1;
-                        index += 2;
-                    } else {
-                        index += sql[index..].chars().next()?.len_utf8();
-                    }
-                }
-                if depth > 0 {
-                    return None;
-                }
-                result.push(' ');
-            }
-            b';' => {
-                statement_ended = true;
-                index += 1;
-            }
-            _ => {
-                let character = sql[index..].chars().next()?;
-                if statement_ended && !character.is_whitespace() {
-                    return None;
-                }
-                result.push(character);
-                index += character.len_utf8();
-            }
-        }
-    }
-    Some(result)
 }
 
 #[cfg(test)]
@@ -265,6 +170,14 @@ mod tests {
             classify_transaction_control("ROLLBACK TO SAVEPOINT checkpoint"),
             TransactionControl::Other
         );
+        assert_eq!(
+            classify_transaction_control("ROLLBACK TRANSACTION TO SAVEPOINT checkpoint"),
+            TransactionControl::Other
+        );
+        assert_eq!(
+            classify_transaction_control("ABORT WORK TO checkpoint"),
+            TransactionControl::Other
+        );
     }
 
     #[test]
@@ -287,6 +200,10 @@ mod tests {
         );
         assert_eq!(
             classify_transaction_control("SELECT 1 /* outer ; /* nested ; */ still comment */;"),
+            TransactionControl::Other
+        );
+        assert_eq!(
+            classify_transaction_control("SELECT E'it\\'s; -- not a comment' AS value;"),
             TransactionControl::Other
         );
     }

--- a/crates/tsql/src/app/mod.rs
+++ b/crates/tsql/src/app/mod.rs
@@ -1,6 +1,19 @@
 #[allow(clippy::module_inception)]
 mod app;
+mod execution;
+mod notebook;
+mod pg_snapshot;
+mod refinement;
 mod state;
 
 pub use app::{encode_schema_id_component, App, DbEvent, DbSession, QueryResult, SharedClient};
-pub use state::{DbStatus, Focus, Mode, PanelDirection, SidebarSection};
+pub use execution::{
+    ActiveExecution, CellId, ExecutionContext, ExecutionId, ExecutionTarget, TransactionState,
+};
+pub use notebook::{NotebookCell, NotebookFocus, NotebookState};
+pub use pg_snapshot::PgTempSnapshot;
+pub use refinement::{
+    RefinementAvailability, RefinementUnavailableReason, ResultVersion, RetainedResult,
+    RetainedResultHandle,
+};
+pub use state::{DbStatus, Focus, Mode, PanelDirection, SidebarSection, WorkspaceMode};

--- a/crates/tsql/src/app/mod.rs
+++ b/crates/tsql/src/app/mod.rs
@@ -2,8 +2,12 @@
 mod app;
 mod execution;
 mod notebook;
+mod notebook_export;
+mod notebook_run;
 mod pg_snapshot;
 mod refinement;
+mod result_transform;
+mod sql_lexer;
 mod state;
 
 pub use app::{encode_schema_id_component, App, DbEvent, DbSession, QueryResult, SharedClient};

--- a/crates/tsql/src/app/notebook.rs
+++ b/crates/tsql/src/app/notebook.rs
@@ -425,6 +425,7 @@ impl NotebookState {
             self.cells[0].additional_dependencies.clear();
             self.cells[0].execution_history.clear();
             self.cells[0].execution = CellExecutionState::NeverRun;
+            self.cells[0].bound_connection_generation = None;
             return None;
         }
         let removed = self.cells.remove(index);
@@ -463,6 +464,7 @@ mod tests {
         cell.result_name = Some("recent_rows".to_string());
         cell.source_collapsed = true;
         cell.output_collapsed = true;
+        cell.bound_connection_generation = Some(42);
 
         assert!(notebook.remove_cell(cell_id).is_none());
         let cell = notebook.selected_cell();
@@ -471,6 +473,7 @@ mod tests {
         assert!(!cell.source_collapsed);
         assert!(!cell.output_collapsed);
         assert_eq!(cell.execution, CellExecutionState::NeverRun);
+        assert_eq!(cell.bound_connection_generation, None);
     }
 
     #[test]

--- a/crates/tsql/src/app/notebook.rs
+++ b/crates/tsql/src/app/notebook.rs
@@ -1,0 +1,422 @@
+//! Notebook document state and revision-aware cell transitions.
+
+use std::time::Duration;
+
+use super::execution::{CellId, ExecutionContext};
+use super::refinement::{RefinementAvailability, ResultVersion, RetainedResult};
+use crate::ui::{GridModel, GridState, QueryEditor};
+
+/// Which part of the selected notebook cell owns keyboard input.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum NotebookFocus {
+    #[default]
+    Cell,
+    Editor,
+    Result,
+}
+
+/// Current execution state for a cell.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CellExecutionState {
+    #[default]
+    NeverRun,
+    Running(ExecutionContext),
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+/// Durable display output for a completed cell execution.
+pub struct NotebookOutput {
+    pub grid: GridModel,
+    pub grid_state: GridState,
+    pub command_tag: Option<String>,
+    pub elapsed: Duration,
+    pub error: Option<String>,
+    pub retained: Option<RetainedResult>,
+    pub refinement: RefinementAvailability,
+    pub executed_revision: u64,
+    pub truncated: bool,
+}
+
+/// One SQL/Mongo source cell and its latest durable output.
+pub struct NotebookCell {
+    pub id: CellId,
+    pub revision: u64,
+    pub editor: QueryEditor,
+    pub editor_scroll: (u16, u16),
+    pub execution: CellExecutionState,
+    pub output: Option<NotebookOutput>,
+    pub failure: Option<String>,
+    pub dependency: Option<ResultVersion>,
+    pub bound_connection_generation: Option<u64>,
+    pub output_collapsed: bool,
+}
+
+impl NotebookCell {
+    fn new(id: CellId) -> Self {
+        Self {
+            id,
+            revision: 0,
+            editor: QueryEditor::new(),
+            editor_scroll: (0, 0),
+            execution: CellExecutionState::NeverRun,
+            output: None,
+            failure: None,
+            dependency: None,
+            bound_connection_generation: None,
+            output_collapsed: false,
+        }
+    }
+
+    pub fn source(&self) -> String {
+        self.editor.text()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.editor.text().trim().is_empty()
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.output
+            .as_ref()
+            .is_some_and(|output| output.executed_revision != self.revision)
+    }
+
+    pub fn output_is_stale(&self) -> bool {
+        self.output.is_some()
+            && (self.is_dirty()
+                || matches!(
+                    self.execution,
+                    CellExecutionState::Running(_)
+                        | CellExecutionState::Failed
+                        | CellExecutionState::Cancelled
+                ))
+    }
+
+    pub fn replace_source(&mut self, source: String) {
+        if self.editor.text() != source {
+            self.editor.set_text(source);
+            self.revision = self.revision.wrapping_add(1);
+        }
+    }
+
+    pub fn mark_edited(&mut self) {
+        self.revision = self.revision.wrapping_add(1);
+    }
+}
+
+/// Ordered notebook document with exactly one trailing draft cell.
+pub struct NotebookState {
+    pub cells: Vec<NotebookCell>,
+    pub selected: CellId,
+    pub focus: NotebookFocus,
+    pub scroll_cell: usize,
+    pub pending_delete: bool,
+    next_cell_id: u64,
+}
+
+impl Default for NotebookState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NotebookState {
+    pub fn new() -> Self {
+        let first = CellId(1);
+        Self {
+            cells: vec![NotebookCell::new(first)],
+            selected: first,
+            focus: NotebookFocus::Cell,
+            scroll_cell: 0,
+            pending_delete: false,
+            next_cell_id: 2,
+        }
+    }
+
+    pub fn from_sources(
+        cells: Vec<(String, bool, Option<ResultVersion>)>,
+        selected_index: usize,
+    ) -> Self {
+        Self::from_sources_with_ids(
+            cells
+                .into_iter()
+                .map(|(source, output_collapsed, dependency)| {
+                    (None, source, output_collapsed, dependency)
+                })
+                .collect(),
+            selected_index,
+        )
+    }
+
+    /// Restores persisted cells without renumbering their structural identities.
+    pub fn from_sources_with_ids(
+        cells: Vec<(Option<CellId>, String, bool, Option<ResultVersion>)>,
+        selected_index: usize,
+    ) -> Self {
+        let mut notebook = Self::new();
+        notebook.cells.clear();
+        notebook.next_cell_id = cells
+            .iter()
+            .filter_map(|(id, _, _, _)| id.map(|id| id.0))
+            .max()
+            .and_then(|id| id.checked_add(1))
+            .unwrap_or(1);
+
+        for (saved_id, source, output_collapsed, dependency) in cells {
+            let id = saved_id
+                .filter(|id| id.0 != 0 && !notebook.cells.iter().any(|cell| cell.id == *id))
+                .unwrap_or_else(|| notebook.allocate_cell_id());
+            let mut cell = NotebookCell::new(id);
+            cell.replace_source(source);
+            cell.output_collapsed = output_collapsed;
+            cell.dependency = dependency;
+            notebook.cells.push(cell);
+        }
+        if notebook.cells.is_empty() {
+            notebook.cells.push(NotebookCell::new(CellId(1)));
+            notebook.next_cell_id = 2;
+        }
+        notebook.ensure_trailing_draft();
+        let selected_index = selected_index.min(notebook.cells.len().saturating_sub(1));
+        notebook.selected = notebook.cells[selected_index].id;
+        notebook.pending_delete = false;
+        notebook
+    }
+
+    pub fn selected_index(&self) -> usize {
+        self.cells
+            .iter()
+            .position(|cell| cell.id == self.selected)
+            .unwrap_or(0)
+    }
+
+    pub fn selected_cell(&self) -> &NotebookCell {
+        &self.cells[self.selected_index()]
+    }
+
+    pub fn selected_cell_mut(&mut self) -> &mut NotebookCell {
+        let index = self.selected_index();
+        &mut self.cells[index]
+    }
+
+    pub fn cell_mut(&mut self, id: CellId) -> Option<&mut NotebookCell> {
+        self.cells.iter_mut().find(|cell| cell.id == id)
+    }
+
+    pub fn select_previous(&mut self) {
+        let index = self.selected_index().saturating_sub(1);
+        self.selected = self.cells[index].id;
+    }
+
+    pub fn select_next(&mut self) {
+        let index = (self.selected_index() + 1).min(self.cells.len().saturating_sub(1));
+        self.selected = self.cells[index].id;
+    }
+
+    pub fn select_first(&mut self) {
+        if let Some(cell) = self.cells.first() {
+            self.selected = cell.id;
+        }
+    }
+
+    pub fn select_last(&mut self) {
+        if let Some(cell) = self.cells.last() {
+            self.selected = cell.id;
+        }
+    }
+
+    /// Selects the empty tail, preserving a non-empty tail and appending a new draft.
+    pub fn select_or_create_draft(&mut self) {
+        let needs_draft = self.cells.last().is_none_or(|cell| !cell.is_empty());
+        if needs_draft {
+            let id = self.allocate_cell_id();
+            self.cells.push(NotebookCell::new(id));
+        }
+        self.select_last();
+        self.focus = NotebookFocus::Editor;
+    }
+
+    /// Preserves an executed/non-empty cell and ensures an empty trailing draft exists.
+    pub fn ensure_trailing_draft(&mut self) {
+        if self.cells.last().is_none_or(|cell| !cell.is_empty()) {
+            let id = self.allocate_cell_id();
+            self.cells.push(NotebookCell::new(id));
+        }
+    }
+
+    pub fn insert_refinement(&mut self, version: ResultVersion) -> CellId {
+        let source_index = self.selected_index();
+        let id = self.allocate_cell_id();
+        let mut cell = NotebookCell::new(id);
+        cell.replace_source(format!("SELECT *\nFROM @result_{}", version.source_cell.0));
+        cell.dependency = Some(version);
+        self.cells.insert(source_index + 1, cell);
+        self.selected = id;
+        self.focus = NotebookFocus::Editor;
+        self.ensure_trailing_draft();
+        id
+    }
+
+    fn allocate_cell_id(&mut self) -> CellId {
+        let mut candidate = self.next_cell_id.max(1);
+        while self.cells.iter().any(|cell| cell.id.0 == candidate) {
+            candidate = candidate.checked_add(1).unwrap_or(1);
+        }
+        self.next_cell_id = candidate.checked_add(1).unwrap_or(1);
+        CellId(candidate)
+    }
+
+    pub fn remove_cell(&mut self, id: CellId) -> Option<NotebookCell> {
+        let index = self.cells.iter().position(|cell| cell.id == id)?;
+        if self.cells.len() == 1 {
+            self.cells[0].replace_source(String::new());
+            self.cells[0].output = None;
+            self.cells[0].failure = None;
+            self.cells[0].dependency = None;
+            self.cells[0].execution = CellExecutionState::NeverRun;
+            return None;
+        }
+        let removed = self.cells.remove(index);
+        let selected_index = index.min(self.cells.len().saturating_sub(1));
+        self.selected = self.cells[selected_index].id;
+        self.ensure_trailing_draft();
+        Some(removed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_nonempty_tail_and_appends_one_draft() {
+        let mut notebook = NotebookState::new();
+        notebook
+            .selected_cell_mut()
+            .replace_source("select 1".to_string());
+
+        notebook.select_or_create_draft();
+        notebook.select_or_create_draft();
+
+        assert_eq!(notebook.cells.len(), 2);
+        assert_eq!(notebook.cells[0].source(), "select 1");
+        assert!(notebook.cells[1].is_empty());
+    }
+
+    #[test]
+    fn source_revision_makes_previous_output_dirty() {
+        let mut cell = NotebookCell::new(CellId(1));
+        cell.replace_source("select 1".to_string());
+        cell.output = Some(NotebookOutput {
+            grid: GridModel::empty(),
+            grid_state: GridState::default(),
+            command_tag: None,
+            elapsed: Duration::ZERO,
+            error: None,
+            retained: None,
+            refinement: RefinementAvailability::Unavailable(
+                crate::app::RefinementUnavailableReason::SnapshotDisabled,
+            ),
+            executed_revision: cell.revision,
+            truncated: false,
+        });
+
+        cell.replace_source("select 2".to_string());
+
+        assert!(cell.is_dirty());
+    }
+
+    #[test]
+    fn restores_stable_cell_ids_and_keeps_refinement_lineage() {
+        let version = ResultVersion {
+            source_cell: CellId(4),
+            source_execution: super::super::execution::ExecutionId(7),
+            source_revision: 2,
+        };
+
+        let mut notebook = NotebookState::from_sources_with_ids(
+            vec![
+                (Some(CellId(4)), "select 1".to_string(), false, None),
+                (
+                    Some(CellId(9)),
+                    "select * from @result_4".to_string(),
+                    false,
+                    Some(version),
+                ),
+            ],
+            1,
+        );
+
+        assert_eq!(
+            notebook
+                .cells
+                .iter()
+                .map(|cell| cell.id)
+                .collect::<Vec<_>>(),
+            [CellId(4), CellId(9), CellId(10)]
+        );
+        assert_eq!(notebook.selected, CellId(9));
+        assert_eq!(notebook.selected_cell().dependency, Some(version));
+
+        notebook.select_first();
+        let refinement = notebook.insert_refinement(version);
+
+        assert_eq!(refinement, CellId(11));
+        assert_eq!(notebook.selected_cell().dependency, Some(version));
+        assert_eq!(
+            notebook.selected_cell().source(),
+            "SELECT *\nFROM @result_4"
+        );
+    }
+
+    #[test]
+    fn restores_legacy_and_duplicate_ids_without_collisions() {
+        let notebook = NotebookState::from_sources_with_ids(
+            vec![
+                (Some(CellId(2)), "select 1".to_string(), false, None),
+                (None, "select 2".to_string(), false, None),
+                (Some(CellId(2)), "select 3".to_string(), false, None),
+                (Some(CellId(0)), "select 4".to_string(), false, None),
+            ],
+            0,
+        );
+
+        assert_eq!(
+            notebook
+                .cells
+                .iter()
+                .map(|cell| cell.id)
+                .collect::<Vec<_>>(),
+            [CellId(2), CellId(3), CellId(4), CellId(5), CellId(6)]
+        );
+    }
+
+    #[test]
+    fn restores_v2_cells_without_ids_using_legacy_ordinals() {
+        let version = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: super::super::execution::ExecutionId(4),
+            source_revision: 2,
+        };
+
+        let notebook = NotebookState::from_sources(
+            vec![
+                ("select 1".to_string(), false, None),
+                ("select * from @result_1".to_string(), false, Some(version)),
+            ],
+            1,
+        );
+
+        assert_eq!(
+            notebook
+                .cells
+                .iter()
+                .map(|cell| cell.id)
+                .collect::<Vec<_>>(),
+            [CellId(1), CellId(2), CellId(3)]
+        );
+        assert_eq!(notebook.selected_cell().dependency, Some(version));
+    }
+}

--- a/crates/tsql/src/app/notebook.rs
+++ b/crates/tsql/src/app/notebook.rs
@@ -3,8 +3,22 @@
 use std::time::Duration;
 
 use super::execution::{CellId, ExecutionContext};
-use super::refinement::{RefinementAvailability, ResultVersion, RetainedResult};
+use super::refinement::{
+    normalize_result_name, RefinementAvailability, ResultVersion, RetainedResult,
+};
+use crate::session::{bounded_notebook_run_history, NotebookRunRecord};
 use crate::ui::{GridModel, GridState, QueryEditor};
+
+type RestoredNotebookCell = (
+    Option<CellId>,
+    Option<String>,
+    String,
+    bool,
+    bool,
+    Option<ResultVersion>,
+    Vec<ResultVersion>,
+    Vec<NotebookRunRecord>,
+);
 
 /// Which part of the selected notebook cell owns keyboard input.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -42,6 +56,7 @@ pub struct NotebookOutput {
 /// One SQL/Mongo source cell and its latest durable output.
 pub struct NotebookCell {
     pub id: CellId,
+    pub result_name: Option<String>,
     pub revision: u64,
     pub editor: QueryEditor,
     pub editor_scroll: (u16, u16),
@@ -49,7 +64,10 @@ pub struct NotebookCell {
     pub output: Option<NotebookOutput>,
     pub failure: Option<String>,
     pub dependency: Option<ResultVersion>,
+    pub additional_dependencies: Vec<ResultVersion>,
+    pub execution_history: Vec<NotebookRunRecord>,
     pub bound_connection_generation: Option<u64>,
+    pub source_collapsed: bool,
     pub output_collapsed: bool,
 }
 
@@ -57,6 +75,7 @@ impl NotebookCell {
     fn new(id: CellId) -> Self {
         Self {
             id,
+            result_name: None,
             revision: 0,
             editor: QueryEditor::new(),
             editor_scroll: (0, 0),
@@ -64,7 +83,10 @@ impl NotebookCell {
             output: None,
             failure: None,
             dependency: None,
+            additional_dependencies: Vec::new(),
+            execution_history: Vec::new(),
             bound_connection_generation: None,
+            source_collapsed: false,
             output_collapsed: false,
         }
     }
@@ -103,6 +125,26 @@ impl NotebookCell {
 
     pub fn mark_edited(&mut self) {
         self.revision = self.revision.wrapping_add(1);
+    }
+
+    /// Adds a compact completed-run record, keeping only the newest bounded history.
+    pub fn push_run(&mut self, record: NotebookRunRecord) {
+        self.execution_history.push(record);
+        self.execution_history =
+            bounded_notebook_run_history(std::mem::take(&mut self.execution_history));
+    }
+
+    /// Replaces the source with one of this cell's previous execution sources.
+    pub fn restore_run_source(&mut self, history_index: usize) -> bool {
+        let Some(source) = self
+            .execution_history
+            .get(history_index)
+            .map(|record| record.source.clone())
+        else {
+            return false;
+        };
+        self.replace_source(source);
+        true
     }
 }
 
@@ -155,23 +197,70 @@ impl NotebookState {
         cells: Vec<(Option<CellId>, String, bool, Option<ResultVersion>)>,
         selected_index: usize,
     ) -> Self {
+        Self::from_sources_with_dependencies(
+            cells
+                .into_iter()
+                .map(|(id, source, collapsed, dependency)| {
+                    (
+                        id,
+                        None,
+                        source,
+                        false,
+                        collapsed,
+                        dependency,
+                        Vec::new(),
+                        Vec::new(),
+                    )
+                })
+                .collect(),
+            selected_index,
+        )
+    }
+
+    /// Restores all structural result bindings for cells that join multiple sources.
+    pub fn from_sources_with_dependencies(
+        cells: Vec<RestoredNotebookCell>,
+        selected_index: usize,
+    ) -> Self {
         let mut notebook = Self::new();
         notebook.cells.clear();
         notebook.next_cell_id = cells
             .iter()
-            .filter_map(|(id, _, _, _)| id.map(|id| id.0))
+            .filter_map(|(id, _, _, _, _, _, _, _)| id.map(|id| id.0))
             .max()
             .and_then(|id| id.checked_add(1))
             .unwrap_or(1);
 
-        for (saved_id, source, output_collapsed, dependency) in cells {
+        for (
+            saved_id,
+            result_name,
+            source,
+            source_collapsed,
+            output_collapsed,
+            dependency,
+            additional_dependencies,
+            execution_history,
+        ) in cells
+        {
             let id = saved_id
                 .filter(|id| id.0 != 0 && !notebook.cells.iter().any(|cell| cell.id == *id))
                 .unwrap_or_else(|| notebook.allocate_cell_id());
             let mut cell = NotebookCell::new(id);
             cell.replace_source(source);
+            cell.editor.mark_saved();
+            cell.result_name = result_name
+                .and_then(|name| normalize_result_name(&name))
+                .filter(|name| {
+                    !notebook
+                        .cells
+                        .iter()
+                        .any(|existing| existing.result_name.as_ref() == Some(name))
+                });
+            cell.source_collapsed = source_collapsed;
             cell.output_collapsed = output_collapsed;
             cell.dependency = dependency;
+            cell.additional_dependencies = additional_dependencies;
+            cell.execution_history = bounded_notebook_run_history(execution_history);
             notebook.cells.push(cell);
         }
         if notebook.cells.is_empty() {
@@ -259,6 +348,61 @@ impl NotebookState {
         id
     }
 
+    /// Inserts a fresh source cell next to the selection and focuses its editor.
+    pub fn insert_cell(&mut self, below: bool) -> CellId {
+        let index = self.selected_index().saturating_add(usize::from(below));
+        let id = self.allocate_cell_id();
+        self.cells
+            .insert(index.min(self.cells.len()), NotebookCell::new(id));
+        self.selected = id;
+        self.focus = NotebookFocus::Editor;
+        self.ensure_trailing_draft();
+        id
+    }
+
+    /// Duplicates source and lineage without copying stale runtime output.
+    pub fn duplicate_selected(&mut self) -> CellId {
+        let index = self.selected_index();
+        let source = self.cells[index].source();
+        let source_collapsed = self.cells[index].source_collapsed;
+        let dependency = self.cells[index].dependency;
+        let additional_dependencies = self.cells[index].additional_dependencies.clone();
+        let id = self.allocate_cell_id();
+        let mut cell = NotebookCell::new(id);
+        cell.replace_source(source);
+        cell.source_collapsed = source_collapsed;
+        cell.dependency = dependency;
+        cell.additional_dependencies = additional_dependencies;
+        self.cells.insert(index + 1, cell);
+        self.selected = id;
+        self.focus = NotebookFocus::Cell;
+        self.ensure_trailing_draft();
+        id
+    }
+
+    /// Moves the selected cell one position while keeping its stable identity.
+    pub fn move_selected(&mut self, down: bool) -> bool {
+        let index = self.selected_index();
+        let last_movable = if self.cells.last().is_some_and(NotebookCell::is_empty) {
+            self.cells.len().saturating_sub(2)
+        } else {
+            self.cells.len().saturating_sub(1)
+        };
+        if index > last_movable {
+            return false;
+        }
+        let target = if down {
+            index.saturating_add(1)
+        } else {
+            index.saturating_sub(1)
+        };
+        if target == index || target > last_movable {
+            return false;
+        }
+        self.cells.swap(index, target);
+        true
+    }
+
     fn allocate_cell_id(&mut self) -> CellId {
         let mut candidate = self.next_cell_id.max(1);
         while self.cells.iter().any(|cell| cell.id.0 == candidate) {
@@ -272,9 +416,14 @@ impl NotebookState {
         let index = self.cells.iter().position(|cell| cell.id == id)?;
         if self.cells.len() == 1 {
             self.cells[0].replace_source(String::new());
+            self.cells[0].result_name = None;
             self.cells[0].output = None;
+            self.cells[0].output_collapsed = false;
+            self.cells[0].source_collapsed = false;
             self.cells[0].failure = None;
             self.cells[0].dependency = None;
+            self.cells[0].additional_dependencies.clear();
+            self.cells[0].execution_history.clear();
             self.cells[0].execution = CellExecutionState::NeverRun;
             return None;
         }
@@ -303,6 +452,25 @@ mod tests {
         assert_eq!(notebook.cells.len(), 2);
         assert_eq!(notebook.cells[0].source(), "select 1");
         assert!(notebook.cells[1].is_empty());
+    }
+
+    #[test]
+    fn removing_the_only_cell_resets_all_persisted_cell_state() {
+        let mut notebook = NotebookState::new();
+        let cell_id = notebook.selected;
+        let cell = notebook.selected_cell_mut();
+        cell.replace_source("select 1".to_string());
+        cell.result_name = Some("recent_rows".to_string());
+        cell.source_collapsed = true;
+        cell.output_collapsed = true;
+
+        assert!(notebook.remove_cell(cell_id).is_none());
+        let cell = notebook.selected_cell();
+        assert!(cell.is_empty());
+        assert_eq!(cell.result_name, None);
+        assert!(!cell.source_collapsed);
+        assert!(!cell.output_collapsed);
+        assert_eq!(cell.execution, CellExecutionState::NeverRun);
     }
 
     #[test]
@@ -418,5 +586,176 @@ mod tests {
             [CellId(1), CellId(2), CellId(3)]
         );
         assert_eq!(notebook.selected_cell().dependency, Some(version));
+    }
+
+    #[test]
+    fn restored_sources_start_unmodified() {
+        let notebook = NotebookState::from_sources_with_ids(
+            vec![(Some(CellId(7)), "select 1".to_string(), false, None)],
+            0,
+        );
+
+        assert!(!notebook.cells[0].editor.is_modified());
+        assert!(!notebook.cells[0].is_dirty());
+    }
+
+    #[test]
+    fn restores_unique_normalized_result_names_and_discards_duplicates() {
+        let notebook = NotebookState::from_sources_with_dependencies(
+            vec![
+                (
+                    Some(CellId(4)),
+                    Some("Recent_Users".to_string()),
+                    "SELECT 1".to_string(),
+                    false,
+                    false,
+                    None,
+                    Vec::new(),
+                    Vec::new(),
+                ),
+                (
+                    Some(CellId(5)),
+                    Some("recent_users".to_string()),
+                    "SELECT 2".to_string(),
+                    false,
+                    false,
+                    None,
+                    Vec::new(),
+                    Vec::new(),
+                ),
+                (
+                    Some(CellId(6)),
+                    Some("not valid".to_string()),
+                    "SELECT 3".to_string(),
+                    false,
+                    false,
+                    None,
+                    Vec::new(),
+                    Vec::new(),
+                ),
+            ],
+            0,
+        );
+
+        assert_eq!(
+            notebook.cells[0].result_name.as_deref(),
+            Some("recent_users")
+        );
+        assert!(notebook.cells[1].result_name.is_none());
+        assert!(notebook.cells[2].result_name.is_none());
+    }
+
+    #[test]
+    fn cell_operations_preserve_stable_ids_sources_and_lineage() {
+        let version = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: super::super::execution::ExecutionId(3),
+            source_revision: 2,
+        };
+        let mut notebook = NotebookState::new();
+        notebook.cells[0].replace_source("SELECT * FROM @result_1".to_string());
+        notebook.cells[0].dependency = Some(version);
+        notebook.ensure_trailing_draft();
+
+        let duplicate = notebook.duplicate_selected();
+        assert_ne!(duplicate, CellId(1));
+        assert_eq!(notebook.selected_cell().source(), "SELECT * FROM @result_1");
+        assert_eq!(notebook.selected_cell().dependency, Some(version));
+        assert!(notebook.selected_cell().output.is_none());
+        assert!(notebook.move_selected(false));
+        assert_eq!(notebook.cells[0].id, duplicate);
+
+        let inserted = notebook.insert_cell(true);
+        assert_eq!(notebook.selected, inserted);
+        assert!(notebook.selected_cell().is_empty());
+        assert_eq!(notebook.focus, NotebookFocus::Editor);
+    }
+
+    #[test]
+    fn moving_cells_does_not_move_or_replace_the_trailing_draft() {
+        let mut notebook = NotebookState::new();
+        notebook.cells[0].replace_source("SELECT 1".to_string());
+        notebook.ensure_trailing_draft();
+        notebook.selected = CellId(1);
+
+        assert!(!notebook.move_selected(true));
+        assert_eq!(notebook.cells.len(), 2);
+        assert_eq!(notebook.cells[0].id, CellId(1));
+        assert!(notebook.cells[1].is_empty());
+
+        notebook.select_last();
+        assert!(!notebook.move_selected(false));
+        assert_eq!(notebook.cells.len(), 2);
+        assert!(notebook.cells[1].is_empty());
+    }
+
+    #[test]
+    fn restores_and_bounds_run_history_and_can_restore_previous_source() {
+        use crate::session::{NotebookRunStatus, MAX_NOTEBOOK_RUN_HISTORY};
+
+        let history = (0..MAX_NOTEBOOK_RUN_HISTORY + 3)
+            .map(|index| NotebookRunRecord {
+                execution_id: index as u64,
+                source_revision: index as u64,
+                source: format!("SELECT {index}"),
+                status: NotebookRunStatus::Succeeded,
+                finished_at: "2026-07-11T12:00:00Z".parse().unwrap(),
+                elapsed_ms: 5,
+                row_count: 1,
+                headers: vec!["value".to_string()],
+                rows: vec![vec![index.to_string()]],
+                error: None,
+                truncated: false,
+            })
+            .collect();
+        let mut notebook = NotebookState::from_sources_with_dependencies(
+            vec![(
+                Some(CellId(4)),
+                None,
+                "SELECT current".to_string(),
+                false,
+                false,
+                None,
+                Vec::new(),
+                history,
+            )],
+            0,
+        );
+
+        let cell = notebook.selected_cell_mut();
+        assert_eq!(cell.execution_history.len(), MAX_NOTEBOOK_RUN_HISTORY);
+        assert_eq!(cell.execution_history[0].execution_id, 3);
+        assert!(cell.restore_run_source(0));
+        assert_eq!(cell.source(), "SELECT 3");
+        assert!(!cell.restore_run_source(MAX_NOTEBOOK_RUN_HISTORY));
+    }
+
+    #[test]
+    fn pushing_completed_runs_keeps_only_newest_records() {
+        use crate::session::{NotebookRunStatus, MAX_NOTEBOOK_RUN_HISTORY};
+
+        let mut cell = NotebookCell::new(CellId(1));
+        for index in 0..MAX_NOTEBOOK_RUN_HISTORY + 1 {
+            cell.push_run(NotebookRunRecord {
+                execution_id: index as u64,
+                source_revision: index as u64,
+                source: format!("SELECT {index}"),
+                status: NotebookRunStatus::Succeeded,
+                finished_at: "2026-07-11T12:00:00Z".parse().unwrap(),
+                elapsed_ms: 2,
+                row_count: 1,
+                headers: vec!["value".to_string()],
+                rows: vec![vec![index.to_string()]],
+                error: None,
+                truncated: false,
+            });
+        }
+
+        assert_eq!(cell.execution_history.len(), MAX_NOTEBOOK_RUN_HISTORY);
+        assert_eq!(cell.execution_history.first().unwrap().execution_id, 1);
+        assert_eq!(
+            cell.execution_history.last().unwrap().execution_id,
+            MAX_NOTEBOOK_RUN_HISTORY as u64
+        );
     }
 }

--- a/crates/tsql/src/app/notebook_export.rs
+++ b/crates/tsql/src/app/notebook_export.rs
@@ -1,0 +1,559 @@
+//! Bounded, atomic exports for retained PostgreSQL notebook results.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use futures_util::TryStreamExt;
+use tokio::fs::{self, File};
+use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio_postgres::{Client, SimpleQueryMessage};
+use uuid::Uuid;
+
+use super::pg_snapshot::{validate_snapshot_identity, PgTempSnapshot};
+use super::refinement::ResultVersion;
+use crate::ui::quote_identifier;
+
+/// File format for a streamed notebook-result export.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum NotebookExportFormat {
+    Csv,
+    Json,
+    Tsv,
+    Sql { table: String },
+}
+
+impl NotebookExportFormat {
+    pub(crate) fn label(&self) -> &'static str {
+        match self {
+            Self::Csv => "CSV",
+            Self::Json => "JSON",
+            Self::Tsv => "TSV",
+            Self::Sql { .. } => "SQL",
+        }
+    }
+}
+
+/// Stream a retained snapshot to a temporary sibling file, then atomically replace the target.
+///
+/// Rows are formatted and written as they arrive; a full retained result is never held in memory.
+pub(crate) async fn export_snapshot(
+    client: &Client,
+    snapshot: &PgTempSnapshot,
+    version: ResultVersion,
+    path: &Path,
+    format: &NotebookExportFormat,
+    cancelled: &Arc<AtomicBool>,
+) -> Result<usize, String> {
+    if cancelled.load(Ordering::Acquire) {
+        return Err("export cancelled".to_string());
+    }
+    validate_snapshot_identity(client, snapshot).await?;
+
+    let qualified = format!(
+        "pg_temp.\"{}\"",
+        snapshot.physical_name.replace('"', "\"\"")
+    );
+    let columns = snapshot
+        .public_columns
+        .iter()
+        .map(|column| format!("\"{}\"", column.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let ordinal = format!("__tsql_row_ordinal_{:016x}", version.source_execution.0);
+    let query = format!("SELECT {columns} FROM {qualified} ORDER BY \"{ordinal}\"");
+
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| format!("invalid export path: {}", path.display()))?;
+    let temporary = path.with_file_name(format!(".{file_name}.{}.part", Uuid::new_v4().simple()));
+    let result = write_snapshot(client, &query, snapshot, &temporary, format, cancelled).await;
+    match result {
+        Ok(rows) => {
+            if let Err(error) = fs::rename(&temporary, path).await {
+                let _ = fs::remove_file(&temporary).await;
+                return Err(format!("failed to replace {}: {error}", path.display()));
+            }
+            Ok(rows)
+        }
+        Err(error) => {
+            let _ = fs::remove_file(&temporary).await;
+            Err(error)
+        }
+    }
+}
+
+async fn write_snapshot(
+    client: &Client,
+    query: &str,
+    snapshot: &PgTempSnapshot,
+    path: &PathBuf,
+    format: &NotebookExportFormat,
+    cancelled: &Arc<AtomicBool>,
+) -> Result<usize, String> {
+    let file = File::create(path)
+        .await
+        .map_err(|error| format!("failed to create {}: {error}", path.display()))?;
+    let mut writer = BufWriter::new(file);
+    write_header(&mut writer, &snapshot.public_columns, format).await?;
+
+    let stream = client
+        .simple_query_raw(query)
+        .await
+        .map_err(|error| format!("failed to read retained result: {error}"))?;
+    tokio::pin!(stream);
+    let mut rows = 0usize;
+    while let Some(message) = stream
+        .try_next()
+        .await
+        .map_err(|error| format!("failed to read retained result: {error}"))?
+    {
+        if cancelled.load(Ordering::Acquire) {
+            return Err("export cancelled".to_string());
+        }
+        if let SimpleQueryMessage::Row(row) = message {
+            let values = (0..row.len())
+                .map(|index| row.get(index))
+                .collect::<Vec<_>>();
+            write_row(&mut writer, &snapshot.public_columns, &values, format, rows).await?;
+            rows = rows.saturating_add(1);
+        }
+    }
+    if matches!(format, NotebookExportFormat::Json) {
+        writer
+            .write_all(if rows == 0 { b"[]\n" } else { b"\n]\n" })
+            .await
+            .map_err(|error| format!("failed to finish JSON export: {error}"))?;
+    }
+    writer
+        .flush()
+        .await
+        .map_err(|error| format!("failed to flush export: {error}"))?;
+    Ok(rows)
+}
+
+async fn write_header(
+    writer: &mut BufWriter<File>,
+    headers: &[String],
+    format: &NotebookExportFormat,
+) -> Result<(), String> {
+    let line = match format {
+        NotebookExportFormat::Csv => format!(
+            "{}\n",
+            headers
+                .iter()
+                .map(|header| escape_delimited(header, ','))
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        NotebookExportFormat::Tsv => format!(
+            "{}\n",
+            headers
+                .iter()
+                .map(|header| escape_tsv(header))
+                .collect::<Vec<_>>()
+                .join("\t")
+        ),
+        NotebookExportFormat::Json | NotebookExportFormat::Sql { .. } => String::new(),
+    };
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|error| format!("failed to write export header: {error}"))
+}
+
+async fn write_row(
+    writer: &mut BufWriter<File>,
+    headers: &[String],
+    values: &[Option<&str>],
+    format: &NotebookExportFormat,
+    row_index: usize,
+) -> Result<(), String> {
+    let line = match format {
+        NotebookExportFormat::Csv => format!(
+            "{}\n",
+            values
+                .iter()
+                .map(|value| escape_delimited(value.unwrap_or_default(), ','))
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        NotebookExportFormat::Tsv => format!(
+            "{}\n",
+            values
+                .iter()
+                .map(|value| escape_tsv(value.unwrap_or_default()))
+                .collect::<Vec<_>>()
+                .join("\t")
+        ),
+        NotebookExportFormat::Json => {
+            let pairs = headers
+                .iter()
+                .zip(values.iter())
+                .map(|(header, value)| match value {
+                    Some(value) => {
+                        format!("\"{}\": \"{}\"", escape_json(header), escape_json(value))
+                    }
+                    None => format!("\"{}\": null", escape_json(header)),
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            if row_index == 0 {
+                format!("[\n  {{{pairs}}}")
+            } else {
+                format!(",\n  {{{pairs}}}")
+            }
+        }
+        NotebookExportFormat::Sql { table } => {
+            let table = table
+                .split('.')
+                .map(quote_identifier)
+                .collect::<Vec<_>>()
+                .join(".");
+            let columns = headers
+                .iter()
+                .map(|header| quote_identifier(header))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let values = values
+                .iter()
+                .map(|value| {
+                    value.map_or_else(
+                        || "NULL".to_string(),
+                        |value| format!("'{}'", value.replace('\'', "''")),
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("INSERT INTO {table} ({columns}) VALUES ({values});\n")
+        }
+    };
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|error| format!("failed to write export row: {error}"))
+}
+
+fn escape_delimited(value: &str, delimiter: char) -> String {
+    if value.contains([delimiter, '"', '\n', '\r']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+fn escape_tsv(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+fn escape_json(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{0008}' => escaped.push_str("\\b"),
+            '\u{000c}' => escaped.push_str("\\f"),
+            control if control < ' ' => escaped.push_str(&format!("\\u{:04x}", control as u32)),
+            printable => escaped.push(printable),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    use super::{escape_delimited, escape_json, escape_tsv, export_snapshot, NotebookExportFormat};
+    use crate::app::execution::{CellId, ExecutionId};
+    use crate::app::pg_snapshot::PgTempSnapshot;
+    use crate::app::refinement::ResultVersion;
+
+    #[test]
+    fn delimited_fields_quote_special_characters() {
+        assert_eq!(escape_delimited("plain", ','), "plain");
+        assert_eq!(escape_delimited("a,b", ','), "\"a,b\"");
+        assert_eq!(escape_delimited("say \"hi\"", ','), "\"say \"\"hi\"\"\"");
+        assert_eq!(escape_delimited("two\nlines", ','), "\"two\nlines\"");
+    }
+
+    #[test]
+    fn json_and_tsv_fields_keep_row_boundaries_intact() {
+        assert_eq!(escape_tsv("a\tb\nc\\d"), "a\\tb\\nc\\\\d");
+        assert_eq!(escape_json("a\"b\nc\\d\t"), "a\\\"b\\nc\\\\d\\t");
+        assert_eq!(
+            escape_json("back\u{0008} form\u{000c} control\u{0001}"),
+            "back\\b form\\f control\\u0001"
+        );
+    }
+
+    #[test]
+    fn format_labels_are_stable() {
+        assert_eq!(NotebookExportFormat::Csv.label(), "CSV");
+        assert_eq!(NotebookExportFormat::Json.label(), "JSON");
+        assert_eq!(NotebookExportFormat::Tsv.label(), "TSV");
+        assert_eq!(
+            NotebookExportFormat::Sql {
+                table: "result".to_string()
+            }
+            .label(),
+            "SQL"
+        );
+    }
+
+    #[tokio::test]
+    async fn postgres_snapshot_exports_all_formats_in_ordinal_order_and_preserves_values() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        client
+            .batch_execute(
+                r#"
+                CREATE TEMP TABLE "export ""snapshot""" (
+                    "id" text,
+                    "odd, ""name""" text,
+                    "notes" text,
+                    "missing" text,
+                    "__tsql_row_ordinal_000000000000002a" bigint
+                );
+                INSERT INTO "export ""snapshot""" VALUES
+                    ('2', '', 'NULL', 'value', 2),
+                    ('1', 'O''Reilly, "hello"', E'line one\nline two\t\\tail', NULL, 1);
+                "#,
+            )
+            .await
+            .unwrap();
+        let identity = client
+            .query_one(
+                r#"SELECT pg_backend_pid(), 'pg_temp."export ""snapshot"""'::regclass::oid"#,
+                &[],
+            )
+            .await
+            .unwrap();
+        let snapshot = PgTempSnapshot {
+            physical_name: "export \"snapshot\"".to_string(),
+            public_columns: vec![
+                "id".to_string(),
+                "odd, \"name\"".to_string(),
+                "notes".to_string(),
+                "missing".to_string(),
+            ],
+            relation_oid: identity.get(1),
+            connection_generation: 4,
+            backend_pid: identity.get(0),
+            row_count: 2,
+            byte_size: 256,
+        };
+        let version = ResultVersion {
+            source_cell: CellId(3),
+            source_execution: ExecutionId(42),
+            source_revision: 1,
+        };
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let directory = tempfile::tempdir().unwrap();
+
+        let csv = directory.path().join("result.csv");
+        tokio::fs::write(&csv, "stale").await.unwrap();
+        assert_eq!(
+            export_snapshot(
+                &client,
+                &snapshot,
+                version,
+                &csv,
+                &NotebookExportFormat::Csv,
+                &cancelled,
+            )
+            .await
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(&csv).await.unwrap(),
+            concat!(
+                "id,\"odd, \"\"name\"\"\",notes,missing\n",
+                "1,\"O'Reilly, \"\"hello\"\"\",\"line one\nline two\t\\tail\",\n",
+                "2,,NULL,value\n"
+            )
+        );
+
+        let tsv = directory.path().join("result.tsv");
+        assert_eq!(
+            export_snapshot(
+                &client,
+                &snapshot,
+                version,
+                &tsv,
+                &NotebookExportFormat::Tsv,
+                &cancelled,
+            )
+            .await
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(&tsv).await.unwrap(),
+            concat!(
+                "id\todd, \"name\"\tnotes\tmissing\n",
+                "1\tO'Reilly, \"hello\"\tline one\\nline two\\t\\\\tail\t\n",
+                "2\t\tNULL\tvalue\n"
+            )
+        );
+
+        let json = directory.path().join("result.json");
+        assert_eq!(
+            export_snapshot(
+                &client,
+                &snapshot,
+                version,
+                &json,
+                &NotebookExportFormat::Json,
+                &cancelled,
+            )
+            .await
+            .unwrap(),
+            2
+        );
+        let json = serde_json::from_str::<serde_json::Value>(
+            &tokio::fs::read_to_string(&json).await.unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!([
+                {
+                    "id": "1",
+                    "odd, \"name\"": "O'Reilly, \"hello\"",
+                    "notes": "line one\nline two\t\\tail",
+                    "missing": null
+                },
+                {"id": "2", "odd, \"name\"": "", "notes": "NULL", "missing": "value"}
+            ])
+        );
+
+        let sql = directory.path().join("result.sql");
+        assert_eq!(
+            export_snapshot(
+                &client,
+                &snapshot,
+                version,
+                &sql,
+                &NotebookExportFormat::Sql {
+                    table: "reporting.user \"copy\"".to_string()
+                },
+                &cancelled,
+            )
+            .await
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(&sql).await.unwrap(),
+            concat!(
+                "INSERT INTO reporting.\"user \"\"copy\"\"\" ",
+                "(id, \"odd, \"\"name\"\"\", notes, missing) ",
+                "VALUES ('1', 'O''Reilly, \"hello\"', 'line one\nline two\t\\tail', NULL);\n",
+                "INSERT INTO reporting.\"user \"\"copy\"\"\" ",
+                "(id, \"odd, \"\"name\"\"\", notes, missing) ",
+                "VALUES ('2', '', 'NULL', 'value');\n"
+            )
+        );
+
+        let destination_directory = directory.path().join("cannot-replace");
+        tokio::fs::create_dir(&destination_directory).await.unwrap();
+        let error = export_snapshot(
+            &client,
+            &snapshot,
+            version,
+            &destination_directory,
+            &NotebookExportFormat::Csv,
+            &cancelled,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("failed to replace"), "{error}");
+        assert!(destination_directory.is_dir());
+
+        let mut entries = std::fs::read_dir(directory.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        entries.sort();
+        assert_eq!(
+            entries,
+            [
+                std::ffi::OsString::from("cannot-replace"),
+                std::ffi::OsString::from("result.csv"),
+                std::ffi::OsString::from("result.json"),
+                std::ffi::OsString::from("result.sql"),
+                std::ffi::OsString::from("result.tsv")
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_export_preserves_existing_target_and_leaves_no_partial_file() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("result.csv");
+        tokio::fs::write(&target, "keep me").await.unwrap();
+        let snapshot = PgTempSnapshot {
+            physical_name: "missing".to_string(),
+            public_columns: vec!["value".to_string()],
+            relation_oid: 0,
+            connection_generation: 1,
+            backend_pid: 0,
+            row_count: 0,
+            byte_size: 0,
+        };
+        let version = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(1),
+            source_revision: 1,
+        };
+        let cancelled = Arc::new(AtomicBool::new(true));
+
+        let error = export_snapshot(
+            &client,
+            &snapshot,
+            version,
+            &target,
+            &NotebookExportFormat::Csv,
+            &cancelled,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error, "export cancelled");
+        assert_eq!(tokio::fs::read_to_string(&target).await.unwrap(), "keep me");
+        let entries = std::fs::read_dir(directory.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, [std::ffi::OsString::from("result.csv")]);
+    }
+}

--- a/crates/tsql/src/app/notebook_run.rs
+++ b/crates/tsql/src/app/notebook_run.rs
@@ -1,0 +1,283 @@
+//! Dependency-aware execution planning for notebook workflows.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use super::execution::CellId;
+use super::refinement::{logical_result_references, LogicalResultReference};
+
+/// Which portion of the notebook should be queued for execution.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NotebookRunScope {
+    All,
+    Above,
+    Below,
+    Dependents,
+}
+
+/// Produces a stable, dependency-first execution order for non-empty cells.
+///
+/// Numbered references create explicit graph edges. `@result` is ordered after
+/// the nearest preceding source so a full replay preserves its publication
+/// semantics. Dependencies outside a partial run are assumed to be retained.
+#[cfg(test)]
+pub(crate) fn notebook_run_plan(
+    cells: &[(CellId, &str)],
+    selected: CellId,
+    scope: NotebookRunScope,
+) -> Result<Vec<CellId>, String> {
+    notebook_run_plan_inner(cells, selected, scope, true, &HashMap::new())
+}
+
+/// Produces a dependency-first plan with stable named result sources.
+pub(crate) fn notebook_run_plan_with_names(
+    cells: &[(CellId, &str)],
+    selected: CellId,
+    scope: NotebookRunScope,
+    named_sources: &HashMap<String, CellId>,
+) -> Result<Vec<CellId>, String> {
+    notebook_run_plan_inner(cells, selected, scope, true, named_sources)
+}
+
+/// Produces a document-order plan for backends without logical-result references.
+pub(crate) fn notebook_run_plan_without_references(
+    cells: &[(CellId, &str)],
+    selected: CellId,
+    scope: NotebookRunScope,
+) -> Result<Vec<CellId>, String> {
+    notebook_run_plan_inner(cells, selected, scope, false, &HashMap::new())
+}
+
+fn notebook_run_plan_inner(
+    cells: &[(CellId, &str)],
+    selected: CellId,
+    scope: NotebookRunScope,
+    parse_references: bool,
+    named_sources: &HashMap<String, CellId>,
+) -> Result<Vec<CellId>, String> {
+    let positions = cells
+        .iter()
+        .enumerate()
+        .map(|(index, (id, _))| (*id, index))
+        .collect::<HashMap<_, _>>();
+    let selected_index = positions
+        .get(&selected)
+        .copied()
+        .ok_or_else(|| format!("Cell {} is not present in the notebook", selected.0))?;
+    let runnable = cells
+        .iter()
+        .filter_map(|(id, source)| (!source.trim().is_empty()).then_some(*id))
+        .collect::<HashSet<_>>();
+
+    let mut dependencies = HashMap::<CellId, Vec<CellId>>::new();
+    for (index, (cell, source)) in cells.iter().enumerate() {
+        if !runnable.contains(cell) {
+            continue;
+        }
+        let mut sources = Vec::new();
+        let references = if parse_references {
+            logical_result_references(source)?
+        } else {
+            Vec::new()
+        };
+        for reference in references {
+            let dependency = match reference {
+                LogicalResultReference::Cell(source_cell) => {
+                    if !positions.contains_key(&source_cell) {
+                        return Err(format!(
+                            "Cell {} references missing cell {}",
+                            cell.0, source_cell.0
+                        ));
+                    }
+                    Some(source_cell)
+                }
+                LogicalResultReference::Latest => cells[..index]
+                    .iter()
+                    .rev()
+                    .find_map(|(id, _)| runnable.contains(id).then_some(*id)),
+                LogicalResultReference::Named(name) => {
+                    Some(*named_sources.get(&name).ok_or_else(|| {
+                        format!("Cell {} references unknown result name '{}'", cell.0, name)
+                    })?)
+                }
+            };
+            if dependency == Some(*cell) {
+                return Err(format!("Cell {} depends on itself", cell.0));
+            }
+            if let Some(dependency) = dependency.filter(|dependency| !sources.contains(dependency))
+            {
+                sources.push(dependency);
+            }
+        }
+        dependencies.insert(*cell, sources);
+    }
+
+    let requested = match scope {
+        NotebookRunScope::All => runnable.clone(),
+        NotebookRunScope::Above => cells[..=selected_index]
+            .iter()
+            .filter_map(|(id, _)| runnable.contains(id).then_some(*id))
+            .collect(),
+        NotebookRunScope::Below => cells[selected_index..]
+            .iter()
+            .filter_map(|(id, _)| runnable.contains(id).then_some(*id))
+            .collect(),
+        NotebookRunScope::Dependents => {
+            let mut reverse = HashMap::<CellId, Vec<CellId>>::new();
+            for (cell, sources) in &dependencies {
+                for source in sources {
+                    reverse.entry(*source).or_default().push(*cell);
+                }
+            }
+            let mut requested = HashSet::new();
+            let mut pending = VecDeque::from([selected]);
+            while let Some(cell) = pending.pop_front() {
+                if !requested.insert(cell) {
+                    continue;
+                }
+                if let Some(dependents) = reverse.get(&cell) {
+                    pending.extend(dependents.iter().copied());
+                }
+            }
+            requested.retain(|cell| runnable.contains(cell));
+            requested
+        }
+    };
+
+    let mut remaining = requested.clone();
+    let mut ordered = Vec::with_capacity(requested.len());
+    while !remaining.is_empty() {
+        let next = cells.iter().map(|(id, _)| *id).find(|cell| {
+            remaining.contains(cell)
+                && dependencies
+                    .get(cell)
+                    .is_none_or(|sources| sources.iter().all(|source| !remaining.contains(source)))
+        });
+        let Some(next) = next else {
+            return Err("Notebook result dependencies contain a cycle".to_string());
+        };
+        remaining.remove(&next);
+        ordered.push(next);
+    }
+
+    Ok(ordered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_all_orders_dependencies_before_out_of_order_cells() {
+        let cells = [
+            (CellId(8), "SELECT * FROM @result_4"),
+            (CellId(2), "SELECT 1"),
+            (CellId(4), "SELECT * FROM @result_2"),
+            (CellId(9), "  "),
+        ];
+
+        assert_eq!(
+            notebook_run_plan(&cells, CellId(8), NotebookRunScope::All),
+            Ok(vec![CellId(2), CellId(4), CellId(8)])
+        );
+    }
+
+    #[test]
+    fn run_dependents_only_queues_the_selected_tree() {
+        let cells = [
+            (CellId(1), "SELECT 1"),
+            (CellId(2), "SELECT * FROM @result_1"),
+            (CellId(3), "SELECT * FROM @result_2"),
+            (CellId(4), "SELECT 4"),
+        ];
+
+        assert_eq!(
+            notebook_run_plan(&cells, CellId(2), NotebookRunScope::Dependents),
+            Ok(vec![CellId(2), CellId(3)])
+        );
+    }
+
+    #[test]
+    fn latest_reference_runs_after_the_nearest_preceding_source() {
+        let cells = [
+            (CellId(1), "SELECT 1"),
+            (CellId(2), "SELECT 2"),
+            (CellId(3), "SELECT * FROM @result"),
+        ];
+
+        assert_eq!(
+            notebook_run_plan(&cells, CellId(2), NotebookRunScope::Below),
+            Ok(vec![CellId(2), CellId(3)])
+        );
+    }
+
+    #[test]
+    fn multiple_numbered_sources_run_before_their_join() {
+        let cells = [
+            (
+                CellId(9),
+                "SELECT * FROM @result_4 a JOIN @result_2 b ON true",
+            ),
+            (CellId(2), "SELECT 2"),
+            (CellId(4), "SELECT 4"),
+        ];
+
+        assert_eq!(
+            notebook_run_plan(&cells, CellId(9), NotebookRunScope::All),
+            Ok(vec![CellId(2), CellId(4), CellId(9)])
+        );
+    }
+
+    #[test]
+    fn detects_missing_sources_and_cycles() {
+        let missing = [(CellId(1), "SELECT * FROM @result_9")];
+        assert_eq!(
+            notebook_run_plan(&missing, CellId(1), NotebookRunScope::All),
+            Err("Cell 1 references missing cell 9".to_string())
+        );
+
+        let cycle = [
+            (CellId(1), "SELECT * FROM @result_2"),
+            (CellId(2), "SELECT * FROM @result_1"),
+        ];
+        assert_eq!(
+            notebook_run_plan(&cycle, CellId(1), NotebookRunScope::All),
+            Err("Notebook result dependencies contain a cycle".to_string())
+        );
+    }
+
+    #[test]
+    fn document_order_planner_does_not_parse_mongo_shell_as_sql() {
+        let cells = [
+            (CellId(4), "db.users.find({ note: `@result_foo` })"),
+            (CellId(2), "// @result_1\ndb.users.find({ active: true })"),
+            (CellId(8), "db.users.find({ text: '@result_99' })"),
+        ];
+
+        assert_eq!(
+            notebook_run_plan_without_references(&cells, CellId(2), NotebookRunScope::All),
+            Ok(vec![CellId(4), CellId(2), CellId(8)])
+        );
+        assert_eq!(
+            notebook_run_plan_without_references(&cells, CellId(2), NotebookRunScope::Dependents),
+            Ok(vec![CellId(2)])
+        );
+    }
+
+    #[test]
+    fn named_sources_participate_in_dependency_ordering() {
+        let cells = [
+            (CellId(8), "SELECT * FROM @result_recent_users"),
+            (CellId(2), "SELECT 1"),
+        ];
+        let names = HashMap::from([("recent_users".to_string(), CellId(2))]);
+
+        assert_eq!(
+            notebook_run_plan_with_names(&cells, CellId(8), NotebookRunScope::All, &names),
+            Ok(vec![CellId(2), CellId(8)])
+        );
+        assert_eq!(
+            notebook_run_plan(&cells, CellId(8), NotebookRunScope::All),
+            Err("Cell 8 references unknown result name 'recent_users'".to_string())
+        );
+    }
+}

--- a/crates/tsql/src/app/pg_snapshot.rs
+++ b/crates/tsql/src/app/pg_snapshot.rs
@@ -1,15 +1,18 @@
 //! PostgreSQL session-local TEMP-table refinement provider.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Instant;
 
-use tokio_postgres::SimpleQueryMessage;
+use tokio_postgres::{types::Kind, SimpleQueryMessage};
 
 use super::app::{QueryResult, SharedClient};
 use super::execution::ExecutionContext;
 use super::refinement::{
-    RefinementProviderId, ResultVersion, RetainedResult, RetainedResultHandle,
+    RefinementProviderId, ResultVersion, RetainedResult, RetainedResultHandle, SqlSourceMap,
 };
-use crate::util::format_pg_error;
+use super::sql_lexer;
+use crate::util::{format_pg_error, format_pg_error_with_position};
 
 /// Backend resource tracked by the PostgreSQL snapshot manager.
 #[derive(Clone, Debug)]
@@ -21,6 +24,51 @@ pub struct PgTempSnapshot {
     pub backend_pid: i32,
     pub row_count: usize,
     pub byte_size: u64,
+}
+
+/// Checks that a retained relation still belongs to the expected backend session.
+pub(crate) async fn validate_snapshot_identity(
+    client: &tokio_postgres::Client,
+    snapshot: &PgTempSnapshot,
+) -> Result<(), String> {
+    let qualified = format!("pg_temp.{}", quote_identifier(&snapshot.physical_name));
+    let identity = client
+        .query_one(
+            "SELECT pg_backend_pid(), to_regclass($1)::oid",
+            &[&qualified],
+        )
+        .await
+        .map_err(|error| pg_error("failed to validate source snapshot", &error))?;
+    let backend_pid: i32 = identity.get(0);
+    let relation_oid: Option<u32> = identity.get(1);
+    if backend_pid != snapshot.backend_pid || relation_oid != Some(snapshot.relation_oid) {
+        return Err("source snapshot is no longer available on this session".to_string());
+    }
+    Ok(())
+}
+
+/// Drops a retained relation only while its backend PID and relation OID still match.
+pub(crate) async fn drop_if_identity_matches(
+    client: &tokio_postgres::Client,
+    snapshot: &PgTempSnapshot,
+) -> Result<(), String> {
+    let qualified = format!("pg_temp.{}", quote_identifier(&snapshot.physical_name));
+    let identity = client
+        .query_one(
+            "SELECT pg_backend_pid(), to_regclass($1)::oid",
+            &[&qualified],
+        )
+        .await
+        .map_err(|error| pg_error("failed to inspect snapshot before cleanup", &error))?;
+    let backend_pid: i32 = identity.get(0);
+    let relation_oid: Option<u32> = identity.get(1);
+    if backend_pid != snapshot.backend_pid || relation_oid != Some(snapshot.relation_oid) {
+        return Ok(());
+    }
+    client
+        .batch_execute(&format!("DROP TABLE IF EXISTS {qualified}"))
+        .await
+        .map_err(|error| pg_error("failed to discard snapshot", &error))
 }
 
 pub(crate) struct PgSnapshotResult {
@@ -37,7 +85,17 @@ pub(crate) struct PgSnapshotRequest {
     pub display_max_rows: usize,
     pub max_bytes: u64,
     pub timeout_secs: u32,
-    pub source_snapshot: Option<PgTempSnapshot>,
+    pub source_snapshots: Vec<PgTempSnapshot>,
+    pub cancelled: Option<Arc<AtomicBool>>,
+    pub source_map: Option<SqlSourceMap>,
+}
+
+/// Result of a side-effect-free snapshot eligibility check.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SnapshotEligibility {
+    Eligible(String),
+    Ineligible(String),
+    Invalid(String),
 }
 
 pub(crate) async fn execute(
@@ -45,8 +103,17 @@ pub(crate) async fn execute(
     request: PgSnapshotRequest,
 ) -> Result<PgSnapshotResult, String> {
     let started = Instant::now();
-    let source = snapshot_source(&request.query)?;
+    let mut source = snapshot_source(&request.query)?;
+    let leading = &request.query[..request.query.len() - request.query.trim_start().len()];
+    source.insert_str(0, leading);
     let mut guard = client.lock().await;
+    if request
+        .cancelled
+        .as_ref()
+        .is_some_and(|cancelled| cancelled.load(Ordering::Acquire))
+    {
+        return Err("query cancelled before snapshot execution".to_string());
+    }
     let transaction = guard
         .transaction()
         .await
@@ -62,7 +129,7 @@ pub(crate) async fn execute(
             .map_err(|error| pg_error("failed to set snapshot timeout", &error))?;
     }
 
-    if let Some(expected) = &request.source_snapshot {
+    for expected in &request.source_snapshots {
         let qualified = format!("pg_temp.{}", quote_identifier(&expected.physical_name));
         let identity = transaction
             .query_one(
@@ -78,44 +145,109 @@ pub(crate) async fn execute(
         }
     }
 
-    let statement = transaction
-        .prepare(&source)
+    let capabilities = transaction
+        .query_one(
+            "SELECT pg_is_in_recovery(), current_setting('transaction_read_only') = 'on', \
+             has_database_privilege(current_database(), 'TEMP')",
+            &[],
+        )
         .await
-        .map_err(|error| pg_error("snapshot preflight failed", &error))?;
+        .map_err(|error| pg_error("failed to inspect snapshot capability", &error))?;
+    let in_recovery: bool = capabilities.get(0);
+    let read_only: bool = capabilities.get(1);
+    let has_temp_privilege: bool = capabilities.get(2);
+    if in_recovery || read_only || !has_temp_privilege {
+        return execute_preview_fallback(
+            transaction,
+            &source,
+            &request,
+            Vec::new(),
+            started,
+            "session cannot create a PostgreSQL TEMP snapshot",
+        )
+        .await;
+    }
+
+    let statement = transaction.prepare(&source).await.map_err(|error| {
+        pg_error_mapped(
+            "snapshot preflight failed",
+            &error,
+            request.source_map.as_ref(),
+            "",
+        )
+    })?;
     if statement.columns().is_empty() {
-        return Err("statement has no row result to retain".to_string());
+        return execute_preview_fallback(
+            transaction,
+            &source,
+            &request,
+            Vec::new(),
+            started,
+            "statement has no row result to retain",
+        )
+        .await;
+    }
+    if !statement.params().is_empty() {
+        return Err("statement contains unbound PostgreSQL parameters".to_string());
     }
     if statement
         .columns()
         .iter()
-        .any(|column| matches!(column.type_().name(), "record" | "void"))
+        .any(|column| contains_pseudo_type(column.type_()))
     {
-        return Err("result contains a PostgreSQL pseudo-type".to_string());
+        let col_types = statement
+            .columns()
+            .iter()
+            .map(|column| column.type_().name().to_string())
+            .collect();
+        return execute_preview_fallback(
+            transaction,
+            &source,
+            &request,
+            col_types,
+            started,
+            "result contains a PostgreSQL pseudo-type",
+        )
+        .await;
     }
 
     let physical_name = format!(
-        "__tsql_nb_{}_{}",
-        request.context.id.0, request.context.source_revision
+        "__tsql_nb_{}_{:016x}",
+        uuid::Uuid::new_v4().simple(),
+        request.context.id.0
     );
-    let ordinal_name = format!("__tsql_row_ordinal_{}", request.context.id.0);
-    let output_names =
-        normalize_column_names(statement.columns().iter().map(|column| column.name()));
+    let ordinal_name = format!("__tsql_row_ordinal_{:016x}", request.context.id.0);
+    let output_names = normalize_column_names(
+        statement.columns().iter().map(|column| column.name()),
+        &ordinal_name,
+    );
     let mut table_columns = Vec::with_capacity(output_names.len() + 1);
     table_columns.push(quote_identifier(&ordinal_name));
     table_columns.extend(output_names.iter().map(|name| quote_identifier(name)));
-    let create_sql = format!(
+    let create_prefix = format!(
         "CREATE TEMP TABLE {} ({}) ON COMMIT PRESERVE ROWS AS \
-         SELECT row_number() OVER (), __tsql_source.* FROM ({}) AS __tsql_source \
-         LIMIT {}",
+         SELECT row_number() OVER (), __tsql_source.* FROM (\n",
         quote_identifier(&physical_name),
-        table_columns.join(", "),
-        source,
-        request.max_rows.saturating_add(1)
+        table_columns.join(", ")
+    );
+    let create_sql = format!(
+        "{create_prefix}{source}\n) AS __tsql_source LIMIT {}",
+        request
+            .max_rows
+            .saturating_add(1)
+            .max(request.display_max_rows)
     );
     transaction
         .batch_execute(&create_sql)
         .await
-        .map_err(|error| pg_error("snapshot materialization failed", &error))?;
+        .map_err(|error| {
+            pg_error_mapped(
+                "snapshot materialization failed",
+                &error,
+                request.source_map.as_ref(),
+                &create_prefix,
+            )
+        })?;
 
     let qualified_name = format!("pg_temp.{}", quote_identifier(&physical_name));
     let count_sql = format!("SELECT count(*)::bigint FROM {qualified_name}");
@@ -134,6 +266,8 @@ pub(crate) async fn execute(
         .get(0);
     let byte_size = u64::try_from(byte_size_i64)
         .map_err(|_| "snapshot returned an invalid relation size".to_string())?;
+    let display_max_rows =
+        notebook_preview_row_limit(row_count, byte_size, request.display_max_rows);
 
     let select_columns = output_names
         .iter()
@@ -144,13 +278,16 @@ pub(crate) async fn execute(
         "SELECT {select_columns} FROM {qualified_name} \
          ORDER BY {} LIMIT {}",
         quote_identifier(&ordinal_name),
-        request.display_max_rows
+        display_max_rows
     );
     let messages = transaction
         .simple_query(&display_sql)
         .await
         .map_err(|error| pg_error("failed to read snapshot result", &error))?;
-    let (headers, rows) = display_rows(messages, request.display_max_rows);
+    let (mut headers, rows, null_cells) = display_rows(messages, display_max_rows);
+    if headers.is_empty() {
+        headers.clone_from(&output_names);
+    }
     let complete = row_count <= request.max_rows && byte_size <= request.max_bytes;
 
     let (retained, snapshot) = if complete {
@@ -210,8 +347,9 @@ pub(crate) async fn execute(
         query_result: QueryResult {
             headers,
             rows,
+            null_cells,
             command_tag: Some(format!("SELECT {row_count}")),
-            truncated: !complete || row_count > request.display_max_rows,
+            truncated: !complete || row_count > display_max_rows,
             elapsed: started.elapsed(),
             source_table: None,
             primary_keys: Vec::new(),
@@ -230,174 +368,255 @@ fn pg_error(context: &str, error: &tokio_postgres::Error) -> String {
     format!("{context}: {}", format_pg_error(error))
 }
 
+fn pg_error_mapped(
+    context: &str,
+    error: &tokio_postgres::Error,
+    source_map: Option<&SqlSourceMap>,
+    generated_prefix: &str,
+) -> String {
+    format!(
+        "{context}: {}",
+        format_pg_error_with_position(error, |position| {
+            source_map.and_then(|source_map| source_map.map_position(position, generated_prefix))
+        })
+    )
+}
+
+async fn execute_preview_fallback(
+    transaction: tokio_postgres::Transaction<'_>,
+    source: &str,
+    request: &PgSnapshotRequest,
+    col_types: Vec<String>,
+    started: Instant,
+    reason: &str,
+) -> Result<PgSnapshotResult, String> {
+    let cursor = format!("__tsql_nb_preview_{:016x}", request.context.id.0);
+    let preview_prefix = format!(
+        "DECLARE {} NO SCROLL CURSOR FOR\n",
+        quote_identifier(&cursor)
+    );
+    transaction
+        .batch_execute(&format!("{preview_prefix}{source}\n"))
+        .await
+        .map_err(|error| {
+            pg_error_mapped(
+                &format!("{reason}; preview failed"),
+                &error,
+                request.source_map.as_ref(),
+                &preview_prefix,
+            )
+        })?;
+    let messages = transaction
+        .simple_query(&format!(
+            "FETCH FORWARD {} FROM {}",
+            request.display_max_rows.saturating_add(1),
+            quote_identifier(&cursor)
+        ))
+        .await
+        .map_err(|error| pg_error("failed to read notebook preview", &error))?;
+    let (headers, mut rows, mut null_cells) =
+        display_rows(messages, request.display_max_rows.saturating_add(1));
+    let truncated = rows.len() > request.display_max_rows;
+    rows.truncate(request.display_max_rows);
+    null_cells.truncate(request.display_max_rows);
+    transaction
+        .rollback()
+        .await
+        .map_err(|error| pg_error("failed to close notebook preview", &error))?;
+
+    Ok(PgSnapshotResult {
+        query_result: QueryResult {
+            headers,
+            command_tag: Some(format!("SELECT {}", rows.len())),
+            rows,
+            null_cells,
+            truncated,
+            elapsed: started.elapsed(),
+            source_table: None,
+            primary_keys: Vec::new(),
+            col_types,
+        },
+        retained: None,
+        snapshot: None,
+    })
+}
+
 fn snapshot_source(query: &str) -> Result<String, String> {
-    let trimmed = query.trim();
-    let bytes = trimmed.as_bytes();
-    let mut index = 0;
-    let mut terminal_semicolon = None;
-    let mut comment_ranges = Vec::new();
-
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\'' | b'"' => {
-                if terminal_semicolon.is_some() {
-                    return Err(
-                        "multiple statements are not eligible for a session snapshot".to_string(),
-                    );
-                }
-                let delimiter = bytes[index];
-                index += 1;
-                loop {
-                    let Some(offset) = trimmed[index..].find(delimiter as char) else {
-                        return Err("unterminated SQL literal".to_string());
-                    };
-                    index += offset + 1;
-                    if bytes.get(index) == Some(&delimiter) {
-                        index += 1;
-                    } else {
-                        break;
-                    }
-                }
-            }
-            b'$' => {
-                let Some(tag_end_offset) = trimmed[index + 1..].find('$') else {
-                    if terminal_semicolon.is_some() {
-                        return Err(
-                            "multiple statements are not eligible for a session snapshot"
-                                .to_string(),
-                        );
-                    }
-                    index += 1;
-                    continue;
-                };
-                let tag_end = index + 1 + tag_end_offset;
-                let tag = &trimmed[index + 1..tag_end];
-                let mut characters = tag.chars();
-                let valid_tag = characters.next().is_none_or(|character| {
-                    (character.is_ascii_alphabetic() || character == '_')
-                        && characters
-                            .all(|character| character.is_ascii_alphanumeric() || character == '_')
-                });
-                if !valid_tag {
-                    if terminal_semicolon.is_some() {
-                        return Err(
-                            "multiple statements are not eligible for a session snapshot"
-                                .to_string(),
-                        );
-                    }
-                    index += 1;
-                    continue;
-                }
-                if terminal_semicolon.is_some() {
-                    return Err(
-                        "multiple statements are not eligible for a session snapshot".to_string(),
-                    );
-                }
-                let delimiter = &trimmed[index..=tag_end];
-                let content_start = tag_end + 1;
-                let Some(close_offset) = trimmed[content_start..].find(delimiter) else {
-                    return Err("unterminated dollar-quoted SQL literal".to_string());
-                };
-                index = content_start + close_offset + delimiter.len();
-            }
-            b'-' if bytes.get(index + 1) == Some(&b'-') => {
-                let start = index;
-                index = trimmed[index..]
-                    .find('\n')
-                    .map_or(bytes.len(), |offset| index + offset + 1);
-                comment_ranges.push((start, index));
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'*') => {
-                let start = index;
-                let mut depth = 1;
-                index += 2;
-                while index < bytes.len() && depth > 0 {
-                    if bytes.get(index..index + 2) == Some(b"/*") {
-                        depth += 1;
-                        index += 2;
-                    } else if bytes.get(index..index + 2) == Some(b"*/") {
-                        depth -= 1;
-                        index += 2;
-                    } else {
-                        index += trimmed[index..].chars().next().unwrap().len_utf8();
-                    }
-                }
-                if depth > 0 {
-                    return Err("unterminated SQL comment".to_string());
-                }
-                comment_ranges.push((start, index));
-            }
-            b';' => {
-                if terminal_semicolon.is_some() {
-                    return Err(
-                        "multiple statements are not eligible for a session snapshot".to_string(),
-                    );
-                }
-                terminal_semicolon = Some(index);
-                index += 1;
-            }
-            _ => {
-                let character = trimmed[index..].chars().next().unwrap();
-                if terminal_semicolon.is_some() && !character.is_whitespace() {
-                    return Err(
-                        "multiple statements are not eligible for a session snapshot".to_string(),
-                    );
-                }
-                index += character.len_utf8();
-            }
+    match snapshot_eligibility(query) {
+        SnapshotEligibility::Eligible(source) => Ok(source),
+        SnapshotEligibility::Ineligible(reason) | SnapshotEligibility::Invalid(reason) => {
+            Err(reason)
         }
     }
+}
 
-    let source = terminal_semicolon.map_or(trimmed, |index| trimmed[..index].trim_end());
-    let mut parser_source = source.to_string();
-    for (start, end) in comment_ranges.into_iter().rev() {
-        if start < parser_source.len() {
-            parser_source.replace_range(start..end.min(parser_source.len()), " ");
-        }
+/// Classifies a single PostgreSQL statement without executing it.
+pub(crate) fn snapshot_eligibility(query: &str) -> SnapshotEligibility {
+    let source = match sql_lexer::single_statement(query) {
+        Ok(source) => source,
+        Err(error) => return SnapshotEligibility::Invalid(error),
+    };
+    let words = match sql_lexer::code_words(source, usize::MAX) {
+        Ok(words) => words,
+        Err(error) => return SnapshotEligibility::Invalid(error),
+    };
+    let Some(first) = words.first().map(String::as_str) else {
+        return SnapshotEligibility::Invalid("empty SQL statement".to_string());
+    };
+    if !matches!(first, "SELECT" | "WITH" | "VALUES" | "TABLE") {
+        return SnapshotEligibility::Ineligible(
+            "statement is not eligible for a session snapshot".to_string(),
+        );
     }
+    if has_unbound_parameter(source) {
+        return SnapshotEligibility::Ineligible(
+            "statement contains unbound PostgreSQL parameters".to_string(),
+        );
+    }
+    if has_locking_clause(&words) {
+        return SnapshotEligibility::Ineligible(
+            "locking queries are not eligible for a session snapshot".to_string(),
+        );
+    }
+
+    // tree-sitter-sequel does not currently accept standalone VALUES or TABLE,
+    // both of which are valid PostgreSQL row-producing statements.
+    if matches!(first, "VALUES" | "TABLE") {
+        return SnapshotEligibility::Eligible(source.to_string());
+    }
+    let parser_source = match sql_lexer::mask_comments(source) {
+        Ok(source) => source,
+        Err(error) => return SnapshotEligibility::Invalid(error),
+    };
     let mut parser = tree_sitter::Parser::new();
-    parser
-        .set_language(&tree_sitter_sequel::LANGUAGE.into())
-        .map_err(|error| format!("failed to initialize SQL parser: {error}"))?;
-    let tree = parser
-        .parse(&parser_source, None)
-        .ok_or_else(|| "failed to parse SQL statement".to_string())?;
+    if let Err(error) = parser.set_language(&tree_sitter_sequel::LANGUAGE.into()) {
+        return SnapshotEligibility::Invalid(format!("failed to initialize SQL parser: {error}"));
+    }
+    let Some(tree) = parser.parse(&parser_source, None) else {
+        return SnapshotEligibility::Invalid("failed to parse SQL statement".to_string());
+    };
     let root = tree.root_node();
     if root.has_error() || root.named_child_count() != 1 {
-        return Err("statement shape is not eligible for a session snapshot".to_string());
+        return SnapshotEligibility::Ineligible(
+            "statement shape is not eligible for a session snapshot".to_string(),
+        );
     }
-    let first = parser_source
-        .split_whitespace()
-        .next()
-        .unwrap_or_default()
-        .to_ascii_uppercase();
-    if !matches!(first.as_str(), "SELECT" | "WITH" | "VALUES" | "TABLE") {
-        return Err("statement is not eligible for a session snapshot".to_string());
+    if tree_contains_kind(
+        root,
+        &[
+            "insert",
+            "update",
+            "delete",
+            "keyword_merge",
+            "keyword_copy",
+            "keyword_truncate",
+        ],
+    ) {
+        return SnapshotEligibility::Ineligible(
+            "statement contains a data-changing or transaction-control clause".to_string(),
+        );
     }
-    Ok(source.to_string())
+    if tree_contains_kind(root, &["keyword_into"]) {
+        return SnapshotEligibility::Ineligible(
+            "SELECT INTO is not eligible for a session snapshot".to_string(),
+        );
+    }
+    SnapshotEligibility::Eligible(source.to_string())
+}
+
+fn tree_contains_kind(root: tree_sitter::Node<'_>, kinds: &[&str]) -> bool {
+    let mut pending = vec![root];
+    while let Some(node) = pending.pop() {
+        if kinds.contains(&node.kind()) {
+            return true;
+        }
+        let mut cursor = node.walk();
+        pending.extend(node.children(&mut cursor));
+    }
+    false
 }
 
 pub(crate) fn is_snapshot_candidate(query: &str) -> bool {
-    snapshot_source(query).is_ok()
+    matches!(
+        snapshot_eligibility(query),
+        SnapshotEligibility::Eligible(_)
+    )
 }
 
-fn normalize_column_names<'a>(names: impl Iterator<Item = &'a str>) -> Vec<String> {
-    let mut used = std::collections::HashSet::new();
+fn has_unbound_parameter(source: &str) -> bool {
+    sql_lexer::scan(source).is_ok_and(|segments| {
+        segments.into_iter().any(|segment| {
+            segment.kind == sql_lexer::SqlSegmentKind::Code
+                && source[segment.range]
+                    .as_bytes()
+                    .windows(2)
+                    .any(|pair| pair[0] == b'$' && pair[1].is_ascii_digit())
+        })
+    })
+}
+
+fn has_locking_clause(words: &[String]) -> bool {
+    words.windows(2).any(|pair| {
+        pair[0] == "FOR" && matches!(pair[1].as_str(), "UPDATE" | "SHARE" | "KEY" | "NO")
+    })
+}
+
+fn contains_pseudo_type(type_: &tokio_postgres::types::Type) -> bool {
+    match type_.kind() {
+        Kind::Pseudo => true,
+        Kind::Array(inner) | Kind::Range(inner) | Kind::Multirange(inner) | Kind::Domain(inner) => {
+            contains_pseudo_type(inner)
+        }
+        Kind::Composite(fields) => fields
+            .iter()
+            .any(|field| contains_pseudo_type(field.type_())),
+        _ => false,
+    }
+}
+
+const POSTGRES_IDENTIFIER_BYTES: usize = 63;
+const MAX_NOTEBOOK_PREVIEW_BYTES: u64 = 8 * 1024 * 1024;
+
+fn notebook_preview_row_limit(row_count: usize, byte_size: u64, requested: usize) -> usize {
+    if row_count == 0 || byte_size <= MAX_NOTEBOOK_PREVIEW_BYTES {
+        return requested;
+    }
+    let rows_within_budget = MAX_NOTEBOOK_PREVIEW_BYTES
+        .saturating_mul(row_count as u64)
+        .checked_div(byte_size)
+        .unwrap_or(0)
+        .max(1);
+    requested.min(usize::try_from(rows_within_budget).unwrap_or(usize::MAX))
+}
+
+fn normalize_column_names<'a>(names: impl Iterator<Item = &'a str>, reserved: &str) -> Vec<String> {
+    let mut used = std::collections::HashSet::from([reserved.to_string()]);
     names
         .enumerate()
         .map(|(index, name)| {
             let base = if name.is_empty() {
                 format!("column_{}", index + 1)
             } else {
-                name.chars().take(50).collect()
+                name.to_string()
             };
-            let mut candidate = base.clone();
-            let mut suffix = 2;
-            while !used.insert(candidate.clone()) {
-                candidate = format!("{base}_{suffix}");
+            let mut suffix = 1usize;
+            loop {
+                let ending = if suffix == 1 {
+                    String::new()
+                } else {
+                    format!("_{suffix}")
+                };
+                let byte_budget = POSTGRES_IDENTIFIER_BYTES.saturating_sub(ending.len());
+                let mut end = base.len().min(byte_budget);
+                while !base.is_char_boundary(end) {
+                    end -= 1;
+                }
+                let candidate = format!("{}{ending}", &base[..end]);
+                if used.insert(candidate.clone()) {
+                    return candidate;
+                }
                 suffix += 1;
             }
-            candidate
         })
         .collect()
 }
@@ -409,28 +628,42 @@ fn quote_identifier(identifier: &str) -> String {
 fn display_rows(
     messages: Vec<SimpleQueryMessage>,
     max_rows: usize,
-) -> (Vec<String>, Vec<Vec<String>>) {
+) -> (Vec<String>, Vec<Vec<String>>, Vec<Vec<bool>>) {
     let mut headers = Vec::new();
     let mut rows = Vec::new();
+    let mut null_cells = Vec::new();
     for message in messages {
-        if let SimpleQueryMessage::Row(row) = message {
-            if headers.is_empty() {
-                headers = row
-                    .columns()
+        match message {
+            SimpleQueryMessage::Row(row) => {
+                if headers.is_empty() {
+                    headers = row
+                        .columns()
+                        .iter()
+                        .map(|column| column.name().to_string())
+                        .collect();
+                }
+                if rows.len() < max_rows {
+                    let mut values = Vec::with_capacity(row.len());
+                    let mut null_row = Vec::with_capacity(row.len());
+                    for index in 0..row.len() {
+                        let cell = row.get(index);
+                        null_row.push(cell.is_none());
+                        values.push(cell.unwrap_or("NULL").to_string());
+                    }
+                    rows.push(values);
+                    null_cells.push(null_row);
+                }
+            }
+            SimpleQueryMessage::RowDescription(columns) if headers.is_empty() => {
+                headers = columns
                     .iter()
                     .map(|column| column.name().to_string())
                     .collect();
             }
-            if rows.len() < max_rows {
-                rows.push(
-                    (0..row.len())
-                        .map(|index| row.get(index).unwrap_or("NULL").to_string())
-                        .collect(),
-                );
-            }
+            _ => {}
         }
     }
-    (headers, rows)
+    (headers, rows, null_cells)
 }
 
 #[cfg(test)]
@@ -443,9 +676,39 @@ mod tests {
     #[test]
     fn normalizes_empty_and_duplicate_columns() {
         assert_eq!(
-            normalize_column_names(["id", "id", ""].into_iter()),
+            normalize_column_names(["id", "id", ""].into_iter(), "__ordinal"),
             ["id", "id_2", "column_3"]
         );
+
+        let unicode = "á".repeat(31);
+        let names = normalize_column_names(
+            [unicode.as_str(), unicode.as_str(), unicode.as_str()].into_iter(),
+            "__ordinal",
+        );
+        assert_eq!(names.len(), 3);
+        assert!(names.iter().all(|name| name.len() <= 63));
+        assert_eq!(
+            names.iter().collect::<std::collections::HashSet<_>>().len(),
+            3
+        );
+
+        let ascii = "x".repeat(63);
+        let names = normalize_column_names(
+            [ascii.as_str(), ascii.as_str(), "__ordinal"].into_iter(),
+            "__ordinal",
+        );
+        assert_eq!(names[0], ascii);
+        assert!(names[1].ends_with("_2"));
+        assert_eq!(names[2], "__ordinal_2");
+        assert!(names.iter().all(|name| name.len() <= 63));
+    }
+
+    #[test]
+    fn limits_oversized_snapshot_preview_by_estimated_row_bytes() {
+        assert_eq!(notebook_preview_row_limit(100, 1024, 50), 50);
+        assert_eq!(notebook_preview_row_limit(100, 80 * 1024 * 1024, 100), 10);
+        assert_eq!(notebook_preview_row_limit(1, 80 * 1024 * 1024, 100), 1);
+        assert_eq!(notebook_preview_row_limit(0, 80 * 1024 * 1024, 100), 100);
     }
 
     #[test]
@@ -489,6 +752,50 @@ mod tests {
         assert!(snapshot_source("SELECT /* ignored; */ 1; SELECT 2").is_err());
     }
 
+    #[test]
+    fn classifies_supported_and_ineligible_statement_shapes() {
+        for source in [
+            "SELECT 1",
+            "WITH values_cte AS (SELECT 1 AS value) SELECT value FROM values_cte",
+            "VALUES (1), (2)",
+            "TABLE users",
+            "SELECT E'it\\'s @result_1; -- literal' AS note",
+            "SELECT 123 AS value -- trailing comment",
+            "SELECT 1 AS update, 2 AS delete, 3 AS into, 4 AS lock",
+            "WITH update AS (SELECT 1 AS delete) SELECT delete FROM update",
+        ] {
+            assert!(
+                matches!(
+                    snapshot_eligibility(source),
+                    SnapshotEligibility::Eligible(_)
+                ),
+                "not eligible: {source}"
+            );
+        }
+        for source in [
+            "UPDATE users SET active = true",
+            "SELECT * INTO TEMP copied FROM users",
+            "WITH moved AS (DELETE FROM users RETURNING *) SELECT * FROM moved",
+            "WITH created AS (INSERT INTO users(id) VALUES (1) RETURNING *) SELECT * FROM created",
+            "WITH source AS (SELECT 1 AS value) SELECT value INTO TEMP copied FROM source",
+            "SELECT * FROM users FOR UPDATE",
+            "SELECT * FROM users FOR SHARE",
+            "SELECT $1::integer",
+        ] {
+            assert!(
+                matches!(
+                    snapshot_eligibility(source),
+                    SnapshotEligibility::Ineligible(_)
+                ),
+                "not rejected: {source}"
+            );
+        }
+        assert!(matches!(
+            snapshot_eligibility("SELECT E'unterminated\\'"),
+            SnapshotEligibility::Invalid(_)
+        ));
+    }
+
     #[tokio::test]
     async fn postgres_snapshot_retains_complete_native_result_when_configured() {
         let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
@@ -515,7 +822,9 @@ mod tests {
             display_max_rows: 10,
             max_bytes: 1_000_000,
             timeout_secs: 5,
-            source_snapshot: None,
+            source_snapshots: Vec::new(),
+            cancelled: None,
+            source_map: None,
         };
 
         let result = execute(client.clone(), request).await.unwrap();
@@ -551,7 +860,9 @@ mod tests {
                 display_max_rows: 10,
                 max_bytes: 1_000_000,
                 timeout_secs: 5,
-                source_snapshot: Some(source_snapshot),
+                source_snapshots: vec![source_snapshot],
+                cancelled: None,
+                source_map: None,
             },
         )
         .await
@@ -559,5 +870,330 @@ mod tests {
         assert_eq!(refined.query_result.rows.len(), 2);
         assert_eq!(refined.query_result.headers, ["value", "text_value"]);
         assert_eq!(refined.retained.unwrap().rows, 2);
+    }
+
+    #[tokio::test]
+    async fn postgres_snapshot_handles_boundaries_literals_and_preview_fallback() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let client = Arc::new(Mutex::new(client));
+        let request = |id, query: String, max_rows, display_max_rows| PgSnapshotRequest {
+            context: ExecutionContext {
+                id: ExecutionId(id),
+                target: ExecutionTarget::Notebook(CellId(id)),
+                source_revision: 1,
+                connection_generation: 3,
+            },
+            query,
+            handle: RetainedResultHandle(id),
+            max_rows,
+            display_max_rows,
+            max_bytes: 1_000_000,
+            timeout_secs: 5,
+            source_snapshots: Vec::new(),
+            cancelled: None,
+            source_map: None,
+        };
+
+        let values = execute(client.clone(), request(101, "VALUES (1), (2)".into(), 1, 5))
+            .await
+            .unwrap();
+        assert_eq!(values.query_result.rows.len(), 2);
+        assert!(values.retained.is_none());
+        assert!(values.query_result.truncated);
+
+        client
+            .lock()
+            .await
+            .batch_execute(
+                "CREATE TEMP TABLE notebook_table_source(value integer); \
+                 INSERT INTO notebook_table_source VALUES (1), (2)",
+            )
+            .await
+            .unwrap();
+        let table = execute(
+            client.clone(),
+            request(107, "TABLE notebook_table_source".into(), 5, 5),
+        )
+        .await
+        .unwrap();
+        assert_eq!(table.query_result.headers, ["value"]);
+        assert_eq!(table.query_result.rows.len(), 2);
+        assert!(table.retained.is_some());
+
+        let empty = execute(
+            client.clone(),
+            request(
+                102,
+                "SELECT value FROM generate_series(1, 1) value WHERE false".into(),
+                5,
+                5,
+            ),
+        )
+        .await
+        .unwrap();
+        assert!(empty.query_result.rows.is_empty());
+        assert_eq!(empty.query_result.headers, ["value"]);
+        assert!(empty.retained.is_some());
+
+        let literal = execute(
+            client.clone(),
+            request(
+                103,
+                "SELECT E'it\\'s @result_1; -- literal' AS note -- trailing comment".into(),
+                5,
+                5,
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(literal.query_result.rows, [["it's @result_1; -- literal"]]);
+        assert!(literal.retained.is_some());
+
+        let nulls = execute(
+            client.clone(),
+            request(
+                108,
+                "SELECT NULL::text AS actual_null, 'NULL'::text AS literal_null".into(),
+                5,
+                5,
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(nulls.query_result.rows, [["NULL", "NULL"]]);
+        assert_eq!(nulls.query_result.null_cells, [[true, false]]);
+        assert!(nulls.retained.is_some());
+
+        let same_context_first = execute(
+            client.clone(),
+            request(109, "SELECT 1 AS value".into(), 5, 5),
+        )
+        .await
+        .unwrap();
+        let same_context_second = execute(
+            client.clone(),
+            request(109, "SELECT 2 AS value".into(), 5, 5),
+        )
+        .await
+        .unwrap();
+        let first_name = same_context_first.snapshot.unwrap().physical_name;
+        let second_name = same_context_second.snapshot.unwrap().physical_name;
+        assert_ne!(first_name, second_name);
+        assert!(first_name.len() <= POSTGRES_IDENTIFIER_BYTES);
+        assert!(second_name.len() <= POSTGRES_IDENTIFIER_BYTES);
+
+        let unicode = "á".repeat(31);
+        let ordinal = format!("__tsql_row_ordinal_{:016x}", 104u64);
+        let collisions = execute(
+            client.clone(),
+            request(
+                104,
+                format!(
+                    "SELECT 1 AS \"{unicode}\", 2 AS \"{unicode}\", 3 AS \"{unicode}\", 4 AS \"{ordinal}\""
+                ),
+                5,
+                5,
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(collisions.query_result.rows.len(), 1);
+        assert_eq!(collisions.query_result.headers.len(), 4);
+        assert_eq!(
+            collisions
+                .query_result
+                .headers
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            4
+        );
+
+        let pseudo = execute(
+            client.clone(),
+            request(
+                105,
+                "SELECT ROW(1, 2) AS record_value, 'x'::cstring AS raw_value, \
+                 ARRAY[ROW(1, 2), ROW(3, 4)] AS records"
+                    .into(),
+                5,
+                5,
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            pseudo.query_result.headers,
+            ["record_value", "raw_value", "records"]
+        );
+        assert_eq!(
+            pseudo.query_result.rows,
+            [["(1,2)", "x", "{\"(1,2)\",\"(3,4)\"}"]]
+        );
+        assert!(pseudo.retained.is_none());
+
+        client
+            .lock()
+            .await
+            .batch_execute("SET default_transaction_read_only = on")
+            .await
+            .unwrap();
+        let read_only = execute(
+            client.clone(),
+            request(108, "SELECT 1 AS value".into(), 5, 5),
+        )
+        .await
+        .unwrap();
+        assert_eq!(read_only.query_result.headers, ["value"]);
+        assert_eq!(read_only.query_result.rows, [["1"]]);
+        assert!(read_only.retained.is_none());
+        client
+            .lock()
+            .await
+            .batch_execute("SET default_transaction_read_only = off")
+            .await
+            .unwrap();
+
+        let mut cancelled = request(106, "SELECT 1".into(), 5, 5);
+        cancelled.cancelled = Some(Arc::new(AtomicBool::new(true)));
+        let cancelled_error = match execute(client, cancelled).await {
+            Ok(_) => panic!("cancelled snapshot query was executed"),
+            Err(error) => error,
+        };
+        assert!(cancelled_error.contains("cancelled before snapshot execution"));
+    }
+
+    #[tokio::test]
+    async fn postgres_snapshot_cleanup_preserves_a_replaced_relation() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let client = Arc::new(Mutex::new(client));
+        let result = execute(
+            client.clone(),
+            PgSnapshotRequest {
+                context: ExecutionContext {
+                    id: ExecutionId(201),
+                    target: ExecutionTarget::Notebook(CellId(201)),
+                    source_revision: 1,
+                    connection_generation: 7,
+                },
+                query: "SELECT 1 AS value".to_string(),
+                handle: RetainedResultHandle(201),
+                max_rows: 5,
+                display_max_rows: 5,
+                max_bytes: 1_000_000,
+                timeout_secs: 5,
+                source_snapshots: Vec::new(),
+                cancelled: None,
+                source_map: None,
+            },
+        )
+        .await
+        .unwrap();
+        let snapshot = result.snapshot.unwrap();
+        let guard = client.lock().await;
+        validate_snapshot_identity(&guard, &snapshot).await.unwrap();
+        let qualified = format!("pg_temp.{}", quote_identifier(&snapshot.physical_name));
+        guard
+            .batch_execute(&format!(
+                "DROP TABLE {qualified}; CREATE TEMP TABLE {} (replacement integer)",
+                quote_identifier(&snapshot.physical_name)
+            ))
+            .await
+            .unwrap();
+
+        assert!(validate_snapshot_identity(&guard, &snapshot).await.is_err());
+        drop_if_identity_matches(&guard, &snapshot).await.unwrap();
+        let relation_oid: Option<u32> = guard
+            .query_one("SELECT to_regclass($1)::oid", &[&qualified])
+            .await
+            .unwrap()
+            .get(0);
+        assert!(relation_oid.is_some());
+        assert_ne!(relation_oid, Some(snapshot.relation_oid));
+    }
+
+    #[tokio::test]
+    async fn postgres_snapshot_maps_refinement_preflight_error_to_cell_source() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        client
+            .batch_execute("CREATE TEMP TABLE notebook_mapped_source(value integer)")
+            .await
+            .unwrap();
+
+        let source = "  SELECT 'é' AS note, value\nFROM @result_1\nWHERE missing_value = 1";
+        let compiled = crate::app::refinement::compile_logical_references_mapped(
+            source,
+            &[(
+                crate::app::refinement::LogicalResultReference::Cell(CellId(1)),
+                ResultVersion {
+                    source_cell: CellId(1),
+                    source_execution: ExecutionId(21),
+                    source_revision: 1,
+                },
+                "notebook_mapped_source".to_string(),
+                vec!["value".to_string()],
+            )],
+        )
+        .unwrap();
+        let source_position = source[..source.find("missing_value").unwrap()]
+            .chars()
+            .count()
+            + 1;
+        let error = match execute(
+            Arc::new(Mutex::new(client)),
+            PgSnapshotRequest {
+                context: ExecutionContext {
+                    id: ExecutionId(22),
+                    target: ExecutionTarget::Notebook(CellId(2)),
+                    source_revision: 1,
+                    connection_generation: 1,
+                },
+                query: compiled.sql,
+                handle: RetainedResultHandle(22),
+                max_rows: 10,
+                display_max_rows: 10,
+                max_bytes: 1_000_000,
+                timeout_secs: 5,
+                source_snapshots: Vec::new(),
+                cancelled: None,
+                source_map: Some(compiled.source_map),
+            },
+        )
+        .await
+        {
+            Ok(_) => panic!("invalid refinement unexpectedly executed"),
+            Err(error) => error,
+        };
+
+        assert!(error.contains("snapshot preflight failed"), "{error}");
+        assert!(error.contains("[42703]"), "{error}");
+        assert!(
+            error.contains(&format!("POSITION: {source_position} (line 3, column 7)")),
+            "{error}"
+        );
     }
 }

--- a/crates/tsql/src/app/pg_snapshot.rs
+++ b/crates/tsql/src/app/pg_snapshot.rs
@@ -1,0 +1,563 @@
+//! PostgreSQL session-local TEMP-table refinement provider.
+
+use std::time::Instant;
+
+use tokio_postgres::SimpleQueryMessage;
+
+use super::app::{QueryResult, SharedClient};
+use super::execution::ExecutionContext;
+use super::refinement::{
+    RefinementProviderId, ResultVersion, RetainedResult, RetainedResultHandle,
+};
+use crate::util::format_pg_error;
+
+/// Backend resource tracked by the PostgreSQL snapshot manager.
+#[derive(Clone, Debug)]
+pub struct PgTempSnapshot {
+    pub physical_name: String,
+    pub public_columns: Vec<String>,
+    pub relation_oid: u32,
+    pub connection_generation: u64,
+    pub backend_pid: i32,
+    pub row_count: usize,
+    pub byte_size: u64,
+}
+
+pub(crate) struct PgSnapshotResult {
+    pub query_result: QueryResult,
+    pub retained: Option<RetainedResult>,
+    pub snapshot: Option<PgTempSnapshot>,
+}
+
+pub(crate) struct PgSnapshotRequest {
+    pub context: ExecutionContext,
+    pub query: String,
+    pub handle: RetainedResultHandle,
+    pub max_rows: usize,
+    pub display_max_rows: usize,
+    pub max_bytes: u64,
+    pub timeout_secs: u32,
+    pub source_snapshot: Option<PgTempSnapshot>,
+}
+
+pub(crate) async fn execute(
+    client: SharedClient,
+    request: PgSnapshotRequest,
+) -> Result<PgSnapshotResult, String> {
+    let started = Instant::now();
+    let source = snapshot_source(&request.query)?;
+    let mut guard = client.lock().await;
+    let transaction = guard
+        .transaction()
+        .await
+        .map_err(|error| pg_error("failed to start snapshot transaction", &error))?;
+
+    if request.timeout_secs > 0 {
+        transaction
+            .batch_execute(&format!(
+                "SET LOCAL statement_timeout = {}",
+                request.timeout_secs.saturating_mul(1_000)
+            ))
+            .await
+            .map_err(|error| pg_error("failed to set snapshot timeout", &error))?;
+    }
+
+    if let Some(expected) = &request.source_snapshot {
+        let qualified = format!("pg_temp.{}", quote_identifier(&expected.physical_name));
+        let identity = transaction
+            .query_one(
+                "SELECT pg_backend_pid(), to_regclass($1)::oid",
+                &[&qualified],
+            )
+            .await
+            .map_err(|error| pg_error("failed to validate source snapshot", &error))?;
+        let backend_pid: i32 = identity.get(0);
+        let relation_oid: Option<u32> = identity.get(1);
+        if backend_pid != expected.backend_pid || relation_oid != Some(expected.relation_oid) {
+            return Err("source snapshot is no longer available on this session".to_string());
+        }
+    }
+
+    let statement = transaction
+        .prepare(&source)
+        .await
+        .map_err(|error| pg_error("snapshot preflight failed", &error))?;
+    if statement.columns().is_empty() {
+        return Err("statement has no row result to retain".to_string());
+    }
+    if statement
+        .columns()
+        .iter()
+        .any(|column| matches!(column.type_().name(), "record" | "void"))
+    {
+        return Err("result contains a PostgreSQL pseudo-type".to_string());
+    }
+
+    let physical_name = format!(
+        "__tsql_nb_{}_{}",
+        request.context.id.0, request.context.source_revision
+    );
+    let ordinal_name = format!("__tsql_row_ordinal_{}", request.context.id.0);
+    let output_names =
+        normalize_column_names(statement.columns().iter().map(|column| column.name()));
+    let mut table_columns = Vec::with_capacity(output_names.len() + 1);
+    table_columns.push(quote_identifier(&ordinal_name));
+    table_columns.extend(output_names.iter().map(|name| quote_identifier(name)));
+    let create_sql = format!(
+        "CREATE TEMP TABLE {} ({}) ON COMMIT PRESERVE ROWS AS \
+         SELECT row_number() OVER (), __tsql_source.* FROM ({}) AS __tsql_source \
+         LIMIT {}",
+        quote_identifier(&physical_name),
+        table_columns.join(", "),
+        source,
+        request.max_rows.saturating_add(1)
+    );
+    transaction
+        .batch_execute(&create_sql)
+        .await
+        .map_err(|error| pg_error("snapshot materialization failed", &error))?;
+
+    let qualified_name = format!("pg_temp.{}", quote_identifier(&physical_name));
+    let count_sql = format!("SELECT count(*)::bigint FROM {qualified_name}");
+    let row_count_i64: i64 = transaction
+        .query_one(&count_sql, &[])
+        .await
+        .map_err(|error| pg_error("failed to inspect snapshot rows", &error))?
+        .get(0);
+    let row_count = usize::try_from(row_count_i64)
+        .map_err(|_| "snapshot returned an invalid row count".to_string())?;
+    let size_sql = format!("SELECT pg_total_relation_size('{qualified_name}'::regclass)");
+    let byte_size_i64: i64 = transaction
+        .query_one(&size_sql, &[])
+        .await
+        .map_err(|error| pg_error("failed to inspect snapshot size", &error))?
+        .get(0);
+    let byte_size = u64::try_from(byte_size_i64)
+        .map_err(|_| "snapshot returned an invalid relation size".to_string())?;
+
+    let select_columns = output_names
+        .iter()
+        .map(|name| quote_identifier(name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let display_sql = format!(
+        "SELECT {select_columns} FROM {qualified_name} \
+         ORDER BY {} LIMIT {}",
+        quote_identifier(&ordinal_name),
+        request.display_max_rows
+    );
+    let messages = transaction
+        .simple_query(&display_sql)
+        .await
+        .map_err(|error| pg_error("failed to read snapshot result", &error))?;
+    let (headers, rows) = display_rows(messages, request.display_max_rows);
+    let complete = row_count <= request.max_rows && byte_size <= request.max_bytes;
+
+    let (retained, snapshot) = if complete {
+        let identity_sql = format!(
+            "SELECT pg_backend_pid(), '{}'::regclass::oid",
+            qualified_name.replace('\'', "''")
+        );
+        let identity = transaction
+            .query_one(&identity_sql, &[])
+            .await
+            .map_err(|error| pg_error("failed to identify snapshot", &error))?;
+        let backend_pid: i32 = identity.get(0);
+        let relation_oid: u32 = identity.get(1);
+        let version = ResultVersion {
+            source_cell: match request.context.target {
+                super::execution::ExecutionTarget::Notebook(cell) => cell,
+                super::execution::ExecutionTarget::Classic => {
+                    return Err("classic execution cannot publish notebook snapshot".to_string())
+                }
+            },
+            source_execution: request.context.id,
+            source_revision: request.context.source_revision,
+        };
+        (
+            Some(RetainedResult {
+                provider: RefinementProviderId::PostgresTemp,
+                handle: request.handle,
+                version,
+                rows: row_count,
+                retained_bytes: byte_size,
+                connection_generation: request.context.connection_generation,
+            }),
+            Some(PgTempSnapshot {
+                physical_name: physical_name.clone(),
+                public_columns: output_names.clone(),
+                relation_oid,
+                connection_generation: request.context.connection_generation,
+                backend_pid,
+                row_count,
+                byte_size,
+            }),
+        )
+    } else {
+        transaction
+            .batch_execute(&format!("DROP TABLE {qualified_name}"))
+            .await
+            .map_err(|error| pg_error("failed to discard oversized snapshot", &error))?;
+        (None, None)
+    };
+
+    transaction
+        .commit()
+        .await
+        .map_err(|error| pg_error("failed to commit snapshot", &error))?;
+
+    Ok(PgSnapshotResult {
+        query_result: QueryResult {
+            headers,
+            rows,
+            command_tag: Some(format!("SELECT {row_count}")),
+            truncated: !complete || row_count > request.display_max_rows,
+            elapsed: started.elapsed(),
+            source_table: None,
+            primary_keys: Vec::new(),
+            col_types: statement
+                .columns()
+                .iter()
+                .map(|column| column.type_().name().to_string())
+                .collect(),
+        },
+        retained,
+        snapshot,
+    })
+}
+
+fn pg_error(context: &str, error: &tokio_postgres::Error) -> String {
+    format!("{context}: {}", format_pg_error(error))
+}
+
+fn snapshot_source(query: &str) -> Result<String, String> {
+    let trimmed = query.trim();
+    let bytes = trimmed.as_bytes();
+    let mut index = 0;
+    let mut terminal_semicolon = None;
+    let mut comment_ranges = Vec::new();
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' | b'"' => {
+                if terminal_semicolon.is_some() {
+                    return Err(
+                        "multiple statements are not eligible for a session snapshot".to_string(),
+                    );
+                }
+                let delimiter = bytes[index];
+                index += 1;
+                loop {
+                    let Some(offset) = trimmed[index..].find(delimiter as char) else {
+                        return Err("unterminated SQL literal".to_string());
+                    };
+                    index += offset + 1;
+                    if bytes.get(index) == Some(&delimiter) {
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            b'$' => {
+                let Some(tag_end_offset) = trimmed[index + 1..].find('$') else {
+                    if terminal_semicolon.is_some() {
+                        return Err(
+                            "multiple statements are not eligible for a session snapshot"
+                                .to_string(),
+                        );
+                    }
+                    index += 1;
+                    continue;
+                };
+                let tag_end = index + 1 + tag_end_offset;
+                let tag = &trimmed[index + 1..tag_end];
+                let mut characters = tag.chars();
+                let valid_tag = characters.next().is_none_or(|character| {
+                    (character.is_ascii_alphabetic() || character == '_')
+                        && characters
+                            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+                });
+                if !valid_tag {
+                    if terminal_semicolon.is_some() {
+                        return Err(
+                            "multiple statements are not eligible for a session snapshot"
+                                .to_string(),
+                        );
+                    }
+                    index += 1;
+                    continue;
+                }
+                if terminal_semicolon.is_some() {
+                    return Err(
+                        "multiple statements are not eligible for a session snapshot".to_string(),
+                    );
+                }
+                let delimiter = &trimmed[index..=tag_end];
+                let content_start = tag_end + 1;
+                let Some(close_offset) = trimmed[content_start..].find(delimiter) else {
+                    return Err("unterminated dollar-quoted SQL literal".to_string());
+                };
+                index = content_start + close_offset + delimiter.len();
+            }
+            b'-' if bytes.get(index + 1) == Some(&b'-') => {
+                let start = index;
+                index = trimmed[index..]
+                    .find('\n')
+                    .map_or(bytes.len(), |offset| index + offset + 1);
+                comment_ranges.push((start, index));
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                let start = index;
+                let mut depth = 1;
+                index += 2;
+                while index < bytes.len() && depth > 0 {
+                    if bytes.get(index..index + 2) == Some(b"/*") {
+                        depth += 1;
+                        index += 2;
+                    } else if bytes.get(index..index + 2) == Some(b"*/") {
+                        depth -= 1;
+                        index += 2;
+                    } else {
+                        index += trimmed[index..].chars().next().unwrap().len_utf8();
+                    }
+                }
+                if depth > 0 {
+                    return Err("unterminated SQL comment".to_string());
+                }
+                comment_ranges.push((start, index));
+            }
+            b';' => {
+                if terminal_semicolon.is_some() {
+                    return Err(
+                        "multiple statements are not eligible for a session snapshot".to_string(),
+                    );
+                }
+                terminal_semicolon = Some(index);
+                index += 1;
+            }
+            _ => {
+                let character = trimmed[index..].chars().next().unwrap();
+                if terminal_semicolon.is_some() && !character.is_whitespace() {
+                    return Err(
+                        "multiple statements are not eligible for a session snapshot".to_string(),
+                    );
+                }
+                index += character.len_utf8();
+            }
+        }
+    }
+
+    let source = terminal_semicolon.map_or(trimmed, |index| trimmed[..index].trim_end());
+    let mut parser_source = source.to_string();
+    for (start, end) in comment_ranges.into_iter().rev() {
+        if start < parser_source.len() {
+            parser_source.replace_range(start..end.min(parser_source.len()), " ");
+        }
+    }
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_sequel::LANGUAGE.into())
+        .map_err(|error| format!("failed to initialize SQL parser: {error}"))?;
+    let tree = parser
+        .parse(&parser_source, None)
+        .ok_or_else(|| "failed to parse SQL statement".to_string())?;
+    let root = tree.root_node();
+    if root.has_error() || root.named_child_count() != 1 {
+        return Err("statement shape is not eligible for a session snapshot".to_string());
+    }
+    let first = parser_source
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    if !matches!(first.as_str(), "SELECT" | "WITH" | "VALUES" | "TABLE") {
+        return Err("statement is not eligible for a session snapshot".to_string());
+    }
+    Ok(source.to_string())
+}
+
+pub(crate) fn is_snapshot_candidate(query: &str) -> bool {
+    snapshot_source(query).is_ok()
+}
+
+fn normalize_column_names<'a>(names: impl Iterator<Item = &'a str>) -> Vec<String> {
+    let mut used = std::collections::HashSet::new();
+    names
+        .enumerate()
+        .map(|(index, name)| {
+            let base = if name.is_empty() {
+                format!("column_{}", index + 1)
+            } else {
+                name.chars().take(50).collect()
+            };
+            let mut candidate = base.clone();
+            let mut suffix = 2;
+            while !used.insert(candidate.clone()) {
+                candidate = format!("{base}_{suffix}");
+                suffix += 1;
+            }
+            candidate
+        })
+        .collect()
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn display_rows(
+    messages: Vec<SimpleQueryMessage>,
+    max_rows: usize,
+) -> (Vec<String>, Vec<Vec<String>>) {
+    let mut headers = Vec::new();
+    let mut rows = Vec::new();
+    for message in messages {
+        if let SimpleQueryMessage::Row(row) = message {
+            if headers.is_empty() {
+                headers = row
+                    .columns()
+                    .iter()
+                    .map(|column| column.name().to_string())
+                    .collect();
+            }
+            if rows.len() < max_rows {
+                rows.push(
+                    (0..row.len())
+                        .map(|index| row.get(index).unwrap_or("NULL").to_string())
+                        .collect(),
+                );
+            }
+        }
+    }
+    (headers, rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{CellId, ExecutionId, ExecutionTarget};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[test]
+    fn normalizes_empty_and_duplicate_columns() {
+        assert_eq!(
+            normalize_column_names(["id", "id", ""].into_iter()),
+            ["id", "id_2", "column_3"]
+        );
+    }
+
+    #[test]
+    fn rejects_non_row_and_multiple_statements() {
+        assert!(snapshot_source("UPDATE users SET active = true").is_err());
+        assert!(snapshot_source("SELECT 1; SELECT 2").is_err());
+        assert_eq!(snapshot_source("SELECT ';';").unwrap(), "SELECT ';'");
+    }
+
+    #[test]
+    fn ignores_semicolons_in_postgres_literals_and_comments() {
+        assert_eq!(
+            snapshot_source("SELECT $$one;two$$ AS value;").unwrap(),
+            "SELECT $$one;two$$ AS value"
+        );
+        assert_eq!(
+            snapshot_source("SELECT $body$one;two$body$ AS value;").unwrap(),
+            "SELECT $body$one;two$body$ AS value"
+        );
+        assert_eq!(
+            snapshot_source("SELECT /* one; /* nested; */ two; */ 1;").unwrap(),
+            "SELECT /* one; /* nested; */ two; */ 1"
+        );
+        assert_eq!(
+            snapshot_source("SELECT 1 -- ignored;\n;").unwrap(),
+            "SELECT 1 -- ignored;"
+        );
+        assert_eq!(
+            snapshot_source("SELECT 1; -- trailing; comment").unwrap(),
+            "SELECT 1"
+        );
+        assert_eq!(
+            snapshot_source("/* leading; */ SELECT 1;").unwrap(),
+            "/* leading; */ SELECT 1"
+        );
+    }
+
+    #[test]
+    fn rejects_multiple_statements_after_dollar_literals_and_comments() {
+        assert!(snapshot_source("SELECT $$one;two$$; SELECT 2").is_err());
+        assert!(snapshot_source("SELECT /* ignored; */ 1; SELECT 2").is_err());
+    }
+
+    #[tokio::test]
+    async fn postgres_snapshot_retains_complete_native_result_when_configured() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let client = Arc::new(Mutex::new(client));
+        let request = PgSnapshotRequest {
+            context: ExecutionContext {
+                id: ExecutionId(42),
+                target: ExecutionTarget::Notebook(CellId(3)),
+                source_revision: 2,
+                connection_generation: 9,
+            },
+            query: "SELECT value, value::text AS text_value FROM generate_series(1, 3) value"
+                .to_string(),
+            handle: RetainedResultHandle(7),
+            max_rows: 10,
+            display_max_rows: 10,
+            max_bytes: 1_000_000,
+            timeout_secs: 5,
+            source_snapshot: None,
+        };
+
+        let result = execute(client.clone(), request).await.unwrap();
+
+        assert_eq!(result.query_result.rows.len(), 3);
+        assert_eq!(result.query_result.headers, ["value", "text_value"]);
+        assert_eq!(result.retained.as_ref().unwrap().rows, 3);
+        assert_eq!(
+            result.retained.as_ref().unwrap().version.source_cell,
+            CellId(3)
+        );
+        let source_snapshot = result.snapshot.unwrap();
+        let source_version = result.retained.unwrap().version;
+        let query = crate::app::refinement::compile_logical_reference(
+            "SELECT * FROM @result_3 WHERE value > 1",
+            source_version,
+            &source_snapshot.physical_name,
+            &source_snapshot.public_columns,
+        )
+        .unwrap();
+        let refined = execute(
+            client,
+            PgSnapshotRequest {
+                context: ExecutionContext {
+                    id: ExecutionId(43),
+                    target: ExecutionTarget::Notebook(CellId(4)),
+                    source_revision: 1,
+                    connection_generation: 9,
+                },
+                query,
+                handle: RetainedResultHandle(8),
+                max_rows: 10,
+                display_max_rows: 10,
+                max_bytes: 1_000_000,
+                timeout_secs: 5,
+                source_snapshot: Some(source_snapshot),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(refined.query_result.rows.len(), 2);
+        assert_eq!(refined.query_result.headers, ["value", "text_value"]);
+        assert_eq!(refined.retained.unwrap().rows, 2);
+    }
+}

--- a/crates/tsql/src/app/pg_snapshot.rs
+++ b/crates/tsql/src/app/pg_snapshot.rs
@@ -484,7 +484,7 @@ pub(crate) fn snapshot_eligibility(query: &str) -> SnapshotEligibility {
     if matches!(first, "VALUES" | "TABLE") {
         return SnapshotEligibility::Eligible(source.to_string());
     }
-    let parser_source = match sql_lexer::mask_comments(source) {
+    let parser_source = match parser_validation_source(source) {
         Ok(source) => source,
         Err(error) => return SnapshotEligibility::Invalid(error),
     };
@@ -546,13 +546,52 @@ pub(crate) fn is_snapshot_candidate(query: &str) -> bool {
 fn has_unbound_parameter(source: &str) -> bool {
     sql_lexer::scan(source).is_ok_and(|segments| {
         segments.into_iter().any(|segment| {
-            segment.kind == sql_lexer::SqlSegmentKind::Code
-                && source[segment.range]
-                    .as_bytes()
-                    .windows(2)
-                    .any(|pair| pair[0] == b'$' && pair[1].is_ascii_digit())
+            if segment.kind != sql_lexer::SqlSegmentKind::Code {
+                return false;
+            }
+            let code = &source[segment.range];
+            code.char_indices().any(|(index, character)| {
+                character == '$'
+                    && code
+                        .as_bytes()
+                        .get(index + 1)
+                        .is_some_and(u8::is_ascii_digit)
+                    && code[..index]
+                        .chars()
+                        .next_back()
+                        .is_none_or(|previous| !is_identifier_character(previous))
+            })
         })
     })
+}
+
+fn parser_validation_source(source: &str) -> Result<String, String> {
+    let masked = sql_lexer::mask_comments(source)?;
+    let mut normalized = String::with_capacity(masked.len());
+    // tree-sitter-sequel rejects PostgreSQL's valid identifier-internal `$` characters.
+    for segment in sql_lexer::scan(&masked)? {
+        let text = &masked[segment.range];
+        if segment.kind != sql_lexer::SqlSegmentKind::Code {
+            normalized.push_str(text);
+            continue;
+        }
+        let mut previous = None;
+        for character in text.chars() {
+            normalized.push(
+                if character == '$' && previous.is_some_and(is_identifier_character) {
+                    '_'
+                } else {
+                    character
+                },
+            );
+            previous = Some(character);
+        }
+    }
+    Ok(normalized)
+}
+
+fn is_identifier_character(character: char) -> bool {
+    character == '_' || character == '$' || character.is_alphanumeric()
 }
 
 fn has_locking_clause(words: &[String]) -> bool {
@@ -794,6 +833,38 @@ mod tests {
             snapshot_eligibility("SELECT E'unterminated\\'"),
             SnapshotEligibility::Invalid(_)
         ));
+    }
+
+    #[test]
+    fn distinguishes_postgres_identifier_dollars_from_unbound_parameters() {
+        for source in [
+            "SELECT foo$1",
+            "SELECT _x$2",
+            "SELECT café$3",
+            "SELECT '$1' AS literal",
+            "SELECT \"$2\" AS quoted",
+            "SELECT $$value $3$$ AS literal",
+            "SELECT 1 /* $4 */ -- $5\n",
+        ] {
+            assert!(!has_unbound_parameter(source), "false parameter: {source}");
+        }
+        for source in ["SELECT $1", "SELECT ($2)", "SELECT café$3, $4"] {
+            assert!(has_unbound_parameter(source), "missed parameter: {source}");
+        }
+    }
+
+    #[test]
+    fn normalizes_identifier_dollars_only_for_parser_validation() {
+        let source = "SELECT foo$1, _x$2, café$3, '$4', \"$5\", $$value $6$$ /* $7 */ -- $8\n";
+
+        assert_eq!(
+            parser_validation_source(source).unwrap(),
+            "SELECT foo_1, _x_2, café_3, '$4', \"$5\", $$value $6$$               \n"
+        );
+        assert_eq!(
+            snapshot_source("SELECT 1 AS foo$1, 2 AS _x$2, 3 AS café$3;").unwrap(),
+            "SELECT 1 AS foo$1, 2 AS _x$2, 3 AS café$3"
+        );
     }
 
     #[tokio::test]

--- a/crates/tsql/src/app/refinement.rs
+++ b/crates/tsql/src/app/refinement.rs
@@ -1,6 +1,7 @@
 //! Database-neutral retained-result contract for notebook refinement.
 
 use super::execution::{CellId, ExecutionId};
+use super::sql_lexer::{self, SqlSegmentKind};
 
 /// Immutable identity of one executed cell result.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -51,134 +52,169 @@ pub enum RefinementAvailability {
 }
 
 /// Logical result selected by a structural notebook reference.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum LogicalResultReference {
     Latest,
     Cell(CellId),
+    Named(String),
+}
+
+/// Maps PostgreSQL character positions in expanded notebook SQL back to the cell source.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SqlSourceMap {
+    source: String,
+    segments: Vec<SqlSourceMapSegment>,
+    compiled_chars: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SqlSourceMapSegment {
+    compiled_start: usize,
+    compiled_end: usize,
+    source_start: usize,
+    source_end: usize,
+    replacement: bool,
+}
+
+impl SqlSourceMap {
+    pub(crate) fn identity(source: &str) -> Self {
+        let chars = source.chars().count();
+        Self {
+            source: source.to_string(),
+            segments: vec![SqlSourceMapSegment {
+                compiled_start: 0,
+                compiled_end: chars,
+                source_start: 0,
+                source_end: chars,
+                replacement: false,
+            }],
+            compiled_chars: chars,
+        }
+    }
+
+    /// Returns the original one-based position, line, and column for a generated position.
+    ///
+    /// `generated_prefix` is the SQL inserted immediately before the expanded query, such as
+    /// the CTAS or preview-cursor wrapper. Positions within generated substitutions point to
+    /// the beginning of the corresponding logical result reference.
+    pub(crate) fn map_position(
+        &self,
+        generated_position: u32,
+        generated_prefix: &str,
+    ) -> Option<(u32, usize, usize)> {
+        let prefix_chars = generated_prefix.chars().count();
+        let compiled_offset = usize::try_from(generated_position)
+            .ok()?
+            .checked_sub(prefix_chars.checked_add(1)?)?;
+        if compiled_offset > self.compiled_chars {
+            return None;
+        }
+
+        let source_offset = self
+            .segments
+            .iter()
+            .find(|segment| {
+                compiled_offset >= segment.compiled_start && compiled_offset < segment.compiled_end
+            })
+            .map(|segment| {
+                if segment.replacement {
+                    segment.source_start
+                } else {
+                    (segment.source_start + compiled_offset - segment.compiled_start)
+                        .min(segment.source_end)
+                }
+            })
+            .unwrap_or_else(|| self.source.chars().count());
+        let source_position = u32::try_from(source_offset.checked_add(1)?).ok()?;
+        let (line, column) = self.source.chars().take(source_offset).fold(
+            (1usize, 1usize),
+            |(line, column), character| {
+                if character == '\n' {
+                    (line + 1, 1)
+                } else {
+                    (line, column + 1)
+                }
+            },
+        );
+        Some((source_position, line, column))
+    }
+}
+
+pub(crate) struct CompiledLogicalSql {
+    pub(crate) sql: String,
+    pub(crate) source_map: SqlSourceMap,
 }
 
 fn visit_logical_result_references(
     source: &str,
     mut visit: impl FnMut(&str, usize, usize) -> Result<(), String>,
 ) -> Result<(), String> {
-    let bytes = source.as_bytes();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\'' | b'"' => {
-                let delimiter = bytes[index];
-                index += 1;
-                loop {
-                    let Some(offset) = source[index..].find(delimiter as char) else {
-                        return Err("unterminated SQL literal".to_string());
-                    };
-                    index += offset + 1;
-                    if bytes.get(index) == Some(&delimiter) {
-                        index += 1;
-                    } else {
-                        break;
-                    }
-                }
-            }
-            b'$' => {
-                let Some(tag_end_offset) = source[index + 1..].find('$') else {
-                    index += 1;
-                    continue;
-                };
-                let tag_end = index + 1 + tag_end_offset;
-                let tag = &source[index + 1..tag_end];
-                let mut characters = tag.chars();
-                let valid_tag = characters.next().is_none_or(|character| {
-                    (character.is_ascii_alphabetic() || character == '_')
-                        && characters
-                            .all(|character| character.is_ascii_alphanumeric() || character == '_')
-                });
-                if !valid_tag {
-                    index += 1;
-                    continue;
-                }
-                let delimiter = &source[index..=tag_end];
-                let content_start = tag_end + 1;
-                let Some(close_offset) = source[content_start..].find(delimiter) else {
-                    return Err("unterminated dollar-quoted SQL literal".to_string());
-                };
-                index = content_start + close_offset + delimiter.len();
-            }
-            b'-' if bytes.get(index + 1) == Some(&b'-') => {
-                index = source[index..]
-                    .find('\n')
-                    .map_or(bytes.len(), |offset| index + offset + 1);
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'*') => {
-                let mut depth = 1;
-                index += 2;
-                while index < bytes.len() && depth > 0 {
-                    if bytes.get(index..index + 2) == Some(b"/*") {
-                        depth += 1;
-                        index += 2;
-                    } else if bytes.get(index..index + 2) == Some(b"*/") {
-                        depth -= 1;
-                        index += 2;
-                    } else {
-                        index += source[index..].chars().next().unwrap().len_utf8();
-                    }
-                }
-                if depth > 0 {
-                    return Err("unterminated SQL comment".to_string());
-                }
-            }
-            b'@' if source[index..].starts_with("@result")
-                && source[..index].chars().next_back().is_none_or(|character| {
-                    !character.is_alphanumeric() && character != '_' && character != '$'
-                }) =>
+    for segment in sql_lexer::scan(source)? {
+        if segment.kind != SqlSegmentKind::Code {
+            continue;
+        }
+        let mut index = segment.range.start;
+        while index < segment.range.end {
+            let Some(offset) = source[index..segment.range.end].find("@result") else {
+                break;
+            };
+            let start = index + offset;
+            index = start + "@result".len();
+            if source[..start]
+                .chars()
+                .next_back()
+                .is_some_and(|character| {
+                    character.is_alphanumeric() || character == '_' || character == '$'
+                })
             {
-                let start = index;
-                index += "@result".len();
-                while let Some(character) = source[index..].chars().next() {
-                    if !character.is_alphanumeric() && character != '_' && character != '$' {
-                        break;
-                    }
-                    index += character.len_utf8();
-                }
-                visit(&source[start..index], start, index)?;
+                continue;
             }
-            _ => index += source[index..].chars().next().unwrap().len_utf8(),
+            while index < segment.range.end {
+                let Some(character) = source[index..].chars().next() else {
+                    break;
+                };
+                if !character.is_alphanumeric() && character != '_' && character != '$' {
+                    break;
+                }
+                index += character.len_utf8();
+            }
+            visit(&source[start..index], start, index)?;
         }
     }
 
     Ok(())
 }
 
-/// Returns the single structural result reference used by a notebook query.
-pub(crate) fn logical_result_reference(
+/// Returns all distinct structural result references used by a notebook query.
+pub(crate) fn logical_result_references(
     source: &str,
-) -> Result<Option<LogicalResultReference>, String> {
-    let mut found = None;
+) -> Result<Vec<LogicalResultReference>, String> {
+    let mut found = Vec::new();
     visit_logical_result_references(source, |reference, _, _| {
-        let current = if reference == "@result" {
-            LogicalResultReference::Latest
-        } else if let Some(cell) = reference.strip_prefix("@result_") {
-            let id = cell
-                .parse::<u64>()
-                .ok()
-                .filter(|id| *id > 0)
-                .ok_or_else(|| format!("invalid logical result reference: {reference}"))?;
-            LogicalResultReference::Cell(CellId(id))
-        } else {
-            return Err(format!("invalid logical result reference: {reference}"));
-        };
+        let current = parse_logical_reference(reference)?;
 
-        if found.is_some_and(|found| found != current) {
-            return Err("a cell can reference only one result source".to_string());
+        if !found.contains(&current) {
+            found.push(current);
         }
-        found = Some(current);
         Ok(())
     })?;
     Ok(found)
 }
 
+/// Returns the single structural result reference used by a notebook query.
+pub(crate) fn logical_result_reference(
+    source: &str,
+) -> Result<Option<LogicalResultReference>, String> {
+    let references = logical_result_references(source)?;
+    match references.as_slice() {
+        [] => Ok(None),
+        [reference] => Ok(Some(reference.clone())),
+        _ => Err("a cell can reference only one result source".to_string()),
+    }
+}
+
 /// Compiles one structurally bound logical result reference outside SQL literals/comments.
+#[cfg(test)]
 pub(crate) fn compile_logical_reference(
     source: &str,
     version: ResultVersion,
@@ -191,6 +227,9 @@ pub(crate) fn compile_logical_reference(
         Some(LogicalResultReference::Cell(_)) => {
             return Err("logical result reference does not match cell dependency".to_string());
         }
+        Some(LogicalResultReference::Named(_)) => {
+            return Err("named result references require an explicit binding".to_string());
+        }
         None => {
             return Err("dependent cell is missing its logical result reference".to_string());
         }
@@ -200,22 +239,209 @@ pub(crate) fn compile_logical_reference(
         .map(|column| format!("\"{}\"", column.replace('"', "\"\"")))
         .collect::<Vec<_>>()
         .join(", ");
-    let replacement = format!(
-        "(SELECT {columns} FROM pg_temp.\"{}\") AS \"__tsql_result_{}\"",
-        physical_name.replace('"', "\"\""),
-        version.source_cell.0
+    let relation = format!(
+        "(SELECT {columns} FROM pg_temp.\"{}\")",
+        physical_name.replace('"', "\"\"")
     );
-    let mut compiled = String::with_capacity(source.len() + replacement.len());
+    let generated_alias = format!(" AS \"__tsql_result_{}\"", version.source_cell.0);
+    let mut compiled = String::with_capacity(source.len() + relation.len() + generated_alias.len());
     let mut copied_until = 0;
     visit_logical_result_references(source, |_, start, end| {
         compiled.push_str(&source[copied_until..start]);
-        compiled.push_str(&replacement);
+        compiled.push_str(&relation);
+        if !has_user_alias(source, end)? {
+            compiled.push_str(&generated_alias);
+        }
         copied_until = end;
         Ok(())
     })?;
     compiled.push_str(&source[copied_until..]);
 
     Ok(compiled)
+}
+
+/// Compiles multiple structurally bound references for dependency joins.
+#[cfg(test)]
+pub(crate) fn compile_logical_references(
+    source: &str,
+    bindings: &[(LogicalResultReference, ResultVersion, String, Vec<String>)],
+) -> Result<String, String> {
+    compile_logical_references_mapped(source, bindings).map(|compiled| compiled.sql)
+}
+
+/// Compiles structural references and records the source locations hidden by each expansion.
+pub(crate) fn compile_logical_references_mapped(
+    source: &str,
+    bindings: &[(LogicalResultReference, ResultVersion, String, Vec<String>)],
+) -> Result<CompiledLogicalSql, String> {
+    let mut compiled = String::with_capacity(source.len());
+    let mut copied_until = 0;
+    let mut compiled_chars = 0;
+    let mut segments = Vec::new();
+    visit_logical_result_references(source, |token, start, end| {
+        let reference = parse_logical_reference(token)?;
+        let (_, version, physical_name, public_columns) = bindings
+            .iter()
+            .find(|(candidate, _, _, _)| candidate == &reference)
+            .ok_or_else(|| format!("logical result reference is not bound: {token}"))?;
+        if matches!(&reference, LogicalResultReference::Cell(cell) if *cell != version.source_cell)
+        {
+            return Err("logical result reference does not match cell dependency".to_string());
+        }
+        let columns = public_columns
+            .iter()
+            .map(|column| format!("\"{}\"", column.replace('"', "\"\"")))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let copied = &source[copied_until..start];
+        let copied_chars = copied.chars().count();
+        let source_start = source[..copied_until].chars().count();
+        let reference_start = source[..start].chars().count();
+        let reference_end = source[..end].chars().count();
+        if copied_chars > 0 {
+            segments.push(SqlSourceMapSegment {
+                compiled_start: compiled_chars,
+                compiled_end: compiled_chars + copied_chars,
+                source_start,
+                source_end: reference_start,
+                replacement: false,
+            });
+        }
+        compiled.push_str(copied);
+        compiled_chars += copied_chars;
+
+        let mut replacement = format!(
+            "(SELECT {columns} FROM pg_temp.\"{}\")",
+            physical_name.replace('"', "\"\"")
+        );
+        if !has_user_alias(source, end)? {
+            replacement.push_str(&format!(" AS \"__tsql_result_{}\"", version.source_cell.0));
+        }
+        let replacement_chars = replacement.chars().count();
+        compiled.push_str(&replacement);
+        segments.push(SqlSourceMapSegment {
+            compiled_start: compiled_chars,
+            compiled_end: compiled_chars + replacement_chars,
+            source_start: reference_start,
+            source_end: reference_end,
+            replacement: true,
+        });
+        compiled_chars += replacement_chars;
+        copied_until = end;
+        Ok(())
+    })?;
+    let copied = &source[copied_until..];
+    let copied_chars = copied.chars().count();
+    let source_start = source[..copied_until].chars().count();
+    let source_end = source.chars().count();
+    compiled.push_str(copied);
+    if copied_chars > 0 {
+        segments.push(SqlSourceMapSegment {
+            compiled_start: compiled_chars,
+            compiled_end: compiled_chars + copied_chars,
+            source_start,
+            source_end,
+            replacement: false,
+        });
+    }
+    compiled_chars += copied_chars;
+    Ok(CompiledLogicalSql {
+        sql: compiled,
+        source_map: SqlSourceMap {
+            source: source.to_string(),
+            segments,
+            compiled_chars,
+        },
+    })
+}
+
+fn parse_logical_reference(reference: &str) -> Result<LogicalResultReference, String> {
+    if reference == "@result" {
+        return Ok(LogicalResultReference::Latest);
+    }
+    if let Some(cell) = reference.strip_prefix("@result_") {
+        if cell.chars().all(|character| character.is_ascii_digit()) {
+            let id = cell
+                .parse::<u64>()
+                .ok()
+                .filter(|id| *id > 0)
+                .ok_or_else(|| format!("invalid logical result reference: {reference}"))?;
+            return Ok(LogicalResultReference::Cell(CellId(id)));
+        }
+        let name = normalize_result_name(cell)
+            .ok_or_else(|| format!("invalid logical result reference: {reference}"))?;
+        return Ok(LogicalResultReference::Named(name));
+    }
+    Err(format!("invalid logical result reference: {reference}"))
+}
+
+/// Normalizes a user-facing result name to a stable SQL-safe token suffix.
+pub(crate) fn normalize_result_name(name: &str) -> Option<String> {
+    let name = name.trim();
+    let mut characters = name.chars();
+    let first = characters.next()?;
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return None;
+    }
+    if !characters.all(|character| character.is_ascii_alphanumeric() || character == '_') {
+        return None;
+    }
+    Some(name.to_ascii_lowercase())
+}
+
+fn has_user_alias(source: &str, reference_end: usize) -> Result<bool, String> {
+    let suffix = &source[reference_end..];
+    for segment in sql_lexer::scan(suffix)? {
+        match segment.kind {
+            SqlSegmentKind::LineComment | SqlSegmentKind::BlockComment => continue,
+            SqlSegmentKind::DoubleQuoted => return Ok(true),
+            SqlSegmentKind::Code => {
+                let code = suffix[segment.range].trim_start();
+                if code.is_empty() {
+                    continue;
+                }
+                let Some(first) = code.chars().next() else {
+                    continue;
+                };
+                if !first.is_ascii_alphabetic() && first != '_' {
+                    return Ok(false);
+                }
+                let word = code
+                    .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+                    .next()
+                    .unwrap_or_default()
+                    .to_ascii_uppercase();
+                return Ok(!matches!(
+                    word.as_str(),
+                    "WHERE"
+                        | "GROUP"
+                        | "ORDER"
+                        | "LIMIT"
+                        | "OFFSET"
+                        | "FETCH"
+                        | "FOR"
+                        | "JOIN"
+                        | "INNER"
+                        | "LEFT"
+                        | "RIGHT"
+                        | "FULL"
+                        | "CROSS"
+                        | "NATURAL"
+                        | "ON"
+                        | "USING"
+                        | "UNION"
+                        | "INTERSECT"
+                        | "EXCEPT"
+                        | "WINDOW"
+                        | "HAVING"
+                        | "QUALIFY"
+                        | "RETURNING"
+                ));
+            }
+            _ => return Ok(false),
+        }
+    }
+    Ok(false)
 }
 
 #[cfg(test)]
@@ -298,6 +524,12 @@ mod tests {
             Ok(Some(LogicalResultReference::Cell(CellId(12))))
         );
         assert_eq!(
+            logical_result_reference("SELECT * FROM @result_Recent_Users"),
+            Ok(Some(LogicalResultReference::Named(
+                "recent_users".to_string()
+            )))
+        );
+        assert_eq!(
             logical_result_reference(
                 "SELECT '@result', \"@result_2\", $$@result_3$$ /* @result_4 */ -- @result_5"
             ),
@@ -309,6 +541,10 @@ mod tests {
         );
         assert_eq!(
             logical_result_reference("SELECT prefix@result, prefix@result_12"),
+            Ok(None)
+        );
+        assert_eq!(
+            logical_result_reference("SELECT E'it\\'s @result_1; -- literal' AS note"),
             Ok(None)
         );
     }
@@ -333,6 +569,164 @@ mod tests {
         assert_eq!(
             logical_result_reference("SELECT * FROM @result JOIN @result_4 USING (value)"),
             Err("a cell can reference only one result source".to_string())
+        );
+        assert_eq!(
+            logical_result_references(
+                "SELECT * FROM @result_1 a JOIN @result_2 b USING (value) JOIN @result_1 c USING (value)"
+            ),
+            Ok(vec![
+                LogicalResultReference::Cell(CellId(1)),
+                LogicalResultReference::Cell(CellId(2))
+            ])
+        );
+    }
+
+    #[test]
+    fn preserves_explicit_shorthand_and_quoted_aliases() {
+        let version = ResultVersion {
+            source_cell: CellId(2),
+            source_execution: ExecutionId(9),
+            source_revision: 1,
+        };
+
+        assert_eq!(
+            compile_logical_reference(
+                "SELECT a.value, b.value FROM @result_2 AS a JOIN @result_2 b USING (value)",
+                version,
+                "snapshot_2",
+                &["value".to_string()]
+            ),
+            Ok("SELECT a.value, b.value FROM (SELECT \"value\" FROM pg_temp.\"snapshot_2\") AS a JOIN (SELECT \"value\" FROM pg_temp.\"snapshot_2\") b USING (value)".to_string())
+        );
+        assert_eq!(
+            compile_logical_reference(
+                "SELECT r.value FROM @result_2 /* alias */ \"r\" WHERE r.value > 1",
+                version,
+                "snapshot_2",
+                &["value".to_string()]
+            ),
+            Ok("SELECT r.value FROM (SELECT \"value\" FROM pg_temp.\"snapshot_2\") /* alias */ \"r\" WHERE r.value > 1".to_string())
+        );
+    }
+
+    #[test]
+    fn compiles_multiple_numbered_sources_for_a_join() {
+        let first = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(11),
+            source_revision: 2,
+        };
+        let second = ResultVersion {
+            source_cell: CellId(2),
+            source_execution: ExecutionId(12),
+            source_revision: 3,
+        };
+        let bindings = vec![
+            (
+                LogicalResultReference::Cell(CellId(1)),
+                first,
+                "snapshot_1".to_string(),
+                vec!["value".to_string()],
+            ),
+            (
+                LogicalResultReference::Cell(CellId(2)),
+                second,
+                "snapshot_2".to_string(),
+                vec!["value".to_string()],
+            ),
+        ];
+
+        assert_eq!(
+            compile_logical_references(
+                "SELECT a.value, b.value FROM @result_1 AS a JOIN @result_2 b USING (value)",
+                &bindings
+            ),
+            Ok("SELECT a.value, b.value FROM (SELECT \"value\" FROM pg_temp.\"snapshot_1\") AS a JOIN (SELECT \"value\" FROM pg_temp.\"snapshot_2\") b USING (value)".to_string())
+        );
+        assert_eq!(
+            compile_logical_references("SELECT * FROM @result_3", &bindings),
+            Err("logical result reference is not bound: @result_3".to_string())
+        );
+
+        let named = vec![(
+            LogicalResultReference::Named("recent_users".to_string()),
+            first,
+            "snapshot_1".to_string(),
+            vec!["value".to_string()],
+        )];
+        assert_eq!(
+            compile_logical_references("SELECT r.value FROM @result_recent_users AS r", &named),
+            Ok(
+                "SELECT r.value FROM (SELECT \"value\" FROM pg_temp.\"snapshot_1\") AS r"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn maps_expanded_positions_back_to_unicode_cell_source_and_wrappers() {
+        let source = "  SELECT 'é' AS note\nFROM @result_1\nWHERE missing_value = 1";
+        let binding = vec![(
+            LogicalResultReference::Cell(CellId(1)),
+            ResultVersion {
+                source_cell: CellId(1),
+                source_execution: ExecutionId(7),
+                source_revision: 2,
+            },
+            "snapshot_1".to_string(),
+            vec!["value".to_string()],
+        )];
+        let compiled = compile_logical_references_mapped(source, &binding).unwrap();
+        let generated_position = u32::try_from(
+            compiled.sql[..compiled.sql.find("missing_value").unwrap()]
+                .chars()
+                .count()
+                + 1,
+        )
+        .unwrap();
+        let source_position = u32::try_from(
+            source[..source.find("missing_value").unwrap()]
+                .chars()
+                .count()
+                + 1,
+        )
+        .unwrap();
+        assert_eq!(
+            compiled.source_map.map_position(generated_position, ""),
+            Some((source_position, 3, 7))
+        );
+
+        let relation_position = u32::try_from(
+            compiled.sql[..compiled.sql.find("snapshot_1").unwrap()]
+                .chars()
+                .count()
+                + 1,
+        )
+        .unwrap();
+        let reference_position =
+            u32::try_from(source[..source.find("@result_1").unwrap()].chars().count() + 1).unwrap();
+        assert_eq!(
+            compiled.source_map.map_position(relation_position, ""),
+            Some((reference_position, 2, 6))
+        );
+
+        let wrapper = "CREATE TEMP TABLE generated AS SELECT * FROM (\n";
+        let wrapped_position = generated_position + u32::try_from(wrapper.chars().count()).unwrap();
+        assert_eq!(
+            compiled.source_map.map_position(wrapped_position, wrapper),
+            Some((source_position, 3, 7))
+        );
+        assert_eq!(compiled.source_map.map_position(1, wrapper), None);
+    }
+
+    #[test]
+    fn identity_source_map_uses_postgres_character_positions() {
+        let source = "SELECT 'é' AS note\nWHERE broken";
+        let position =
+            u32::try_from(source[..source.find("broken").unwrap()].chars().count() + 1).unwrap();
+        assert_eq!(
+            SqlSourceMap::identity(source).map_position(position, ""),
+            Some((position, 2, 7))
         );
     }
 }

--- a/crates/tsql/src/app/refinement.rs
+++ b/crates/tsql/src/app/refinement.rs
@@ -1,0 +1,338 @@
+//! Database-neutral retained-result contract for notebook refinement.
+
+use super::execution::{CellId, ExecutionId};
+
+/// Immutable identity of one executed cell result.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ResultVersion {
+    pub source_cell: CellId,
+    pub source_execution: ExecutionId,
+    pub source_revision: u64,
+}
+
+/// Opaque key into a backend-specific retained-resource registry.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct RetainedResultHandle(pub(crate) u64);
+
+/// User-visible semantics of a refinement provider.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RefinementProviderId {
+    PostgresTemp,
+}
+
+/// Published retained result. Backend resource details remain in its manager.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RetainedResult {
+    pub provider: RefinementProviderId,
+    pub handle: RetainedResultHandle,
+    pub version: ResultVersion,
+    pub rows: usize,
+    pub retained_bytes: u64,
+    pub connection_generation: u64,
+}
+
+/// Why a cell cannot currently be refined.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RefinementUnavailableReason {
+    SnapshotDisabled,
+    UnsupportedBackend,
+    TransactionNotIdle,
+    IneligibleStatement,
+    ResultIncomplete,
+    SnapshotEvicted,
+    ConnectionChanged,
+}
+
+/// Current refinement state rendered for one output.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RefinementAvailability {
+    Available(RetainedResult),
+    Unavailable(RefinementUnavailableReason),
+}
+
+/// Logical result selected by a structural notebook reference.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LogicalResultReference {
+    Latest,
+    Cell(CellId),
+}
+
+fn visit_logical_result_references(
+    source: &str,
+    mut visit: impl FnMut(&str, usize, usize) -> Result<(), String>,
+) -> Result<(), String> {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' | b'"' => {
+                let delimiter = bytes[index];
+                index += 1;
+                loop {
+                    let Some(offset) = source[index..].find(delimiter as char) else {
+                        return Err("unterminated SQL literal".to_string());
+                    };
+                    index += offset + 1;
+                    if bytes.get(index) == Some(&delimiter) {
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            b'$' => {
+                let Some(tag_end_offset) = source[index + 1..].find('$') else {
+                    index += 1;
+                    continue;
+                };
+                let tag_end = index + 1 + tag_end_offset;
+                let tag = &source[index + 1..tag_end];
+                let mut characters = tag.chars();
+                let valid_tag = characters.next().is_none_or(|character| {
+                    (character.is_ascii_alphabetic() || character == '_')
+                        && characters
+                            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+                });
+                if !valid_tag {
+                    index += 1;
+                    continue;
+                }
+                let delimiter = &source[index..=tag_end];
+                let content_start = tag_end + 1;
+                let Some(close_offset) = source[content_start..].find(delimiter) else {
+                    return Err("unterminated dollar-quoted SQL literal".to_string());
+                };
+                index = content_start + close_offset + delimiter.len();
+            }
+            b'-' if bytes.get(index + 1) == Some(&b'-') => {
+                index = source[index..]
+                    .find('\n')
+                    .map_or(bytes.len(), |offset| index + offset + 1);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                let mut depth = 1;
+                index += 2;
+                while index < bytes.len() && depth > 0 {
+                    if bytes.get(index..index + 2) == Some(b"/*") {
+                        depth += 1;
+                        index += 2;
+                    } else if bytes.get(index..index + 2) == Some(b"*/") {
+                        depth -= 1;
+                        index += 2;
+                    } else {
+                        index += source[index..].chars().next().unwrap().len_utf8();
+                    }
+                }
+                if depth > 0 {
+                    return Err("unterminated SQL comment".to_string());
+                }
+            }
+            b'@' if source[index..].starts_with("@result")
+                && source[..index].chars().next_back().is_none_or(|character| {
+                    !character.is_alphanumeric() && character != '_' && character != '$'
+                }) =>
+            {
+                let start = index;
+                index += "@result".len();
+                while let Some(character) = source[index..].chars().next() {
+                    if !character.is_alphanumeric() && character != '_' && character != '$' {
+                        break;
+                    }
+                    index += character.len_utf8();
+                }
+                visit(&source[start..index], start, index)?;
+            }
+            _ => index += source[index..].chars().next().unwrap().len_utf8(),
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns the single structural result reference used by a notebook query.
+pub(crate) fn logical_result_reference(
+    source: &str,
+) -> Result<Option<LogicalResultReference>, String> {
+    let mut found = None;
+    visit_logical_result_references(source, |reference, _, _| {
+        let current = if reference == "@result" {
+            LogicalResultReference::Latest
+        } else if let Some(cell) = reference.strip_prefix("@result_") {
+            let id = cell
+                .parse::<u64>()
+                .ok()
+                .filter(|id| *id > 0)
+                .ok_or_else(|| format!("invalid logical result reference: {reference}"))?;
+            LogicalResultReference::Cell(CellId(id))
+        } else {
+            return Err(format!("invalid logical result reference: {reference}"));
+        };
+
+        if found.is_some_and(|found| found != current) {
+            return Err("a cell can reference only one result source".to_string());
+        }
+        found = Some(current);
+        Ok(())
+    })?;
+    Ok(found)
+}
+
+/// Compiles one structurally bound logical result reference outside SQL literals/comments.
+pub(crate) fn compile_logical_reference(
+    source: &str,
+    version: ResultVersion,
+    physical_name: &str,
+    public_columns: &[String],
+) -> Result<String, String> {
+    match logical_result_reference(source)? {
+        Some(LogicalResultReference::Latest) => {}
+        Some(LogicalResultReference::Cell(cell)) if cell == version.source_cell => {}
+        Some(LogicalResultReference::Cell(_)) => {
+            return Err("logical result reference does not match cell dependency".to_string());
+        }
+        None => {
+            return Err("dependent cell is missing its logical result reference".to_string());
+        }
+    }
+    let columns = public_columns
+        .iter()
+        .map(|column| format!("\"{}\"", column.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let replacement = format!(
+        "(SELECT {columns} FROM pg_temp.\"{}\") AS \"__tsql_result_{}\"",
+        physical_name.replace('"', "\"\""),
+        version.source_cell.0
+    );
+    let mut compiled = String::with_capacity(source.len() + replacement.len());
+    let mut copied_until = 0;
+    visit_logical_result_references(source, |_, start, end| {
+        compiled.push_str(&source[copied_until..start]);
+        compiled.push_str(&replacement);
+        copied_until = end;
+        Ok(())
+    })?;
+    compiled.push_str(&source[copied_until..]);
+
+    Ok(compiled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compiles_only_structurally_bound_reference() {
+        let version = ResultVersion {
+            source_cell: CellId(3),
+            source_execution: ExecutionId(7),
+            source_revision: 2,
+        };
+        let compiled = compile_logical_reference(
+            "select '@result_3', $$@result_3$$, * from @result_3 -- @result_3",
+            version,
+            "snapshot_3",
+            &["value".to_string()],
+        )
+        .unwrap();
+        assert_eq!(
+            compiled,
+            "select '@result_3', $$@result_3$$, * from (SELECT \"value\" FROM pg_temp.\"snapshot_3\") AS \"__tsql_result_3\" -- @result_3"
+        );
+    }
+
+    #[test]
+    fn preserves_utf8_and_ignores_nested_comments_and_quoted_references() {
+        let version = ResultVersion {
+            source_cell: CellId(3),
+            source_execution: ExecutionId(7),
+            source_revision: 2,
+        };
+        let source = "SELECT 'café @result_3', \"Δ@result_3\", $tag$🙂 @result_3$tag$ /* outer /* @result_3 */ still comment */ FROM @result_3 -- naïve @result_3";
+
+        let compiled =
+            compile_logical_reference(source, version, "snapshot_3", &["value".to_string()])
+                .unwrap();
+
+        assert_eq!(
+            compiled,
+            "SELECT 'café @result_3', \"Δ@result_3\", $tag$🙂 @result_3$tag$ /* outer /* @result_3 */ still comment */ FROM (SELECT \"value\" FROM pg_temp.\"snapshot_3\") AS \"__tsql_result_3\" -- naïve @result_3"
+        );
+    }
+
+    #[test]
+    fn rejects_prefix_and_malformed_reference_mismatches() {
+        let version = ResultVersion {
+            source_cell: CellId(1),
+            source_execution: ExecutionId(7),
+            source_revision: 2,
+        };
+
+        assert_eq!(
+            compile_logical_reference(
+                "SELECT * FROM @result_10",
+                version,
+                "snapshot_1",
+                &["value".to_string()]
+            ),
+            Err("logical result reference does not match cell dependency".to_string())
+        );
+        for reference in ["@result_1suffix", "@result_", "@result_0", "@resulting"] {
+            let source = format!("SELECT * FROM {reference}");
+            assert_eq!(
+                logical_result_reference(&source),
+                Err(format!("invalid logical result reference: {reference}"))
+            );
+        }
+    }
+
+    #[test]
+    fn detects_latest_and_numbered_structural_references() {
+        assert_eq!(
+            logical_result_reference("SELECT * FROM @result"),
+            Ok(Some(LogicalResultReference::Latest))
+        );
+        assert_eq!(
+            logical_result_reference("SELECT * FROM @result_12"),
+            Ok(Some(LogicalResultReference::Cell(CellId(12))))
+        );
+        assert_eq!(
+            logical_result_reference(
+                "SELECT '@result', \"@result_2\", $$@result_3$$ /* @result_4 */ -- @result_5"
+            ),
+            Ok(None)
+        );
+        assert_eq!(
+            logical_result_reference("SELECT 1 /* outer /* @result_1 */ still comment */"),
+            Ok(None)
+        );
+        assert_eq!(
+            logical_result_reference("SELECT prefix@result, prefix@result_12"),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn compiles_latest_reference_and_rejects_mixed_sources() {
+        let version = ResultVersion {
+            source_cell: CellId(4),
+            source_execution: ExecutionId(9),
+            source_revision: 3,
+        };
+
+        assert_eq!(
+            compile_logical_reference(
+                "SELECT * FROM @result UNION ALL SELECT * FROM @result",
+                version,
+                "snapshot_4",
+                &["value".to_string()]
+            ),
+            Ok("SELECT * FROM (SELECT \"value\" FROM pg_temp.\"snapshot_4\") AS \"__tsql_result_4\" UNION ALL SELECT * FROM (SELECT \"value\" FROM pg_temp.\"snapshot_4\") AS \"__tsql_result_4\"".to_string())
+        );
+        assert_eq!(
+            logical_result_reference("SELECT * FROM @result JOIN @result_4 USING (value)"),
+            Err("a cell can reference only one result source".to_string())
+        );
+    }
+}

--- a/crates/tsql/src/app/result_transform.rs
+++ b/crates/tsql/src/app/result_transform.rs
@@ -1,0 +1,913 @@
+//! Typed, database-side transformations for a displayed query result.
+//!
+//! The grid intentionally stores display strings, so filtering or sorting it in
+//! memory would lose PostgreSQL types, SQL NULL identity, and unfetched rows.
+//! This module instead composes a new, read-only query around the source SQL.
+
+use super::{pg_snapshot, sql_lexer};
+
+/// A transformation expressed in terms of zero-based result-column ordinals.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct ResultTransform {
+    pub(crate) projection: Vec<usize>,
+    pub(crate) filters: Vec<ResultFilter>,
+    pub(crate) orders: Vec<ResultOrder>,
+    pub(crate) group_count: Option<usize>,
+}
+
+impl ResultTransform {
+    /// Replaces the projected columns. An empty projection means all columns.
+    pub(crate) fn set_projection(&mut self, projection: Vec<usize>) {
+        self.projection = projection;
+    }
+
+    /// Appends a predicate evaluated before ordering and grouping.
+    pub(crate) fn add_filter(&mut self, filter: ResultFilter) {
+        self.filters.push(filter);
+    }
+
+    /// Removes every filter while preserving projection, ordering, and grouping.
+    pub(crate) fn clear_filters(&mut self) {
+        self.filters.clear();
+    }
+
+    /// Replaces or appends a sort key for a result column.
+    pub(crate) fn set_order(&mut self, ordinal: usize, direction: OrderDirection, append: bool) {
+        if !append {
+            self.orders.clear();
+        } else {
+            self.orders.retain(|order| order.ordinal != ordinal);
+        }
+        self.orders.push(ResultOrder { ordinal, direction });
+    }
+
+    /// Cycles a single-column sort through ascending, descending, and none.
+    pub(crate) fn toggle_order(&mut self, ordinal: usize) {
+        let direction = self
+            .orders
+            .iter()
+            .find(|order| order.ordinal == ordinal)
+            .map(|order| order.direction);
+        self.orders.clear();
+        match direction {
+            None => self.orders.push(ResultOrder {
+                ordinal,
+                direction: OrderDirection::Asc,
+            }),
+            Some(OrderDirection::Asc) => self.orders.push(ResultOrder {
+                ordinal,
+                direction: OrderDirection::Desc,
+            }),
+            Some(OrderDirection::Desc) => {}
+        }
+    }
+
+    /// Clears sort keys without changing other result operations.
+    pub(crate) fn clear_orders(&mut self) {
+        self.orders.clear();
+    }
+
+    /// Groups by one result column and returns its occurrence count.
+    pub(crate) fn set_group_count(&mut self, ordinal: Option<usize>) {
+        self.group_count = ordinal;
+    }
+
+    /// Removes every result operation.
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Returns true when the source query is displayed without transformations.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.projection.is_empty()
+            && self.filters.is_empty()
+            && self.orders.is_empty()
+            && self.group_count.is_none()
+    }
+
+    /// Produces a short, user-facing summary suitable for a results-zone label.
+    pub(crate) fn summary(&self, headers: &[String]) -> String {
+        let mut parts = Vec::new();
+        if !self.filters.is_empty() {
+            let suffix = if self.filters.len() == 1 { "" } else { "s" };
+            parts.push(format!("{} filter{suffix}", self.filters.len()));
+        }
+        if !self.orders.is_empty() {
+            let rendered = self
+                .orders
+                .iter()
+                .map(|order| {
+                    let name = headers.get(order.ordinal).map_or("?", String::as_str);
+                    format!("{name} {}", order.direction.label())
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            parts.push(format!("sort {rendered}"));
+        }
+        if !self.projection.is_empty() {
+            let suffix = if self.projection.len() == 1 { "" } else { "s" };
+            parts.push(format!("{} column{suffix}", self.projection.len()));
+        }
+        if let Some(ordinal) = self.group_count {
+            let name = headers.get(ordinal).map_or("?", String::as_str);
+            parts.push(format!("count by {name}"));
+        }
+        parts.join(" · ")
+    }
+}
+
+/// One predicate over a result column.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ResultFilter {
+    pub(crate) ordinal: usize,
+    pub(crate) op: FilterOp,
+    pub(crate) value: FilterValue,
+}
+
+/// Supported database-side filter operations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum FilterOp {
+    Eq,
+    Ne,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    Contains,
+    NotContains,
+    StartsWith,
+    NotStartsWith,
+    EndsWith,
+    NotEndsWith,
+    IsNull,
+    IsNotNull,
+}
+
+/// A value used by a typed filter predicate.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum FilterValue {
+    Text(String),
+    Integer(i64),
+    Decimal(String),
+    Boolean(bool),
+    Null,
+}
+
+/// Parses a command-prompt value without conflating the text `NULL` with SQL NULL.
+pub(crate) fn parse_filter_value(value: &str) -> FilterValue {
+    let value = value.trim();
+    if let Some(unquoted) = value
+        .strip_prefix('\'')
+        .and_then(|value| value.strip_suffix('\''))
+    {
+        return FilterValue::Text(unquoted.replace("''", "'"));
+    }
+    if let Some(unquoted) = value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+    {
+        return FilterValue::Text(unquoted.replace("\"\"", "\""));
+    }
+    if value.eq_ignore_ascii_case("true") {
+        return FilterValue::Boolean(true);
+    }
+    if value.eq_ignore_ascii_case("false") {
+        return FilterValue::Boolean(false);
+    }
+    if let Ok(value) = value.parse::<i64>() {
+        return FilterValue::Integer(value);
+    }
+    if is_finite_decimal(value) {
+        return FilterValue::Decimal(value.to_string());
+    }
+    FilterValue::Text(value.to_string())
+}
+
+/// One sort key over a result column.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ResultOrder {
+    pub(crate) ordinal: usize,
+    pub(crate) direction: OrderDirection,
+}
+
+/// Sort direction for a result column.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OrderDirection {
+    Asc,
+    Desc,
+}
+
+impl OrderDirection {
+    fn sql(self) -> &'static str {
+        match self {
+            Self::Asc => "ASC",
+            Self::Desc => "DESC",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Asc => "asc",
+            Self::Desc => "desc",
+        }
+    }
+}
+
+/// Compiles a result transformation around one read-only, row-producing query.
+///
+/// Deterministic ordinal aliases make duplicate, quoted, and expression-derived
+/// result headers safe to address. The compiled statement remains a single
+/// `SELECT`, so callers can use a database cursor for paging.
+pub(crate) fn compile_result_transform(
+    base_sql: &str,
+    headers: &[String],
+    spec: &ResultTransform,
+) -> Result<String, String> {
+    if headers.is_empty() {
+        return Err("result has no columns to transform".to_string());
+    }
+    let source = sql_lexer::single_statement(base_sql)?;
+    if !pg_snapshot::is_snapshot_candidate(source) {
+        return Err("only a single read-only, row-returning query can be transformed".to_string());
+    }
+    validate_transform(headers.len(), spec)?;
+
+    let aliases = (0..headers.len())
+        .map(column_alias)
+        .map(|alias| quote_identifier(&alias))
+        .collect::<Vec<_>>();
+    let source_alias = quote_identifier("__tsql_result");
+
+    let select = if let Some(ordinal) = spec.group_count {
+        let column = qualified_column(&source_alias, ordinal);
+        format!(
+            "{column} AS {}, COUNT(*) AS {}",
+            quote_identifier(&headers[ordinal]),
+            quote_identifier("count")
+        )
+    } else {
+        let projection = if spec.projection.is_empty() {
+            (0..headers.len()).collect::<Vec<_>>()
+        } else {
+            spec.projection.clone()
+        };
+        projection
+            .iter()
+            .map(|ordinal| {
+                format!(
+                    "{} AS {}",
+                    qualified_column(&source_alias, *ordinal),
+                    quote_identifier(&headers[*ordinal])
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    let mut sql = format!(
+        "SELECT {select}\nFROM (\n{source}\n) AS {source_alias} ({})",
+        aliases.join(", ")
+    );
+
+    if !spec.filters.is_empty() {
+        let predicates = spec
+            .filters
+            .iter()
+            .map(|filter| compile_filter(&source_alias, filter))
+            .collect::<Result<Vec<_>, _>>()?;
+        sql.push_str("\nWHERE ");
+        sql.push_str(&predicates.join("\n  AND "));
+    }
+
+    if let Some(ordinal) = spec.group_count {
+        sql.push_str("\nGROUP BY ");
+        sql.push_str(&qualified_column(&source_alias, ordinal));
+    }
+
+    if spec.orders.is_empty() && spec.group_count.is_some() {
+        sql.push_str("\nORDER BY COUNT(*) DESC");
+    } else if !spec.orders.is_empty() {
+        let orders = spec
+            .orders
+            .iter()
+            .map(|order| {
+                format!(
+                    "{} {}",
+                    qualified_column(&source_alias, order.ordinal),
+                    order.direction.sql()
+                )
+            })
+            .collect::<Vec<_>>();
+        sql.push_str("\nORDER BY ");
+        sql.push_str(&orders.join(", "));
+    }
+
+    Ok(sql)
+}
+
+fn validate_transform(column_count: usize, spec: &ResultTransform) -> Result<(), String> {
+    let validate = |ordinal: usize| {
+        if ordinal >= column_count {
+            Err(format!(
+                "result column {} is out of range for {column_count} columns",
+                ordinal.saturating_add(1)
+            ))
+        } else {
+            Ok(())
+        }
+    };
+    for ordinal in &spec.projection {
+        validate(*ordinal)?;
+    }
+    for filter in &spec.filters {
+        validate(filter.ordinal)?;
+    }
+    for order in &spec.orders {
+        validate(order.ordinal)?;
+    }
+    if let Some(group_ordinal) = spec.group_count {
+        validate(group_ordinal)?;
+        if spec
+            .orders
+            .iter()
+            .any(|order| order.ordinal != group_ordinal)
+        {
+            return Err("grouped result can only be ordered by its grouped column".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn compile_filter(source_alias: &str, filter: &ResultFilter) -> Result<String, String> {
+    let column = qualified_column(source_alias, filter.ordinal);
+    match filter.op {
+        FilterOp::IsNull => {
+            if filter.value != FilterValue::Null {
+                return Err("IS NULL does not accept a filter value".to_string());
+            }
+            Ok(format!("{column} IS NULL"))
+        }
+        FilterOp::IsNotNull => {
+            if filter.value != FilterValue::Null {
+                return Err("IS NOT NULL does not accept a filter value".to_string());
+            }
+            Ok(format!("{column} IS NOT NULL"))
+        }
+        FilterOp::Eq if filter.value == FilterValue::Null => Ok(format!("{column} IS NULL")),
+        FilterOp::Ne if filter.value == FilterValue::Null => Ok(format!("{column} IS NOT NULL")),
+        FilterOp::Contains
+        | FilterOp::NotContains
+        | FilterOp::StartsWith
+        | FilterOp::NotStartsWith
+        | FilterOp::EndsWith
+        | FilterOp::NotEndsWith => {
+            let FilterValue::Text(value) = &filter.value else {
+                return Err("text-match filters require a text value".to_string());
+            };
+            let escaped = escape_like(value);
+            let pattern = match filter.op {
+                FilterOp::Contains | FilterOp::NotContains => format!("%{escaped}%"),
+                FilterOp::StartsWith | FilterOp::NotStartsWith => format!("{escaped}%"),
+                FilterOp::EndsWith | FilterOp::NotEndsWith => format!("%{escaped}"),
+                _ => unreachable!("text-match operation was checked above"),
+            };
+            let operator = match filter.op {
+                FilterOp::NotContains | FilterOp::NotStartsWith | FilterOp::NotEndsWith => {
+                    "NOT ILIKE"
+                }
+                _ => "ILIKE",
+            };
+            Ok(format!(
+                "{column}::text {operator} {} ESCAPE E'\\\\'",
+                quote_literal(&pattern)?
+            ))
+        }
+        FilterOp::Eq
+        | FilterOp::Ne
+        | FilterOp::Lt
+        | FilterOp::Lte
+        | FilterOp::Gt
+        | FilterOp::Gte => {
+            if filter.value == FilterValue::Null {
+                return Err("NULL only supports equality or IS NULL filters".to_string());
+            }
+            let operator = match filter.op {
+                FilterOp::Eq => "IS NOT DISTINCT FROM",
+                FilterOp::Ne => "IS DISTINCT FROM",
+                FilterOp::Lt => "<",
+                FilterOp::Lte => "<=",
+                FilterOp::Gt => ">",
+                FilterOp::Gte => ">=",
+                _ => unreachable!("comparison operation was checked above"),
+            };
+            Ok(format!(
+                "{column} {operator} {}",
+                compile_value(&filter.value)?
+            ))
+        }
+    }
+}
+
+fn compile_value(value: &FilterValue) -> Result<String, String> {
+    match value {
+        FilterValue::Text(value) => quote_literal(value),
+        FilterValue::Integer(value) => Ok(value.to_string()),
+        FilterValue::Decimal(value) if is_finite_decimal(value) => Ok(value.clone()),
+        FilterValue::Decimal(_) => Err("numeric filter value must be finite".to_string()),
+        FilterValue::Boolean(value) => Ok(if *value { "TRUE" } else { "FALSE" }.to_string()),
+        FilterValue::Null => Ok("NULL".to_string()),
+    }
+}
+
+fn is_finite_decimal(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = usize::from(matches!(bytes.first(), Some(b'+' | b'-')));
+    let integer_start = index;
+    while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+        index += 1;
+    }
+    let has_integer = index > integer_start;
+
+    let mut has_fraction = false;
+    if bytes.get(index) == Some(&b'.') {
+        index += 1;
+        let fraction_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        has_fraction = index > fraction_start;
+    }
+    if !has_integer && !has_fraction {
+        return false;
+    }
+
+    if matches!(bytes.get(index), Some(b'e' | b'E')) {
+        index += 1;
+        if matches!(bytes.get(index), Some(b'+' | b'-')) {
+            index += 1;
+        }
+        let exponent_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        if index == exponent_start {
+            return false;
+        }
+    }
+
+    index == bytes.len()
+}
+
+fn column_alias(ordinal: usize) -> String {
+    format!("__tsql_col_{}", ordinal.saturating_add(1))
+}
+
+fn qualified_column(source_alias: &str, ordinal: usize) -> String {
+    format!(
+        "{source_alias}.{}",
+        quote_identifier(&column_alias(ordinal))
+    )
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn quote_literal(value: &str) -> Result<String, String> {
+    if value.contains('\0') {
+        return Err("text filter value cannot contain a NUL byte".to_string());
+    }
+    Ok(format!(
+        "E'{}'",
+        value.replace('\\', "\\\\").replace('\'', "''")
+    ))
+}
+
+fn escape_like(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers() -> Vec<String> {
+        ["id", "name", "name", "Total \"USD\""]
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn wraps_read_only_source_and_uses_deterministic_ordinal_aliases() {
+        let sql = compile_result_transform(
+            "SELECT id, name, name, amount AS total FROM users; -- trailing",
+            &headers(),
+            &ResultTransform::default(),
+        )
+        .unwrap();
+
+        assert!(sql.starts_with("SELECT \"__tsql_result\".\"__tsql_col_1\" AS \"id\""));
+        assert!(sql.contains(
+            "\"__tsql_col_2\" AS \"name\", \"__tsql_result\".\"__tsql_col_3\" AS \"name\""
+        ));
+        assert!(sql.contains("AS \"Total \"\"USD\"\"\""));
+        assert!(sql.contains("AS \"__tsql_result\" (\"__tsql_col_1\", \"__tsql_col_2\", \"__tsql_col_3\", \"__tsql_col_4\")"));
+        assert!(!sql.contains("; -- trailing"));
+    }
+
+    #[test]
+    fn composes_projection_filters_and_multi_column_ordering() {
+        let spec = ResultTransform {
+            projection: vec![3, 1],
+            filters: vec![
+                ResultFilter {
+                    ordinal: 0,
+                    op: FilterOp::Gte,
+                    value: FilterValue::Integer(10),
+                },
+                ResultFilter {
+                    ordinal: 1,
+                    op: FilterOp::Eq,
+                    value: FilterValue::Text("O'Brien\\ops".to_string()),
+                },
+            ],
+            orders: vec![
+                ResultOrder {
+                    ordinal: 3,
+                    direction: OrderDirection::Desc,
+                },
+                ResultOrder {
+                    ordinal: 0,
+                    direction: OrderDirection::Asc,
+                },
+            ],
+            group_count: None,
+        };
+
+        let sql =
+            compile_result_transform("SELECT id, name, name, total FROM users", &headers(), &spec)
+                .unwrap();
+
+        assert!(sql.starts_with("SELECT \"__tsql_result\".\"__tsql_col_4\" AS \"Total \"\"USD\"\"\", \"__tsql_result\".\"__tsql_col_2\" AS \"name\""));
+        assert!(sql.contains("WHERE \"__tsql_result\".\"__tsql_col_1\" >= 10\n  AND \"__tsql_result\".\"__tsql_col_2\" IS NOT DISTINCT FROM E'O''Brien\\\\ops'"));
+        assert!(sql.ends_with("ORDER BY \"__tsql_result\".\"__tsql_col_4\" DESC, \"__tsql_result\".\"__tsql_col_1\" ASC"));
+        assert!(
+            sql_lexer::single_statement(&sql).is_ok(),
+            "compiled query must remain a single cursor-safe statement: {sql}"
+        );
+    }
+
+    #[test]
+    fn escapes_like_wildcards_and_backslashes() {
+        let spec = ResultTransform {
+            filters: vec![ResultFilter {
+                ordinal: 1,
+                op: FilterOp::Contains,
+                value: FilterValue::Text("100%_done\\ok".to_string()),
+            }],
+            ..ResultTransform::default()
+        };
+
+        let sql =
+            compile_result_transform("SELECT id, name, name, total FROM users", &headers(), &spec)
+                .unwrap();
+
+        assert!(
+            sql.contains("ILIKE E'%100\\\\%\\\\_done\\\\\\\\ok%' ESCAPE E'\\\\'"),
+            "{sql}"
+        );
+    }
+
+    #[test]
+    fn compiles_null_and_typed_comparisons_without_conflating_text_null() {
+        let spec = ResultTransform {
+            filters: vec![
+                ResultFilter {
+                    ordinal: 0,
+                    op: FilterOp::Eq,
+                    value: FilterValue::Null,
+                },
+                ResultFilter {
+                    ordinal: 1,
+                    op: FilterOp::Ne,
+                    value: FilterValue::Null,
+                },
+                ResultFilter {
+                    ordinal: 2,
+                    op: FilterOp::Eq,
+                    value: FilterValue::Text("NULL".to_string()),
+                },
+                ResultFilter {
+                    ordinal: 3,
+                    op: FilterOp::Lt,
+                    value: FilterValue::Decimal("12.5".to_string()),
+                },
+            ],
+            ..ResultTransform::default()
+        };
+
+        let sql =
+            compile_result_transform("SELECT id, name, name, total FROM users", &headers(), &spec)
+                .unwrap();
+
+        assert!(sql.contains("\"__tsql_col_1\" IS NULL"));
+        assert!(sql.contains("\"__tsql_col_2\" IS NOT NULL"));
+        assert!(sql.contains("\"__tsql_col_3\" IS NOT DISTINCT FROM E'NULL'"));
+        assert!(sql.contains("\"__tsql_col_4\" < 12.5"));
+    }
+
+    #[test]
+    fn compiles_group_count_after_filters_and_defaults_to_count_descending() {
+        let spec = ResultTransform {
+            filters: vec![ResultFilter {
+                ordinal: 0,
+                op: FilterOp::Gt,
+                value: FilterValue::Integer(0),
+            }],
+            group_count: Some(1),
+            ..ResultTransform::default()
+        };
+
+        let sql =
+            compile_result_transform("SELECT id, name, name, total FROM users", &headers(), &spec)
+                .unwrap();
+
+        assert!(sql.starts_with(
+            "SELECT \"__tsql_result\".\"__tsql_col_2\" AS \"name\", COUNT(*) AS \"count\""
+        ));
+        assert!(sql.contains("WHERE \"__tsql_result\".\"__tsql_col_1\" > 0"));
+        assert!(sql.contains("GROUP BY \"__tsql_result\".\"__tsql_col_2\""));
+        assert!(sql.ends_with("ORDER BY COUNT(*) DESC"));
+    }
+
+    #[test]
+    fn rejects_unsafe_or_invalid_source_statements() {
+        for source in [
+            "",
+            "SELECT 1; SELECT 2",
+            "UPDATE users SET active = true RETURNING *",
+            "WITH removed AS (DELETE FROM users RETURNING *) SELECT * FROM removed",
+            "SELECT * FROM users FOR UPDATE",
+            "SELECT * FROM users FOR SHARE",
+            "SELECT $1::integer",
+            "SELECT E'unterminated\\'",
+        ] {
+            assert!(
+                compile_result_transform(source, &headers(), &ResultTransform::default()).is_err(),
+                "source should be rejected: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_valid_row_returning_expression_shapes() {
+        for source in [
+            "SELECT 1 AS value",
+            "WITH source AS (SELECT 1 AS value) SELECT value FROM source",
+            "VALUES (1), (2)",
+            "TABLE users",
+            "SELECT '; FOR UPDATE' AS value /* ignored; */",
+        ] {
+            assert!(
+                compile_result_transform(
+                    source,
+                    &["value".to_string()],
+                    &ResultTransform::default()
+                )
+                .is_ok(),
+                "source should be accepted: {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_ordinals_group_order_and_filter_values() {
+        let invalid_specs = [
+            ResultTransform {
+                projection: vec![4],
+                ..ResultTransform::default()
+            },
+            ResultTransform {
+                filters: vec![ResultFilter {
+                    ordinal: 4,
+                    op: FilterOp::Eq,
+                    value: FilterValue::Integer(1),
+                }],
+                ..ResultTransform::default()
+            },
+            ResultTransform {
+                orders: vec![ResultOrder {
+                    ordinal: 4,
+                    direction: OrderDirection::Asc,
+                }],
+                ..ResultTransform::default()
+            },
+            ResultTransform {
+                group_count: Some(1),
+                orders: vec![ResultOrder {
+                    ordinal: 2,
+                    direction: OrderDirection::Asc,
+                }],
+                ..ResultTransform::default()
+            },
+            ResultTransform {
+                filters: vec![ResultFilter {
+                    ordinal: 0,
+                    op: FilterOp::Contains,
+                    value: FilterValue::Integer(1),
+                }],
+                ..ResultTransform::default()
+            },
+            ResultTransform {
+                filters: vec![ResultFilter {
+                    ordinal: 0,
+                    op: FilterOp::Lt,
+                    value: FilterValue::Null,
+                }],
+                ..ResultTransform::default()
+            },
+            ResultTransform {
+                filters: vec![ResultFilter {
+                    ordinal: 0,
+                    op: FilterOp::Eq,
+                    value: FilterValue::Decimal("NaN".to_string()),
+                }],
+                ..ResultTransform::default()
+            },
+            ResultTransform {
+                filters: vec![ResultFilter {
+                    ordinal: 0,
+                    op: FilterOp::Eq,
+                    value: FilterValue::Text("bad\0value".to_string()),
+                }],
+                ..ResultTransform::default()
+            },
+        ];
+
+        for spec in invalid_specs {
+            assert!(
+                compile_result_transform(
+                    "SELECT id, name, name, total FROM users",
+                    &headers(),
+                    &spec
+                )
+                .is_err(),
+                "invalid transform should be rejected: {spec:?}"
+            );
+        }
+        assert!(compile_result_transform("SELECT 1", &[], &ResultTransform::default()).is_err());
+    }
+
+    #[test]
+    fn mutators_reset_and_summary_keep_operations_composable() {
+        let mut spec = ResultTransform::default();
+        assert!(spec.is_empty());
+
+        spec.set_projection(vec![0, 3]);
+        spec.add_filter(ResultFilter {
+            ordinal: 1,
+            op: FilterOp::StartsWith,
+            value: FilterValue::Text("Ada".to_string()),
+        });
+        spec.toggle_order(3);
+        assert_eq!(spec.orders[0].direction, OrderDirection::Asc);
+        spec.toggle_order(3);
+        assert_eq!(spec.orders[0].direction, OrderDirection::Desc);
+        spec.set_order(0, OrderDirection::Asc, true);
+        spec.set_group_count(Some(1));
+
+        assert_eq!(
+            spec.summary(&headers()),
+            "1 filter · sort Total \"USD\" desc, id asc · 2 columns · count by name"
+        );
+        spec.clear_filters();
+        spec.clear_orders();
+        assert!(spec.filters.is_empty());
+        assert!(spec.orders.is_empty());
+        spec.reset();
+        assert!(spec.is_empty());
+    }
+
+    #[test]
+    fn all_filter_operations_render_expected_predicates() {
+        let cases = [
+            (
+                FilterOp::Eq,
+                FilterValue::Integer(1),
+                "IS NOT DISTINCT FROM 1",
+            ),
+            (
+                FilterOp::Ne,
+                FilterValue::Boolean(false),
+                "IS DISTINCT FROM FALSE",
+            ),
+            (FilterOp::Lt, FilterValue::Integer(2), "< 2"),
+            (FilterOp::Lte, FilterValue::Integer(3), "<= 3"),
+            (FilterOp::Gt, FilterValue::Integer(4), "> 4"),
+            (FilterOp::Gte, FilterValue::Integer(5), ">= 5"),
+            (
+                FilterOp::StartsWith,
+                FilterValue::Text("a".to_string()),
+                "ILIKE E'a%'",
+            ),
+            (
+                FilterOp::NotContains,
+                FilterValue::Text("x".to_string()),
+                "NOT ILIKE E'%x%'",
+            ),
+            (
+                FilterOp::NotStartsWith,
+                FilterValue::Text("a".to_string()),
+                "NOT ILIKE E'a%'",
+            ),
+            (
+                FilterOp::EndsWith,
+                FilterValue::Text("z".to_string()),
+                "ILIKE E'%z'",
+            ),
+            (
+                FilterOp::NotEndsWith,
+                FilterValue::Text("z".to_string()),
+                "NOT ILIKE E'%z'",
+            ),
+            (FilterOp::IsNull, FilterValue::Null, "IS NULL"),
+            (FilterOp::IsNotNull, FilterValue::Null, "IS NOT NULL"),
+        ];
+
+        for (op, value, expected) in cases {
+            let sql = compile_result_transform(
+                "SELECT value FROM users",
+                &["value".to_string()],
+                &ResultTransform {
+                    filters: vec![ResultFilter {
+                        ordinal: 0,
+                        op,
+                        value,
+                    }],
+                    ..ResultTransform::default()
+                },
+            )
+            .unwrap();
+            assert!(sql.contains(expected), "expected {expected} in {sql}");
+        }
+    }
+
+    #[test]
+    fn parses_command_values_without_conflating_literal_null() {
+        let cases = [
+            ("42", FilterValue::Integer(42)),
+            (" -9 ", FilterValue::Integer(-9)),
+            ("12.5", FilterValue::Decimal("12.5".to_string())),
+            ("2e3", FilterValue::Decimal("2e3".to_string())),
+            (".125", FilterValue::Decimal(".125".to_string())),
+            ("5.", FilterValue::Decimal("5.".to_string())),
+            ("TRUE", FilterValue::Boolean(true)),
+            ("false", FilterValue::Boolean(false)),
+            ("NULL", FilterValue::Text("NULL".to_string())),
+            ("null", FilterValue::Text("null".to_string())),
+            ("'NULL'", FilterValue::Text("NULL".to_string())),
+            ("'O''Brien'", FilterValue::Text("O'Brien".to_string())),
+            (
+                "\"say \"\"hi\"\"\"",
+                FilterValue::Text("say \"hi\"".to_string()),
+            ),
+            ("plain words", FilterValue::Text("plain words".to_string())),
+            ("NaN", FilterValue::Text("NaN".to_string())),
+            ("Infinity", FilterValue::Text("Infinity".to_string())),
+            ("1e+", FilterValue::Text("1e+".to_string())),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(parse_filter_value(input), expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn preserves_high_precision_decimal_filter_values_exactly() {
+        let decimal = "0.123456789012345678901234567890";
+        let value = parse_filter_value(decimal);
+        assert_eq!(value, FilterValue::Decimal(decimal.to_string()));
+
+        let sql = compile_result_transform(
+            "SELECT amount FROM users",
+            &["amount".to_string()],
+            &ResultTransform {
+                filters: vec![ResultFilter {
+                    ordinal: 0,
+                    op: FilterOp::Eq,
+                    value,
+                }],
+                ..ResultTransform::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            sql.contains(&format!("IS NOT DISTINCT FROM {decimal}")),
+            "high-precision decimal was changed: {sql}"
+        );
+    }
+}

--- a/crates/tsql/src/app/result_transform.rs
+++ b/crates/tsql/src/app/result_transform.rs
@@ -671,6 +671,7 @@ mod tests {
             "VALUES (1), (2)",
             "TABLE users",
             "SELECT '; FOR UPDATE' AS value /* ignored; */",
+            "SELECT foo$1 FROM (VALUES (1)) AS source(foo$1)",
         ] {
             assert!(
                 compile_result_transform(

--- a/crates/tsql/src/app/sql_lexer.rs
+++ b/crates/tsql/src/app/sql_lexer.rs
@@ -1,0 +1,296 @@
+//! Small PostgreSQL-aware lexer shared by notebook execution and refinement.
+
+use std::ops::Range;
+
+/// Lexical regions relevant to structural SQL inspection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SqlSegmentKind {
+    Code,
+    SingleQuoted,
+    DoubleQuoted,
+    DollarQuoted,
+    LineComment,
+    BlockComment,
+}
+
+/// One UTF-8-safe byte range in a SQL source string.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SqlSegment {
+    pub(crate) kind: SqlSegmentKind,
+    pub(crate) range: Range<usize>,
+}
+
+/// Splits SQL into structural code, quoted, and comment regions.
+pub(crate) fn scan(source: &str) -> Result<Vec<SqlSegment>, String> {
+    let bytes = source.as_bytes();
+    let mut segments = Vec::new();
+    let mut index = 0;
+    let mut code_start = 0;
+
+    while index < bytes.len() {
+        let start = index;
+        let kind = match bytes[index] {
+            b'\'' | b'"' => {
+                let delimiter = bytes[index];
+                let escaped = delimiter == b'\'' && is_escape_string(source, index);
+                index += 1;
+                loop {
+                    let Some(character) = source[index..].chars().next() else {
+                        return Err("unterminated SQL literal".to_string());
+                    };
+                    if escaped && character == '\\' {
+                        index += character.len_utf8();
+                        let Some(next) = source[index..].chars().next() else {
+                            return Err("unterminated SQL literal".to_string());
+                        };
+                        index += next.len_utf8();
+                        continue;
+                    }
+                    index += character.len_utf8();
+                    if character == char::from(delimiter) {
+                        if bytes.get(index) == Some(&delimiter) {
+                            index += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                if delimiter == b'\'' {
+                    SqlSegmentKind::SingleQuoted
+                } else {
+                    SqlSegmentKind::DoubleQuoted
+                }
+            }
+            b'$' => {
+                let Some((delimiter_end, delimiter)) = dollar_delimiter(source, index) else {
+                    index += 1;
+                    continue;
+                };
+                let content_start = delimiter_end + 1;
+                let Some(close_offset) = source[content_start..].find(delimiter) else {
+                    return Err("unterminated dollar-quoted SQL literal".to_string());
+                };
+                index = content_start + close_offset + delimiter.len();
+                SqlSegmentKind::DollarQuoted
+            }
+            b'-' if bytes.get(index + 1) == Some(&b'-') => {
+                index = source[index..]
+                    .find(['\r', '\n'])
+                    .map_or(bytes.len(), |offset| index + offset + 1);
+                SqlSegmentKind::LineComment
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                let mut depth = 1usize;
+                index += 2;
+                while depth > 0 {
+                    if bytes.get(index..index + 2) == Some(b"/*") {
+                        depth += 1;
+                        index += 2;
+                    } else if bytes.get(index..index + 2) == Some(b"*/") {
+                        depth -= 1;
+                        index += 2;
+                    } else {
+                        let Some(character) = source[index..].chars().next() else {
+                            return Err("unterminated SQL comment".to_string());
+                        };
+                        index += character.len_utf8();
+                    }
+                }
+                SqlSegmentKind::BlockComment
+            }
+            _ => {
+                let Some(character) = source[index..].chars().next() else {
+                    return Err("invalid UTF-8 boundary while scanning SQL".to_string());
+                };
+                index += character.len_utf8();
+                continue;
+            }
+        };
+
+        if code_start < start {
+            segments.push(SqlSegment {
+                kind: SqlSegmentKind::Code,
+                range: code_start..start,
+            });
+        }
+        segments.push(SqlSegment {
+            kind,
+            range: start..index,
+        });
+        code_start = index;
+    }
+
+    if code_start < source.len() {
+        segments.push(SqlSegment {
+            kind: SqlSegmentKind::Code,
+            range: code_start..source.len(),
+        });
+    }
+    Ok(segments)
+}
+
+/// Returns one statement without its terminal semicolon or trailing comments.
+pub(crate) fn single_statement(source: &str) -> Result<&str, String> {
+    let source = source.trim();
+    if source.is_empty() {
+        return Err("empty SQL statement".to_string());
+    }
+    let segments = scan(source)?;
+    let mut terminal_semicolon = None;
+
+    for segment in segments {
+        match segment.kind {
+            SqlSegmentKind::Code => {
+                for (offset, character) in source[segment.range.clone()].char_indices() {
+                    if character == ';' {
+                        if terminal_semicolon.is_some() {
+                            return Err("multiple SQL statements are not supported".to_string());
+                        }
+                        terminal_semicolon = Some(segment.range.start + offset);
+                    } else if terminal_semicolon.is_some() && !character.is_whitespace() {
+                        return Err("multiple SQL statements are not supported".to_string());
+                    }
+                }
+            }
+            SqlSegmentKind::LineComment | SqlSegmentKind::BlockComment => {}
+            _ if terminal_semicolon.is_some() => {
+                return Err("multiple SQL statements are not supported".to_string());
+            }
+            _ => {}
+        }
+    }
+
+    Ok(terminal_semicolon.map_or(source, |index| source[..index].trim_end()))
+}
+
+/// Replaces comments with whitespace while preserving source byte offsets and newlines.
+pub(crate) fn mask_comments(source: &str) -> Result<String, String> {
+    let mut masked = String::with_capacity(source.len());
+    for segment in scan(source)? {
+        if matches!(
+            segment.kind,
+            SqlSegmentKind::LineComment | SqlSegmentKind::BlockComment
+        ) {
+            for character in source[segment.range].chars() {
+                if matches!(character, '\r' | '\n') {
+                    masked.push(character);
+                } else {
+                    for _ in 0..character.len_utf8() {
+                        masked.push(' ');
+                    }
+                }
+            }
+        } else {
+            masked.push_str(&source[segment.range]);
+        }
+    }
+    Ok(masked)
+}
+
+/// Returns uppercase identifier-like words that occur outside literals and comments.
+pub(crate) fn code_words(source: &str, limit: usize) -> Result<Vec<String>, String> {
+    let mut words = Vec::new();
+    for segment in scan(source)? {
+        if segment.kind != SqlSegmentKind::Code {
+            continue;
+        }
+        let remaining = limit.saturating_sub(words.len());
+        words.extend(
+            source[segment.range]
+                .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+                .filter(|word| !word.is_empty())
+                .take(remaining)
+                .map(str::to_ascii_uppercase),
+        );
+        if words.len() == limit {
+            break;
+        }
+    }
+    Ok(words)
+}
+
+fn is_escape_string(source: &str, quote: usize) -> bool {
+    let bytes = source.as_bytes();
+    if quote > 0 && matches!(bytes[quote - 1], b'E' | b'e') {
+        return quote == 1 || !is_identifier_byte(bytes[quote - 2]);
+    }
+    quote >= 2
+        && matches!(bytes[quote - 2], b'U' | b'u')
+        && bytes[quote - 1] == b'&'
+        && (quote == 2 || !is_identifier_byte(bytes[quote - 3]))
+}
+
+fn dollar_delimiter(source: &str, start: usize) -> Option<(usize, &str)> {
+    let end = start + 1 + source[start + 1..].find('$')?;
+    let tag = &source[start + 1..end];
+    let mut characters = tag.chars();
+    let valid = characters.next().is_none_or(|character| {
+        (character.is_ascii_alphabetic() || character == '_')
+            && characters.all(|character| character.is_ascii_alphanumeric() || character == '_')
+    });
+    valid.then_some((end, &source[start..=end]))
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_escape_strings_and_preserves_structural_boundaries() {
+        let source =
+            "SELECT E'it\\'s @result_1; -- not a comment', U&'one\\0027two', 'plain;value';";
+        let segments = scan(source).unwrap();
+
+        assert_eq!(
+            segments
+                .iter()
+                .map(|segment| segment.kind)
+                .collect::<Vec<_>>(),
+            [
+                SqlSegmentKind::Code,
+                SqlSegmentKind::SingleQuoted,
+                SqlSegmentKind::Code,
+                SqlSegmentKind::SingleQuoted,
+                SqlSegmentKind::Code,
+                SqlSegmentKind::SingleQuoted,
+                SqlSegmentKind::Code,
+            ]
+        );
+        assert_eq!(
+            single_statement(source).unwrap(),
+            source.trim_end_matches(';')
+        );
+    }
+
+    #[test]
+    fn skips_unicode_dollar_quotes_and_nested_comments() {
+        let source =
+            "/* café /* nested; */ 🙂 */ SELECT $body$one; @result_2$body$ AS value -- naïve;\n;";
+        let statement = single_statement(source).unwrap();
+        assert!(statement.ends_with("-- naïve;"));
+        assert_eq!(code_words(statement, 4).unwrap(), ["SELECT", "AS", "VALUE"]);
+        let masked = mask_comments(statement).unwrap();
+        assert_eq!(masked.len(), statement.len());
+        assert!(masked.contains("SELECT $body$one; @result_2$body$"));
+        assert!(!masked.contains("nested"));
+    }
+
+    #[test]
+    fn rejects_multiple_and_unterminated_statements() {
+        for source in [
+            "SELECT 1; SELECT 2",
+            "SELECT $$one;two$$; SELECT 2",
+            "SELECT 1 /* ignored; */; SELECT 2",
+            "SELECT 'unterminated",
+            "SELECT E'unterminated\\'",
+            "SELECT $tag$unterminated",
+            "SELECT /* unterminated",
+        ] {
+            assert!(single_statement(source).is_err(), "accepted: {source}");
+        }
+    }
+}

--- a/crates/tsql/src/app/state.rs
+++ b/crates/tsql/src/app/state.rs
@@ -10,6 +10,7 @@ pub enum SidebarSection {
 pub enum Focus {
     Query,
     Grid,
+    Notebook,
     Sidebar(SidebarSection),
 }
 
@@ -18,10 +19,19 @@ impl Focus {
         match self {
             Focus::Query => "QUERY",
             Focus::Grid => "RESULTS",
+            Focus::Notebook => "NOTEBOOK",
             Focus::Sidebar(SidebarSection::Connections) => "CONNECTIONS",
             Focus::Sidebar(SidebarSection::Schema) => "SCHEMA",
         }
     }
+}
+
+/// Which main workspace is visible.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WorkspaceMode {
+    #[default]
+    Classic,
+    Notebook,
 }
 
 /// Direction for spatial pane navigation.

--- a/crates/tsql/src/config/connections.rs
+++ b/crates/tsql/src/config/connections.rs
@@ -1229,7 +1229,7 @@ impl ConnectionsFile {
                 });
             }
             SortMode::Alpha => {
-                sorted.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+                sorted.sort_by_key(|a| a.name.to_lowercase());
             }
             SortMode::Folder => {
                 sorted.sort_by(|a, b| {

--- a/crates/tsql/src/config/keymap.rs
+++ b/crates/tsql/src/config/keymap.rs
@@ -55,6 +55,22 @@ pub enum Action {
     ExecuteQuery,
     CancelQuery,
 
+    // Notebook cell actions
+    PreviousCell,
+    NextCell,
+    FirstCell,
+    LastCell,
+    EnterCellEditor,
+    InspectCellResult,
+    ExecuteCellAndAdvance,
+    NewNotebookCell,
+    RefineNotebookCell,
+    ToggleCellOutput,
+    CollapseCellOutput,
+    ExpandCellOutput,
+    ClearNotebookCellExecution,
+    DeleteNotebookCell,
+
     // Grid actions
     SelectRow,
     GridSelectAll,
@@ -155,6 +171,20 @@ impl Action {
             Action::SelectAll => "Select all",
             Action::ExecuteQuery => "Execute query",
             Action::CancelQuery => "Cancel running query",
+            Action::PreviousCell => "Select previous notebook cell",
+            Action::NextCell => "Select next notebook cell",
+            Action::FirstCell => "Select first notebook cell",
+            Action::LastCell => "Select last notebook cell",
+            Action::EnterCellEditor => "Edit selected notebook cell",
+            Action::InspectCellResult => "Inspect selected cell result",
+            Action::ExecuteCellAndAdvance => "Execute cell and advance",
+            Action::NewNotebookCell => "Select or create notebook draft",
+            Action::RefineNotebookCell => "Refine selected cell result",
+            Action::ToggleCellOutput => "Collapse or expand cell output",
+            Action::CollapseCellOutput => "Collapse selected cell output",
+            Action::ExpandCellOutput => "Expand selected cell output",
+            Action::ClearNotebookCellExecution => "Clear cell and dependent executions",
+            Action::DeleteNotebookCell => "Delete selected notebook cell",
             Action::SelectRow => "Select/toggle row",
             Action::GridSelectAll => "Select all rows",
             Action::ClearSelection => "Clear selection",
@@ -253,6 +283,20 @@ impl FromStr for Action {
             // Query execution
             "execute_query" => Ok(Action::ExecuteQuery),
             "cancel_query" => Ok(Action::CancelQuery),
+            "previous_cell" => Ok(Action::PreviousCell),
+            "next_cell" => Ok(Action::NextCell),
+            "first_cell" => Ok(Action::FirstCell),
+            "last_cell" => Ok(Action::LastCell),
+            "enter_cell_editor" => Ok(Action::EnterCellEditor),
+            "inspect_cell_result" => Ok(Action::InspectCellResult),
+            "execute_cell_and_advance" => Ok(Action::ExecuteCellAndAdvance),
+            "new_notebook_cell" => Ok(Action::NewNotebookCell),
+            "refine_notebook_cell" => Ok(Action::RefineNotebookCell),
+            "toggle_cell_output" => Ok(Action::ToggleCellOutput),
+            "collapse_cell_output" => Ok(Action::CollapseCellOutput),
+            "expand_cell_output" => Ok(Action::ExpandCellOutput),
+            "clear_notebook_cell_execution" => Ok(Action::ClearNotebookCellExecution),
+            "delete_notebook_cell" => Ok(Action::DeleteNotebookCell),
 
             // Grid actions
             "select_row" => Ok(Action::SelectRow),
@@ -964,6 +1008,106 @@ impl Keymap {
         km
     }
 
+    /// Create the default keymap for Notebook Cell focus.
+    pub fn default_notebook_keymap() -> Self {
+        let mut keymap = Self::new();
+        keymap.bind_focus_cycle();
+        keymap.bind_directional_focus(KeyModifiers::CONTROL);
+        keymap.bind_directional_focus(KeyModifiers::ALT);
+        for code in [KeyCode::Char('k'), KeyCode::Up] {
+            keymap.bind(
+                KeyBinding::new(code, KeyModifiers::NONE),
+                Action::PreviousCell,
+            );
+        }
+        for code in [KeyCode::Char('j'), KeyCode::Down] {
+            keymap.bind(KeyBinding::new(code, KeyModifiers::NONE), Action::NextCell);
+        }
+        keymap.bind(
+            KeyBinding::new(KeyCode::Home, KeyModifiers::NONE),
+            Action::FirstCell,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::End, KeyModifiers::NONE),
+            Action::LastCell,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            Action::LastCell,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('G'), KeyModifiers::NONE),
+            Action::LastCell,
+        );
+        for code in [KeyCode::Enter, KeyCode::Char('e')] {
+            keymap.bind(
+                KeyBinding::new(code, KeyModifiers::NONE),
+                Action::EnterCellEditor,
+            );
+        }
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('o'), KeyModifiers::NONE),
+            Action::InspectCellResult,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('n'), KeyModifiers::NONE),
+            Action::NewNotebookCell,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            Action::RefineNotebookCell,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('z'), KeyModifiers::NONE),
+            Action::ToggleCellOutput,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('h'), KeyModifiers::NONE),
+            Action::CollapseCellOutput,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('l'), KeyModifiers::NONE),
+            Action::ExpandCellOutput,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            Action::ClearNotebookCellExecution,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('e'), KeyModifiers::CONTROL),
+            Action::ExecuteQuery,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('E'), KeyModifiers::SHIFT),
+            Action::ExecuteCellAndAdvance,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::PageUp, KeyModifiers::NONE),
+            Action::PageUp,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::PageDown, KeyModifiers::NONE),
+            Action::PageDown,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('u'), KeyModifiers::CONTROL),
+            Action::HalfPageUp,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char('d'), KeyModifiers::CONTROL),
+            Action::HalfPageDown,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Delete, KeyModifiers::NONE),
+            Action::DeleteNotebookCell,
+        );
+        keymap.bind(
+            KeyBinding::new(KeyCode::Char(':'), KeyModifiers::NONE),
+            Action::EnterCommandMode,
+        );
+        keymap
+    }
+
     /// Create the default keymap for the query editor in visual mode.
     pub fn default_editor_visual_keymap() -> Self {
         let mut km = Self::new();
@@ -1136,6 +1280,20 @@ mod tests {
     }
 
     #[test]
+    fn test_default_notebook_keymap() {
+        let km = Keymap::default_notebook_keymap();
+        let colon = KeyBinding::new(KeyCode::Char(':'), KeyModifiers::NONE);
+        let h = KeyBinding::new(KeyCode::Char('h'), KeyModifiers::NONE);
+        let l = KeyBinding::new(KeyCode::Char('l'), KeyModifiers::NONE);
+        let x = KeyBinding::new(KeyCode::Char('x'), KeyModifiers::NONE);
+
+        assert_eq!(km.get(&colon), Some(&Action::EnterCommandMode));
+        assert_eq!(km.get(&h), Some(&Action::CollapseCellOutput));
+        assert_eq!(km.get(&l), Some(&Action::ExpandCellOutput));
+        assert_eq!(km.get(&x), Some(&Action::ClearNotebookCellExecution));
+    }
+
+    #[test]
     fn test_visual_and_sidebar_focus_keymaps() {
         let visual = Keymap::default_editor_visual_keymap();
         let sidebar = Keymap::default_sidebar_keymap();
@@ -1204,6 +1362,18 @@ mod tests {
         assert_eq!("focus_down".parse::<Action>().unwrap(), Action::FocusDown);
         assert_eq!("focus_up".parse::<Action>().unwrap(), Action::FocusUp);
         assert_eq!("focus_right".parse::<Action>().unwrap(), Action::FocusRight);
+        assert_eq!(
+            "collapse_cell_output".parse::<Action>().unwrap(),
+            Action::CollapseCellOutput
+        );
+        assert_eq!(
+            "expand_cell_output".parse::<Action>().unwrap(),
+            Action::ExpandCellOutput
+        );
+        assert_eq!(
+            "clear_notebook_cell_execution".parse::<Action>().unwrap(),
+            Action::ClearNotebookCellExecution
+        );
     }
 
     #[test]

--- a/crates/tsql/src/config/mod.rs
+++ b/crates/tsql/src/config/mod.rs
@@ -18,8 +18,8 @@ pub use connections::{
 pub use keymap::{Action, KeyBinding, Keymap};
 pub use schema::{
     AiConfig, AiProvider, ClipboardBackend, ClipboardConfig, Config, ConnectionConfig,
-    CustomKeyBinding, DisplayConfig, EditorConfig, IdentifierStyle, KeymapConfig, SqlConfig,
-    UpdateChannel, UpdateMode, UpdatesConfig,
+    CustomKeyBinding, DisplayConfig, EditorConfig, IdentifierStyle, KeymapConfig, NotebookConfig,
+    SnapshotMode, SqlConfig, UpdateChannel, UpdateMode, UpdatesConfig,
 };
 
 use anyhow::{Context, Result};

--- a/crates/tsql/src/config/schema.rs
+++ b/crates/tsql/src/config/schema.rs
@@ -23,6 +23,54 @@ pub struct Config {
     pub updates: UpdatesConfig,
     /// AI assistant settings
     pub ai: AiConfig,
+    /// Notebook workspace and snapshot retention settings.
+    pub notebook: NotebookConfig,
+}
+
+/// Notebook workspace and retained-result settings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NotebookConfig {
+    /// Start in Notebook instead of Classic workspace.
+    pub startup: bool,
+    /// Whether eligible PostgreSQL results should be retained automatically.
+    pub snapshot_mode: SnapshotMode,
+    /// Maximum complete row count retained for refinement.
+    pub snapshot_max_rows: usize,
+    /// Maximum size of one retained snapshot.
+    pub snapshot_max_bytes: u64,
+    /// Maximum aggregate size of retained snapshots.
+    pub snapshot_total_bytes: u64,
+    /// Maximum number of retained snapshots.
+    pub max_retained_snapshots: usize,
+    /// Maximum visible source rows in one composer.
+    pub composer_max_rows: usize,
+    /// Maximum result rows shown inline.
+    pub output_preview_rows: usize,
+}
+
+impl Default for NotebookConfig {
+    fn default() -> Self {
+        Self {
+            startup: false,
+            snapshot_mode: SnapshotMode::Auto,
+            snapshot_max_rows: 2_000,
+            snapshot_max_bytes: 64 * 1024 * 1024,
+            snapshot_total_bytes: 128 * 1024 * 1024,
+            max_retained_snapshots: 8,
+            composer_max_rows: 10,
+            output_preview_rows: 12,
+        }
+    }
+}
+
+/// Automatic snapshot behavior for notebook queries.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotMode {
+    #[default]
+    Auto,
+    Off,
 }
 
 /// Display-related settings
@@ -192,6 +240,9 @@ pub struct KeymapConfig {
     /// Custom keybindings for grid navigation
     #[serde(default)]
     pub grid: Vec<CustomKeyBinding>,
+    /// Custom keybindings for Notebook Cell focus.
+    #[serde(default)]
+    pub notebook: Vec<CustomKeyBinding>,
     /// Custom keybindings for sidebar navigation
     #[serde(default)]
     pub sidebar: Vec<CustomKeyBinding>,
@@ -209,6 +260,7 @@ impl Default for KeymapConfig {
             insert: Vec::new(),
             visual: Vec::new(),
             grid: Vec::new(),
+            notebook: Vec::new(),
             sidebar: Vec::new(),
             connection_form: Vec::new(),
         }

--- a/crates/tsql/src/config/schema.rs
+++ b/crates/tsql/src/config/schema.rs
@@ -43,9 +43,7 @@ pub struct DisplayConfig {
     pub show_null_indicator: bool,
     /// NULL indicator text
     pub null_indicator: String,
-    /// Show borders around cells
-    pub show_borders: bool,
-    /// Theme name (for future theme support)
+    /// Built-in or custom theme name
     pub theme: String,
 }
 
@@ -59,7 +57,6 @@ impl Default for DisplayConfig {
             truncate_cells: true,
             show_null_indicator: true,
             null_indicator: "NULL".to_string(),
-            show_borders: true,
             theme: "default".to_string(),
         }
     }
@@ -541,5 +538,19 @@ description = "Focus the next pane"
         assert!(toml_str.contains("[connection]"));
         assert!(toml_str.contains("[updates]"));
         assert!(toml_str.contains("[ai]"));
+    }
+
+    #[test]
+    fn test_removed_show_borders_field_is_ignored() {
+        let config: Config = toml::from_str(
+            r#"
+            [display]
+            show_borders = true
+            theme = "github_light"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.display.theme, "github_light");
     }
 }

--- a/crates/tsql/src/history.rs
+++ b/crates/tsql/src/history.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::history_path;
 
+const MAX_SAVED_SNIPPETS: usize = 512;
+
 /// A single history entry with metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryEntry {
@@ -39,11 +41,29 @@ impl HistoryEntry {
     }
 }
 
+/// A named, reusable query saved independently of execution history.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SavedQuerySnippet {
+    /// Human-readable snippet name, unique without regard to case.
+    pub name: String,
+    /// The SQL or Mongo query source.
+    pub query: String,
+    /// Optional connection hint (sanitized - no passwords).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection: Option<String>,
+    /// When this snippet was first saved.
+    pub created_at: DateTime<Utc>,
+    /// When this snippet was most recently updated.
+    pub updated_at: DateTime<Utc>,
+}
+
 /// The history file format.
 #[derive(Debug, Serialize, Deserialize)]
 struct HistoryFile {
     version: u32,
     entries: Vec<HistoryEntry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    snippets: Vec<SavedQuerySnippet>,
 }
 
 impl Default for HistoryFile {
@@ -51,6 +71,7 @@ impl Default for HistoryFile {
         Self {
             version: 1,
             entries: Vec::new(),
+            snippets: Vec::new(),
         }
     }
 }
@@ -71,6 +92,7 @@ pub struct HistoryMatch {
 /// Manages query history with persistence and fuzzy search.
 pub struct History {
     entries: Vec<HistoryEntry>,
+    snippets: Vec<SavedQuerySnippet>,
     max_entries: usize,
     path: PathBuf,
     dirty: bool,
@@ -85,17 +107,21 @@ impl History {
 
     /// Load history from a specific path.
     pub fn load_from_path(path: &Path, max_entries: usize) -> Result<Self> {
-        let entries = if path.exists() {
+        let (entries, mut snippets) = if path.exists() {
             let content = fs::read_to_string(path)
                 .with_context(|| format!("Failed to read history file: {}", path.display()))?;
 
             let file: HistoryFile = serde_json::from_str(&content)
                 .with_context(|| format!("Failed to parse history file: {}", path.display()))?;
 
-            file.entries
+            (file.entries, file.snippets)
         } else {
-            Vec::new()
+            (Vec::new(), Vec::new())
         };
+
+        if snippets.len() > MAX_SAVED_SNIPPETS {
+            snippets.drain(..snippets.len() - MAX_SAVED_SNIPPETS);
+        }
 
         // Enforce max_entries limit on load, skipping pinned entries when pruning.
         let mut entries = entries;
@@ -109,6 +135,7 @@ impl History {
 
         Ok(Self {
             entries,
+            snippets,
             max_entries,
             path: path.to_path_buf(),
             dirty: false,
@@ -119,6 +146,7 @@ impl History {
     pub fn new_empty(max_entries: usize) -> Self {
         Self {
             entries: Vec::new(),
+            snippets: Vec::new(),
             max_entries,
             path: PathBuf::new(),
             dirty: false,
@@ -140,6 +168,7 @@ impl History {
         let file = HistoryFile {
             version: 1,
             entries: self.entries.clone(),
+            snippets: self.snippets.clone(),
         };
 
         let content = serde_json::to_string_pretty(&file).context("Failed to serialize history")?;
@@ -195,6 +224,93 @@ impl History {
     /// Get all history entries (oldest first).
     pub fn entries(&self) -> &[HistoryEntry] {
         &self.entries
+    }
+
+    /// Returns saved snippets in their stable creation order.
+    pub fn snippets(&self) -> &[SavedQuerySnippet] {
+        &self.snippets
+    }
+
+    /// Creates or replaces a named query snippet. Names are case-insensitive.
+    pub fn save_snippet(
+        &mut self,
+        name: &str,
+        query: String,
+        connection: Option<String>,
+    ) -> Result<()> {
+        let name = name.trim();
+        anyhow::ensure!(!name.is_empty(), "Snippet name cannot be empty");
+        anyhow::ensure!(name.chars().count() <= 80, "Snippet name is too long");
+        let query = query.trim();
+        anyhow::ensure!(!query.is_empty(), "Cannot save an empty query snippet");
+
+        let now = Utc::now();
+        if let Some(snippet) = self
+            .snippets
+            .iter_mut()
+            .find(|snippet| snippet.name.eq_ignore_ascii_case(name))
+        {
+            snippet.name = name.to_string();
+            snippet.query = query.to_string();
+            snippet.connection = connection;
+            snippet.updated_at = now;
+        } else {
+            anyhow::ensure!(
+                self.snippets.len() < MAX_SAVED_SNIPPETS,
+                "Cannot save more than {MAX_SAVED_SNIPPETS} query snippets"
+            );
+            self.snippets.push(SavedQuerySnippet {
+                name: name.to_string(),
+                query: query.to_string(),
+                connection,
+                created_at: now,
+                updated_at: now,
+            });
+        }
+        self.dirty = true;
+        Ok(())
+    }
+
+    /// Removes a named query snippet. Returns whether a snippet was removed.
+    pub fn remove_snippet(&mut self, name: &str) -> bool {
+        let Some(index) = self
+            .snippets
+            .iter()
+            .position(|snippet| snippet.name.eq_ignore_ascii_case(name.trim()))
+        else {
+            return false;
+        };
+        self.snippets.remove(index);
+        self.dirty = true;
+        true
+    }
+
+    /// Fuzzy-searches saved snippets by both name and query source.
+    pub fn search_snippets(&self, pattern: &str) -> Vec<SavedQuerySnippet> {
+        if pattern.trim().is_empty() {
+            return self.snippets.iter().rev().cloned().collect();
+        }
+
+        let mut matcher = Matcher::new(Config::DEFAULT);
+        let pattern = Pattern::parse(pattern, CaseMatching::Ignore, Normalization::Smart);
+        let mut matches = self
+            .snippets
+            .iter()
+            .filter_map(|snippet| {
+                let text = format!("{} {}", snippet.name, snippet.query);
+                let mut indices = Vec::new();
+                let mut buffer = Vec::new();
+                pattern
+                    .indices(
+                        Utf32Str::new(&text, &mut buffer),
+                        &mut matcher,
+                        &mut indices,
+                    )
+                    .map(|score| (score, snippet.clone()))
+            })
+            .collect::<Vec<_>>();
+        matches.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
+        matches.into_iter().map(|(_, snippet)| snippet).collect()
     }
 
     /// Get the number of entries.
@@ -465,6 +581,7 @@ mod tests {
         let file = HistoryFile {
             version: 1,
             entries,
+            snippets: Vec::new(),
         };
         let mut f = fs::File::create(&path).unwrap();
         f.write_all(serde_json::to_string(&file).unwrap().as_bytes())
@@ -492,6 +609,7 @@ mod tests {
             entries: (1..=10)
                 .map(|i| HistoryEntry::new(format!("query{}", i), None))
                 .collect(),
+            snippets: Vec::new(),
         };
 
         let mut f = fs::File::create(&path).unwrap();
@@ -506,6 +624,78 @@ mod tests {
         assert_eq!(history.entries()[1].query, "query9");
         assert_eq!(history.entries()[2].query, "query10");
 
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn snippets_round_trip_update_case_insensitively_and_search_name_or_source() {
+        let path = temp_path();
+        let _ = fs::remove_file(&path);
+        let created_at;
+
+        {
+            let mut history = History::load_from_path(&path, 100).unwrap();
+            history
+                .save_snippet(
+                    "Recent users",
+                    " SELECT * FROM users ORDER BY created_at DESC ".to_string(),
+                    Some("localhost/app".to_string()),
+                )
+                .unwrap();
+            created_at = history.snippets()[0].created_at;
+            history
+                .save_snippet("recent USERS", "SELECT id FROM users".to_string(), None)
+                .unwrap();
+            assert_eq!(history.snippets().len(), 1);
+            assert_eq!(history.snippets()[0].created_at, created_at);
+            assert_eq!(history.snippets()[0].name, "recent USERS");
+            assert_eq!(history.snippets()[0].query, "SELECT id FROM users");
+            assert!(history.snippets()[0].connection.is_none());
+            assert_eq!(history.search_snippets("recent").len(), 1);
+            assert_eq!(history.search_snippets("id users").len(), 1);
+            history.save().unwrap();
+        }
+
+        let history = History::load_from_path(&path, 100).unwrap();
+        assert_eq!(history.snippets().len(), 1);
+        assert_eq!(history.snippets()[0].created_at, created_at);
+        assert_eq!(history.search_snippets("")[0].query, "SELECT id FROM users");
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn snippet_validation_and_removal_are_safe() {
+        let mut history = History::new_empty(100);
+        assert!(history
+            .save_snippet(" ", "SELECT 1".to_string(), None)
+            .is_err());
+        assert!(history
+            .save_snippet("valid", "  ".to_string(), None)
+            .is_err());
+        assert!(history
+            .save_snippet(&"x".repeat(81), "SELECT 1".to_string(), None)
+            .is_err());
+        history
+            .save_snippet("Useful", "SELECT 1".to_string(), None)
+            .unwrap();
+        assert!(!history.remove_snippet("missing"));
+        assert!(history.remove_snippet(" useful "));
+        assert!(history.snippets().is_empty());
+    }
+
+    #[test]
+    fn legacy_history_without_snippets_still_loads() {
+        let path = temp_path();
+        let _ = fs::remove_file(&path);
+        fs::write(
+            &path,
+            r#"{"version":1,"entries":[{"query":"SELECT 1","timestamp":"2026-01-01T00:00:00Z","pinned":false}]}"#,
+        )
+        .unwrap();
+
+        let history = History::load_from_path(&path, 100).unwrap();
+        assert_eq!(history.len(), 1);
+        assert!(history.snippets().is_empty());
         fs::remove_file(&path).ok();
     }
 }

--- a/crates/tsql/src/history.rs
+++ b/crates/tsql/src/history.rs
@@ -251,7 +251,7 @@ impl History {
             .collect();
 
         // Sort by score descending (best matches first).
-        matches.sort_by(|a, b| b.score.cmp(&a.score));
+        matches.sort_by_key(|b| std::cmp::Reverse(b.score));
 
         matches
     }

--- a/crates/tsql/src/main.rs
+++ b/crates/tsql/src/main.rs
@@ -2,7 +2,10 @@ use std::env;
 use std::io::{self, Stdout, Write};
 
 use anyhow::{Context, Result};
-use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent};
+use crossterm::event::{
+    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+    Event, KeyCode, KeyEvent,
+};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -520,7 +523,12 @@ fn run_debug_keys(with_mouse: bool) -> Result<()> {
 fn init_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )?;
 
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
@@ -532,7 +540,8 @@ fn restore_terminal(mut terminal: Terminal<CrosstermBackend<Stdout>>) -> Result<
     execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,
-        DisableMouseCapture
+        DisableMouseCapture,
+        DisableBracketedPaste
     )?;
     terminal.show_cursor()?;
     Ok(())

--- a/crates/tsql/src/main.rs
+++ b/crates/tsql/src/main.rs
@@ -13,7 +13,7 @@ use ratatui::Terminal;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 
-use tsql::app::App;
+use tsql::app::{App, WorkspaceMode};
 use tsql::config;
 use tsql::session::load_session;
 use tsql::ui::GridModel;
@@ -155,6 +155,7 @@ fn print_usage() {
     eprintln!("      --debug-keys  Print detected key/mouse events (for troubleshooting)");
     eprintln!("      --mouse       (with --debug-keys) Also print mouse events");
     eprintln!("      --safe-mode   Skip session reconnect and startup side effects");
+    eprintln!("      --notebook    Start in the notebook workspace");
     eprintln!("      --no-auto-connect");
     eprintln!("                    Alias for --safe-mode");
     eprintln!();
@@ -303,6 +304,7 @@ fn main() -> Result<()> {
     }
 
     let safe_mode = has_any_startup_option(&args, &["--safe-mode", "--no-auto-connect"]);
+    let notebook_mode = has_any_startup_option(&args, &["--notebook"]);
     let mut startup_warnings: Vec<String> = Vec::new();
 
     if let Err(err) = config::migrate_legacy_config_dir_on_startup() {
@@ -371,6 +373,9 @@ fn main() -> Result<()> {
 
     // Apply session state (editor content, sidebar visibility, pending schema expanded)
     let session_connection = app.apply_session_state(session);
+    if notebook_mode {
+        app.switch_workspace(WorkspaceMode::Notebook);
+    }
 
     // Auto-connect from session if no CLI/env connection was specified. Queue
     // it for after the first draw so keychain/1Password cannot black-screen

--- a/crates/tsql/src/main.rs
+++ b/crates/tsql/src/main.rs
@@ -349,6 +349,7 @@ fn main() -> Result<()> {
         cfg,
     );
     app.set_safe_mode(safe_mode);
+    startup_warnings.extend(app.take_startup_warnings());
 
     // Display startup warnings.
     if let Some(warning) = libpq_warning {

--- a/crates/tsql/src/session.rs
+++ b/crates/tsql/src/session.rs
@@ -3,8 +3,10 @@
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 
@@ -12,6 +14,145 @@ use crate::config::config_dir;
 
 /// Current session file schema version.
 const SESSION_VERSION: u32 = 2;
+const NOTEBOOK_FILE_VERSION: u32 = 1;
+pub const MAX_NOTEBOOK_RUN_HISTORY: usize = 20;
+const MAX_NOTEBOOK_RUN_SOURCE_CHARS: usize = 64 * 1024;
+const MAX_NOTEBOOK_RUN_PREVIEW_ROWS: usize = 5;
+const MAX_NOTEBOOK_RUN_PREVIEW_COLUMNS: usize = 24;
+const MAX_NOTEBOOK_RUN_PREVIEW_CELL_CHARS: usize = 240;
+const MAX_NOTEBOOK_RUN_ERROR_CHARS: usize = 8 * 1024;
+
+/// Durable status for a completed notebook-cell execution.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NotebookRunStatus {
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+/// A compact, portable record of a previous cell execution and its output preview.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotebookRunRecord {
+    pub execution_id: u64,
+    pub source_revision: u64,
+    pub source: String,
+    pub status: NotebookRunStatus,
+    pub finished_at: DateTime<Utc>,
+    #[serde(default)]
+    pub elapsed_ms: u64,
+    #[serde(default)]
+    pub row_count: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub headers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rows: Vec<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub truncated: bool,
+}
+
+impl NotebookRunRecord {
+    /// Creates a durable run record. Call `with_output` or `with_error` for details.
+    pub fn new(
+        execution_id: u64,
+        source_revision: u64,
+        source: String,
+        status: NotebookRunStatus,
+    ) -> Self {
+        Self {
+            execution_id,
+            source_revision,
+            source,
+            status,
+            finished_at: Utc::now(),
+            elapsed_ms: 0,
+            row_count: 0,
+            headers: Vec::new(),
+            rows: Vec::new(),
+            error: None,
+            truncated: false,
+        }
+    }
+
+    /// Captures a compact output preview from a completed execution.
+    pub fn with_output(
+        mut self,
+        elapsed: Duration,
+        row_count: usize,
+        headers: &[String],
+        rows: &[Vec<String>],
+        truncated: bool,
+    ) -> Self {
+        self.elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+        self.row_count = row_count;
+        self.headers = headers
+            .iter()
+            .take(MAX_NOTEBOOK_RUN_PREVIEW_COLUMNS)
+            .cloned()
+            .collect();
+        self.rows = rows
+            .iter()
+            .take(MAX_NOTEBOOK_RUN_PREVIEW_ROWS)
+            .cloned()
+            .collect();
+        self.truncated = truncated || row_count > self.rows.len();
+        self.bounded()
+    }
+
+    /// Captures a failed or cancelled execution's error and elapsed time.
+    pub fn with_error(mut self, elapsed: Duration, error: Option<String>) -> Self {
+        self.elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+        self.error = error;
+        self.bounded()
+    }
+
+    /// Bounds all variable-sized fields so one cell's history cannot grow without limit.
+    pub fn bounded(mut self) -> Self {
+        self.source = truncate_chars(self.source, MAX_NOTEBOOK_RUN_SOURCE_CHARS);
+        self.headers.truncate(MAX_NOTEBOOK_RUN_PREVIEW_COLUMNS);
+        self.headers = self
+            .headers
+            .into_iter()
+            .map(|header| truncate_chars(header, MAX_NOTEBOOK_RUN_PREVIEW_CELL_CHARS))
+            .collect();
+        self.rows.truncate(MAX_NOTEBOOK_RUN_PREVIEW_ROWS);
+        for row in &mut self.rows {
+            row.truncate(MAX_NOTEBOOK_RUN_PREVIEW_COLUMNS);
+            for value in row {
+                *value = truncate_chars(std::mem::take(value), MAX_NOTEBOOK_RUN_PREVIEW_CELL_CHARS);
+            }
+        }
+        self.error = self
+            .error
+            .map(|error| truncate_chars(error, MAX_NOTEBOOK_RUN_ERROR_CHARS));
+        self
+    }
+}
+
+/// Keeps the newest bounded run records in chronological order.
+pub fn bounded_notebook_run_history(mut history: Vec<NotebookRunRecord>) -> Vec<NotebookRunRecord> {
+    if history.len() > MAX_NOTEBOOK_RUN_HISTORY {
+        history.drain(..history.len() - MAX_NOTEBOOK_RUN_HISTORY);
+    }
+    history
+        .into_iter()
+        .map(NotebookRunRecord::bounded)
+        .collect()
+}
+
+fn truncate_chars(value: String, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value;
+    }
+    let mut truncated = value
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    truncated.push('…');
+    truncated
+}
 
 /// Persisted notebook cell state. Runtime outputs and snapshot handles are excluded.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -19,12 +160,23 @@ pub struct NotebookCellSession {
     /// Stable runtime cell identity used by persisted structural dependencies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cell_id: Option<u64>,
+    /// Optional stable name exposed as `@result_<name>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_name: Option<String>,
     #[serde(default)]
     pub source: String,
+    #[serde(default)]
+    pub source_collapsed: bool,
     #[serde(default)]
     pub output_collapsed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dependency: Option<NotebookDependencySession>,
+    /// Additional immutable sources for a cell that joins multiple results.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub additional_dependencies: Vec<NotebookDependencySession>,
+    /// Bounded metadata and output previews from previous cell executions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub execution_history: Vec<NotebookRunRecord>,
 }
 
 /// Persisted structural lineage to an immutable result version.
@@ -90,12 +242,36 @@ fn default_workspace() -> String {
     "classic".to_string()
 }
 
+fn bounded_notebook_session(mut notebook: NotebookSession) -> NotebookSession {
+    for cell in &mut notebook.cells {
+        cell.execution_history =
+            bounded_notebook_run_history(std::mem::take(&mut cell.execution_history));
+    }
+    notebook
+}
+
+fn source_only_notebook_session(mut notebook: NotebookSession) -> NotebookSession {
+    for cell in &mut notebook.cells {
+        cell.execution_history.clear();
+    }
+    notebook
+}
+
 /// The session file format with versioning.
 #[derive(Debug, Serialize, Deserialize)]
 struct SessionFile {
     version: u32,
     #[serde(flatten)]
     state: SessionState,
+}
+
+/// Portable, source-only notebook document. Runtime outputs and backend handles
+/// are deliberately excluded so documents can be safely reopened or shared.
+#[derive(Debug, Serialize, Deserialize)]
+struct NotebookFile {
+    version: u32,
+    #[serde(flatten)]
+    notebook: NotebookSession,
 }
 
 impl Default for SessionFile {
@@ -143,7 +319,9 @@ pub fn load_session_from_path(path: &Path) -> Result<SessionState> {
         return Ok(SessionState::default());
     }
 
-    Ok(file.state)
+    let mut state = file.state;
+    state.notebook = bounded_notebook_session(state.notebook);
+    Ok(state)
 }
 
 /// Save session state to the default path.
@@ -163,9 +341,11 @@ pub fn save_session_to_path(state: &SessionState, path: &Path) -> Result<()> {
     fs::create_dir_all(parent)
         .with_context(|| format!("Failed to create config directory: {}", parent.display()))?;
 
+    let mut saved_state = state.clone();
+    saved_state.notebook = bounded_notebook_session(saved_state.notebook);
     let file = SessionFile {
         version: SESSION_VERSION,
-        state: state.clone(),
+        state: saved_state,
     };
 
     let content = serde_json::to_string_pretty(&file).context("Failed to serialize session")?;
@@ -195,10 +375,138 @@ pub fn save_session_to_path(state: &SessionState, path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Load a portable notebook document from a specific path.
+pub fn load_notebook_from_path(path: &Path) -> Result<NotebookSession> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read notebook file: {}", path.display()))?;
+    let file: NotebookFile = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse notebook file: {}", path.display()))?;
+    anyhow::ensure!(
+        file.version <= NOTEBOOK_FILE_VERSION,
+        "Notebook file version {} is newer than the supported version {}",
+        file.version,
+        NOTEBOOK_FILE_VERSION
+    );
+    Ok(source_only_notebook_session(file.notebook))
+}
+
+/// Save a portable notebook document atomically. Query sources can contain
+/// sensitive information, so the resulting file is owner-readable on Unix.
+pub fn save_notebook_to_path(notebook: &NotebookSession, path: &Path) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)
+        .with_context(|| format!("Failed to create notebook directory: {}", parent.display()))?;
+
+    let content = serde_json::to_string_pretty(&NotebookFile {
+        version: NOTEBOOK_FILE_VERSION,
+        notebook: source_only_notebook_session(notebook.clone()),
+    })
+    .context("Failed to serialize notebook")?;
+    let mut tmp = NamedTempFile::new_in(parent).with_context(|| {
+        format!(
+            "Failed to create temporary notebook file in: {}",
+            parent.display()
+        )
+    })?;
+    tmp.write_all(content.as_bytes())
+        .context("Failed to write temporary notebook file")?;
+    tmp.flush()
+        .context("Failed to flush temporary notebook file")?;
+    tmp.persist(path)
+        .map_err(|error| anyhow::anyhow!("Failed to persist notebook file: {error}"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn portable_notebook_round_trips_sources_lineage_and_ui_state() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("investigation.tsql-notebook.json");
+        let notebook = NotebookSession {
+            cells: vec![
+                NotebookCellSession {
+                    cell_id: Some(4),
+                    result_name: Some("recent_users".to_string()),
+                    source: "SELECT 1 AS value".to_string(),
+                    source_collapsed: true,
+                    output_collapsed: true,
+                    dependency: None,
+                    additional_dependencies: Vec::new(),
+                    execution_history: vec![NotebookRunRecord {
+                        execution_id: 8,
+                        source_revision: 1,
+                        source: "SELECT 1 AS value".to_string(),
+                        status: NotebookRunStatus::Succeeded,
+                        finished_at: "2026-07-11T12:00:00Z".parse().unwrap(),
+                        elapsed_ms: 12,
+                        row_count: 1,
+                        headers: vec!["value".to_string()],
+                        rows: vec![vec!["1".to_string()]],
+                        error: None,
+                        truncated: false,
+                    }],
+                },
+                NotebookCellSession {
+                    cell_id: Some(7),
+                    result_name: None,
+                    source: "SELECT * FROM @result_4".to_string(),
+                    source_collapsed: false,
+                    output_collapsed: false,
+                    dependency: Some(NotebookDependencySession {
+                        source_cell_id: 4,
+                        source_execution_id: 9,
+                        source_revision: 2,
+                    }),
+                    additional_dependencies: vec![NotebookDependencySession {
+                        source_cell_id: 5,
+                        source_execution_id: 10,
+                        source_revision: 1,
+                    }],
+                    execution_history: Vec::new(),
+                },
+            ],
+            selected_index: 1,
+        };
+
+        save_notebook_to_path(&notebook, &path).unwrap();
+        let restored = load_notebook_from_path(&path).unwrap();
+
+        let mut expected = notebook.clone();
+        expected.cells[0].execution_history.clear();
+        assert_eq!(restored, expected);
+        let serialized = fs::read_to_string(path).unwrap();
+        assert!(serialized.contains("\"version\": 1"));
+        assert!(!serialized.contains("connection_name"));
+        assert!(!serialized.contains("editor_content"));
+        assert!(!serialized.contains("execution_history"));
+    }
+
+    #[test]
+    fn portable_notebook_rejects_invalid_and_future_documents() {
+        let dir = tempdir().unwrap();
+        let invalid = dir.path().join("invalid.json");
+        fs::write(&invalid, "not json").unwrap();
+        assert!(load_notebook_from_path(&invalid).is_err());
+
+        let future = dir.path().join("future.json");
+        fs::write(&future, r#"{"version":2,"cells":[],"selected_index":0}"#).unwrap();
+        let error = load_notebook_from_path(&future).unwrap_err().to_string();
+        assert!(error.contains("newer than the supported version"));
+    }
 
     #[test]
     fn test_load_missing_file() {
@@ -285,13 +593,17 @@ mod tests {
             notebook: NotebookSession {
                 cells: vec![NotebookCellSession {
                     cell_id: Some(3),
+                    result_name: None,
                     source: "SELECT * FROM @result_1".to_string(),
+                    source_collapsed: false,
                     output_collapsed: true,
                     dependency: Some(NotebookDependencySession {
                         source_cell_id: 1,
                         source_execution_id: 4,
                         source_revision: 2,
                     }),
+                    additional_dependencies: Vec::new(),
+                    execution_history: Vec::new(),
                 }],
                 selected_index: 0,
             },
@@ -346,6 +658,112 @@ mod tests {
                 source_revision: 2,
             })
         );
+    }
+
+    #[test]
+    fn notebook_run_history_is_bounded_and_preserves_newest_records() {
+        let oversized = || NotebookRunRecord {
+            execution_id: 0,
+            source_revision: 1,
+            source: "界".repeat(MAX_NOTEBOOK_RUN_SOURCE_CHARS + 50),
+            status: NotebookRunStatus::Failed,
+            finished_at: "2026-07-11T12:00:00Z".parse().unwrap(),
+            elapsed_ms: 25,
+            row_count: 999,
+            headers: vec!["h".repeat(300); MAX_NOTEBOOK_RUN_PREVIEW_COLUMNS + 3],
+            rows: vec![
+                vec!["界".repeat(300); MAX_NOTEBOOK_RUN_PREVIEW_COLUMNS + 3];
+                MAX_NOTEBOOK_RUN_PREVIEW_ROWS + 3
+            ],
+            error: Some("e".repeat(MAX_NOTEBOOK_RUN_ERROR_CHARS + 10)),
+            truncated: true,
+        };
+        let history = (0..MAX_NOTEBOOK_RUN_HISTORY + 4)
+            .map(|index| NotebookRunRecord {
+                execution_id: index as u64,
+                ..oversized()
+            })
+            .collect();
+
+        let history = bounded_notebook_run_history(history);
+        assert_eq!(history.len(), MAX_NOTEBOOK_RUN_HISTORY);
+        assert_eq!(history.first().unwrap().execution_id, 4);
+        let newest = history.last().unwrap();
+        assert_eq!(newest.source.chars().count(), MAX_NOTEBOOK_RUN_SOURCE_CHARS);
+        assert!(newest.source.ends_with('…'));
+        assert_eq!(newest.headers.len(), MAX_NOTEBOOK_RUN_PREVIEW_COLUMNS);
+        assert_eq!(
+            newest.headers[0].chars().count(),
+            MAX_NOTEBOOK_RUN_PREVIEW_CELL_CHARS
+        );
+        assert_eq!(newest.rows.len(), MAX_NOTEBOOK_RUN_PREVIEW_ROWS);
+        assert_eq!(newest.rows[0].len(), MAX_NOTEBOOK_RUN_PREVIEW_COLUMNS);
+        assert_eq!(
+            newest.rows[0][0].chars().count(),
+            MAX_NOTEBOOK_RUN_PREVIEW_CELL_CHARS
+        );
+        assert_eq!(
+            newest.error.as_ref().unwrap().chars().count(),
+            MAX_NOTEBOOK_RUN_ERROR_CHARS
+        );
+        assert_eq!(newest.row_count, 999);
+    }
+
+    #[test]
+    fn notebook_run_builders_capture_compact_output_and_error_details() {
+        let headers = vec!["value".to_string()];
+        let rows = (0..8).map(|row| vec![row.to_string()]).collect::<Vec<_>>();
+        let succeeded = NotebookRunRecord::new(
+            7,
+            2,
+            "SELECT value FROM source".to_string(),
+            NotebookRunStatus::Succeeded,
+        )
+        .with_output(
+            Duration::from_millis(17),
+            rows.len(),
+            &headers,
+            &rows,
+            false,
+        );
+        assert_eq!(succeeded.execution_id, 7);
+        assert_eq!(succeeded.elapsed_ms, 17);
+        assert_eq!(succeeded.row_count, 8);
+        assert_eq!(succeeded.rows.len(), MAX_NOTEBOOK_RUN_PREVIEW_ROWS);
+        assert!(succeeded.truncated);
+        assert_eq!(succeeded.headers, headers);
+
+        let failed = NotebookRunRecord::new(
+            8,
+            3,
+            "SELECT missing".to_string(),
+            NotebookRunStatus::Failed,
+        )
+        .with_error(
+            Duration::from_millis(23),
+            Some("column missing does not exist".to_string()),
+        );
+        assert_eq!(failed.elapsed_ms, 23);
+        assert_eq!(
+            failed.error.as_deref(),
+            Some("column missing does not exist")
+        );
+        assert!(failed.rows.is_empty());
+    }
+
+    #[test]
+    fn legacy_notebook_without_execution_history_still_loads() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("legacy-notebook.json");
+        fs::write(
+            &path,
+            r#"{"version":1,"cells":[{"cell_id":1,"source":"SELECT 1","output_collapsed":false}],"selected_index":0}"#,
+        )
+        .unwrap();
+
+        let restored = load_notebook_from_path(&path).unwrap();
+        assert_eq!(restored.cells.len(), 1);
+        assert!(restored.cells[0].execution_history.is_empty());
     }
 
     #[test]

--- a/crates/tsql/src/session.rs
+++ b/crates/tsql/src/session.rs
@@ -11,10 +11,41 @@ use tempfile::NamedTempFile;
 use crate::config::config_dir;
 
 /// Current session file schema version.
-const SESSION_VERSION: u32 = 1;
+const SESSION_VERSION: u32 = 2;
+
+/// Persisted notebook cell state. Runtime outputs and snapshot handles are excluded.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotebookCellSession {
+    /// Stable runtime cell identity used by persisted structural dependencies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cell_id: Option<u64>,
+    #[serde(default)]
+    pub source: String,
+    #[serde(default)]
+    pub output_collapsed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dependency: Option<NotebookDependencySession>,
+}
+
+/// Persisted structural lineage to an immutable result version.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotebookDependencySession {
+    pub source_cell_id: u64,
+    pub source_execution_id: u64,
+    pub source_revision: u64,
+}
+
+/// Persisted notebook document state.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotebookSession {
+    #[serde(default)]
+    pub cells: Vec<NotebookCellSession>,
+    #[serde(default)]
+    pub selected_index: usize,
+}
 
 /// Serializable session state.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionState {
     /// Active connection name (if connected via saved connection).
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -32,6 +63,31 @@ pub struct SessionState {
     /// Whether sidebar is visible (default: false to match App default).
     #[serde(default)]
     pub sidebar_visible: bool,
+
+    /// Last active workspace (`classic` or `notebook`).
+    #[serde(default = "default_workspace")]
+    pub workspace: String,
+
+    /// Notebook sources and document UI state.
+    #[serde(default)]
+    pub notebook: NotebookSession,
+}
+
+impl Default for SessionState {
+    fn default() -> Self {
+        Self {
+            connection_name: None,
+            editor_content: String::new(),
+            schema_expanded: Vec::new(),
+            sidebar_visible: false,
+            workspace: default_workspace(),
+            notebook: NotebookSession::default(),
+        }
+    }
+}
+
+fn default_workspace() -> String {
+    "classic".to_string()
 }
 
 /// The session file format with versioning.
@@ -168,6 +224,7 @@ mod tests {
                 vec!["public".to_string(), "users".to_string()],
             ],
             sidebar_visible: false,
+            ..SessionState::default()
         };
 
         save_session_to_path(&state, &path).unwrap();
@@ -215,6 +272,80 @@ mod tests {
         assert_eq!(loaded.editor_content, "SELECT 1");
         assert!(loaded.schema_expanded.is_empty());
         assert!(!loaded.sidebar_visible); // default false
+        assert_eq!(loaded.workspace, "classic");
+        assert!(loaded.notebook.cells.is_empty());
+    }
+
+    #[test]
+    fn test_notebook_state_round_trip_excludes_runtime_outputs() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("session.json");
+        let state = SessionState {
+            workspace: "notebook".to_string(),
+            notebook: NotebookSession {
+                cells: vec![NotebookCellSession {
+                    cell_id: Some(3),
+                    source: "SELECT * FROM @result_1".to_string(),
+                    output_collapsed: true,
+                    dependency: Some(NotebookDependencySession {
+                        source_cell_id: 1,
+                        source_execution_id: 4,
+                        source_revision: 2,
+                    }),
+                }],
+                selected_index: 0,
+            },
+            ..SessionState::default()
+        };
+
+        save_session_to_path(&state, &path).unwrap();
+        let loaded = load_session_from_path(&path).unwrap();
+
+        assert_eq!(loaded.workspace, "notebook");
+        assert_eq!(loaded.notebook, state.notebook);
+    }
+
+    #[test]
+    fn test_v2_notebook_cells_without_ids_remain_compatible() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("session.json");
+        let content = r#"{
+            "version": 2,
+            "workspace": "notebook",
+            "notebook": {
+                "cells": [
+                    {"source": "SELECT 1"},
+                    {
+                        "source": "SELECT * FROM @result_1",
+                        "dependency": {
+                            "source_cell_id": 1,
+                            "source_execution_id": 4,
+                            "source_revision": 2
+                        }
+                    }
+                ],
+                "selected_index": 1
+            }
+        }"#;
+        fs::write(&path, content).unwrap();
+
+        let loaded = load_session_from_path(&path).unwrap();
+
+        assert_eq!(loaded.workspace, "notebook");
+        assert_eq!(loaded.notebook.selected_index, 1);
+        assert!(loaded
+            .notebook
+            .cells
+            .iter()
+            .all(|cell| cell.cell_id.is_none()));
+        assert_eq!(
+            loaded.notebook.cells[1].dependency,
+            Some(NotebookDependencySession {
+                source_cell_id: 1,
+                source_execution_id: 4,
+                source_revision: 2,
+            })
+        );
     }
 
     #[test]

--- a/crates/tsql/src/ui/action_palette.rs
+++ b/crates/tsql/src/ui/action_palette.rs
@@ -56,6 +56,7 @@ pub struct ActionContext {
     pub notebook: bool,
     pub has_query: bool,
     pub has_result: bool,
+    pub has_rows: bool,
     pub has_refinable_result: bool,
     pub has_selection: bool,
     pub has_column: bool,
@@ -134,6 +135,11 @@ pub fn action_entries(context: ActionContext) -> Vec<ActionEntry> {
             ActionEntry::new(PaletteAction::ExportJson, "Export JSON", detail),
             ActionEntry::new(PaletteAction::ExportTsv, "Export TSV", detail),
             ActionEntry::new(PaletteAction::ExportSql, "Export SQL inserts", detail),
+        ]);
+    }
+
+    if context.has_rows {
+        entries.extend([
             ActionEntry::new(
                 PaletteAction::GenerateInsert,
                 "Generate INSERT template",
@@ -379,6 +385,7 @@ mod tests {
             notebook: true,
             has_query: true,
             has_result: true,
+            has_rows: true,
             has_refinable_result: true,
             has_selection: true,
             has_error: true,
@@ -389,6 +396,9 @@ mod tests {
         let actions = entries.iter().map(|entry| entry.action).collect::<Vec<_>>();
 
         assert!(actions.contains(&PaletteAction::ExportSql));
+        assert!(actions.contains(&PaletteAction::GenerateInsert));
+        assert!(actions.contains(&PaletteAction::GenerateUpdate));
+        assert!(actions.contains(&PaletteAction::GenerateDelete));
         assert!(actions.contains(&PaletteAction::RefineCell));
         assert!(actions.contains(&PaletteAction::RunDependents));
         assert!(actions.contains(&PaletteAction::CellHistory));
@@ -434,6 +444,9 @@ mod tests {
         assert!(actions.contains(&PaletteAction::ExportCsv));
         assert!(actions.contains(&PaletteAction::ExplainCell));
         assert!(!actions.contains(&PaletteAction::RefineCell));
+        assert!(!actions.contains(&PaletteAction::GenerateInsert));
+        assert!(!actions.contains(&PaletteAction::GenerateUpdate));
+        assert!(!actions.contains(&PaletteAction::GenerateDelete));
     }
 
     #[test]
@@ -441,6 +454,7 @@ mod tests {
         let actions = action_entries(ActionContext {
             has_query: true,
             has_result: true,
+            has_rows: true,
             has_column: true,
             has_cell: true,
             has_transform: true,
@@ -502,6 +516,9 @@ mod tests {
         assert!(!actions.contains(&PaletteAction::ResetResult));
         assert!(!actions.contains(&PaletteAction::CopyTransformedSql));
         assert!(!actions.contains(&PaletteAction::OpenTransformedSql));
+        assert!(!actions.contains(&PaletteAction::GenerateInsert));
+        assert!(!actions.contains(&PaletteAction::GenerateUpdate));
+        assert!(!actions.contains(&PaletteAction::GenerateDelete));
     }
 
     #[test]

--- a/crates/tsql/src/ui/action_palette.rs
+++ b/crates/tsql/src/ui/action_palette.rs
@@ -1,0 +1,530 @@
+//! Context-aware actions for the command palette.
+
+/// An action selected from the contextual palette.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PaletteAction {
+    Run,
+    History,
+    Snippets,
+    SaveSnippet,
+    ExportCsv,
+    ExportJson,
+    ExportTsv,
+    ExportSql,
+    GenerateInsert,
+    GenerateUpdate,
+    GenerateDelete,
+    SortAscending,
+    SortDescending,
+    AddSortAscending,
+    AddSortDescending,
+    FilterCurrentValue,
+    ExcludeCurrentValue,
+    FilterNull,
+    FilterNotNull,
+    FilterContains,
+    FilterNotContains,
+    CustomFilter,
+    ChooseColumns,
+    GroupCountCurrentColumn,
+    ClearFilters,
+    ClearSorting,
+    ResetResult,
+    CopyTransformedSql,
+    OpenTransformedSql,
+    NewCell,
+    RefineCell,
+    RunAll,
+    RunAbove,
+    RunBelow,
+    RunDependents,
+    ExplainCell,
+    ToggleOutput,
+    ToggleSource,
+    ClearCell,
+    CellHistory,
+    InspectError,
+    JumpToError,
+    JumpToActivity,
+    SwitchNotebook,
+    SwitchClassic,
+}
+
+/// State used to decide which actions are relevant to the current workspace.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ActionContext {
+    pub notebook: bool,
+    pub has_query: bool,
+    pub has_result: bool,
+    pub has_refinable_result: bool,
+    pub has_selection: bool,
+    pub has_column: bool,
+    pub has_cell: bool,
+    pub has_transform: bool,
+    pub has_filters: bool,
+    pub has_sort: bool,
+    pub has_error: bool,
+    pub has_cell_history: bool,
+    pub has_activity: bool,
+}
+
+/// A searchable, human-readable palette item.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActionEntry {
+    pub action: PaletteAction,
+    pub label: &'static str,
+    pub detail: &'static str,
+}
+
+impl ActionEntry {
+    fn new(action: PaletteAction, label: &'static str, detail: &'static str) -> Self {
+        Self {
+            action,
+            label,
+            detail,
+        }
+    }
+
+    /// Text used by the fuzzy picker for both display and matching.
+    pub fn display(&self) -> String {
+        format!("{}  {}", self.label, self.detail)
+    }
+}
+
+/// Builds the palette in priority order for the current workspace and focus.
+pub fn action_entries(context: ActionContext) -> Vec<ActionEntry> {
+    let mut entries = Vec::new();
+    if context.has_query {
+        entries.push(ActionEntry::new(
+            PaletteAction::Run,
+            if context.notebook {
+                "Run cell"
+            } else {
+                "Run query"
+            },
+            "Ctrl+E",
+        ));
+    }
+    entries.push(ActionEntry::new(
+        PaletteAction::History,
+        "Query history",
+        ":history",
+    ));
+    entries.push(ActionEntry::new(
+        PaletteAction::Snippets,
+        "Saved snippets",
+        ":snippets",
+    ));
+    if context.has_query {
+        entries.push(ActionEntry::new(
+            PaletteAction::SaveSnippet,
+            "Save current query as snippet",
+            ":snippet-save <name>",
+        ));
+    }
+
+    if context.has_result {
+        let detail = if context.has_selection {
+            "selected rows"
+        } else {
+            "all result rows"
+        };
+        entries.extend([
+            ActionEntry::new(PaletteAction::ExportCsv, "Export CSV", detail),
+            ActionEntry::new(PaletteAction::ExportJson, "Export JSON", detail),
+            ActionEntry::new(PaletteAction::ExportTsv, "Export TSV", detail),
+            ActionEntry::new(PaletteAction::ExportSql, "Export SQL inserts", detail),
+            ActionEntry::new(
+                PaletteAction::GenerateInsert,
+                "Generate INSERT template",
+                ":gen insert",
+            ),
+            ActionEntry::new(
+                PaletteAction::GenerateUpdate,
+                "Generate UPDATE template",
+                ":gen update",
+            ),
+            ActionEntry::new(
+                PaletteAction::GenerateDelete,
+                "Generate DELETE template",
+                ":gen delete",
+            ),
+        ]);
+    }
+
+    if !context.notebook && context.has_result && context.has_column {
+        entries.extend([
+            ActionEntry::new(
+                PaletteAction::SortAscending,
+                "Sort current column ascending",
+                "replace sorting",
+            ),
+            ActionEntry::new(
+                PaletteAction::SortDescending,
+                "Sort current column descending",
+                "replace sorting",
+            ),
+            ActionEntry::new(
+                PaletteAction::AddSortAscending,
+                "Add current column as secondary sort ascending",
+                "keep existing sorting",
+            ),
+            ActionEntry::new(
+                PaletteAction::AddSortDescending,
+                "Add current column as secondary sort descending",
+                "keep existing sorting",
+            ),
+        ]);
+
+        if context.has_cell {
+            entries.extend([
+                ActionEntry::new(
+                    PaletteAction::FilterCurrentValue,
+                    "Filter to current value",
+                    "current cell",
+                ),
+                ActionEntry::new(
+                    PaletteAction::ExcludeCurrentValue,
+                    "Exclude current value",
+                    "current cell",
+                ),
+                ActionEntry::new(
+                    PaletteAction::FilterContains,
+                    "Filter current column containing value",
+                    "current cell",
+                ),
+                ActionEntry::new(
+                    PaletteAction::FilterNotContains,
+                    "Filter current column not containing value",
+                    "current cell",
+                ),
+            ]);
+        }
+
+        entries.extend([
+            ActionEntry::new(
+                PaletteAction::FilterNull,
+                "Filter current column to NULL",
+                "IS NULL",
+            ),
+            ActionEntry::new(
+                PaletteAction::FilterNotNull,
+                "Filter current column to non-NULL",
+                "IS NOT NULL",
+            ),
+            ActionEntry::new(
+                PaletteAction::CustomFilter,
+                "Add custom filter",
+                "choose operator and value",
+            ),
+            ActionEntry::new(
+                PaletteAction::ChooseColumns,
+                "Choose result columns",
+                "show, hide, or reorder",
+            ),
+            ActionEntry::new(
+                PaletteAction::GroupCountCurrentColumn,
+                "Group and count by current column",
+                "GROUP BY + count(*)",
+            ),
+        ]);
+    }
+
+    if !context.notebook && context.has_result {
+        if context.has_filters {
+            entries.push(ActionEntry::new(
+                PaletteAction::ClearFilters,
+                "Clear result filters",
+                "keep sorting and columns",
+            ));
+        }
+        if context.has_sort {
+            entries.push(ActionEntry::new(
+                PaletteAction::ClearSorting,
+                "Clear result sorting",
+                "keep filters and columns",
+            ));
+        }
+        if context.has_transform {
+            entries.extend([
+                ActionEntry::new(
+                    PaletteAction::ResetResult,
+                    "Reset result transformations",
+                    "restore original query result",
+                ),
+                ActionEntry::new(
+                    PaletteAction::CopyTransformedSql,
+                    "Copy transformed SQL",
+                    "clipboard",
+                ),
+                ActionEntry::new(
+                    PaletteAction::OpenTransformedSql,
+                    "Open transformed SQL in editor",
+                    "inspect or edit",
+                ),
+            ]);
+        }
+    }
+
+    if context.notebook {
+        entries.push(ActionEntry::new(
+            PaletteAction::NewCell,
+            "Insert cell below",
+            "n",
+        ));
+        if context.has_refinable_result {
+            entries.push(ActionEntry::new(
+                PaletteAction::RefineCell,
+                "Refine result in new cell",
+                "r",
+            ));
+        }
+        if context.has_result {
+            entries.push(ActionEntry::new(
+                PaletteAction::ToggleOutput,
+                "Expand or collapse result",
+                "h / l",
+            ));
+            entries.push(ActionEntry::new(
+                PaletteAction::ExplainCell,
+                "Explain cell query",
+                ":explain-cell",
+            ));
+        }
+        entries.extend([
+            ActionEntry::new(PaletteAction::RunAll, "Run all cells", ":run-all"),
+            ActionEntry::new(PaletteAction::RunAbove, "Run cells above", ":run-above"),
+            ActionEntry::new(PaletteAction::RunBelow, "Run cells below", ":run-below"),
+            ActionEntry::new(
+                PaletteAction::RunDependents,
+                "Run dependent cells",
+                ":run-dependents",
+            ),
+            ActionEntry::new(
+                PaletteAction::ToggleSource,
+                "Expand or collapse cell source",
+                ":toggle-source",
+            ),
+            ActionEntry::new(
+                PaletteAction::ClearCell,
+                "Clear cell execution and dependents",
+                "x",
+            ),
+        ]);
+        if context.has_cell_history {
+            entries.push(ActionEntry::new(
+                PaletteAction::CellHistory,
+                "Cell execution history",
+                ":cell-history",
+            ));
+        }
+        if context.has_error {
+            entries.push(ActionEntry::new(
+                PaletteAction::JumpToError,
+                "Go to error location",
+                ":error-jump",
+            ));
+            entries.push(ActionEntry::new(
+                PaletteAction::InspectError,
+                "Inspect cell error",
+                ":error",
+            ));
+        }
+        if context.has_activity {
+            entries.push(ActionEntry::new(
+                PaletteAction::JumpToActivity,
+                "Go to latest cell activity",
+                ":activity",
+            ));
+        }
+        entries.push(ActionEntry::new(
+            PaletteAction::SwitchClassic,
+            "Switch to Classic view",
+            ":mode classic",
+        ));
+    } else {
+        entries.push(ActionEntry::new(
+            PaletteAction::SwitchNotebook,
+            "Switch to Notebook view",
+            ":notebook",
+        ));
+    }
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{action_entries, ActionContext, PaletteAction};
+
+    #[test]
+    fn classic_palette_only_offers_relevant_actions() {
+        let actions = action_entries(ActionContext {
+            has_query: true,
+            ..ActionContext::default()
+        })
+        .into_iter()
+        .map(|entry| entry.action)
+        .collect::<Vec<_>>();
+
+        assert!(actions.contains(&PaletteAction::Run));
+        assert!(actions.contains(&PaletteAction::SaveSnippet));
+        assert!(actions.contains(&PaletteAction::SwitchNotebook));
+        assert!(!actions.contains(&PaletteAction::ExportCsv));
+        assert!(!actions.contains(&PaletteAction::RunAll));
+    }
+
+    #[test]
+    fn notebook_result_palette_includes_execution_and_selection_actions() {
+        let entries = action_entries(ActionContext {
+            notebook: true,
+            has_query: true,
+            has_result: true,
+            has_refinable_result: true,
+            has_selection: true,
+            has_error: true,
+            has_cell_history: true,
+            has_activity: true,
+            ..ActionContext::default()
+        });
+        let actions = entries.iter().map(|entry| entry.action).collect::<Vec<_>>();
+
+        assert!(actions.contains(&PaletteAction::ExportSql));
+        assert!(actions.contains(&PaletteAction::RefineCell));
+        assert!(actions.contains(&PaletteAction::RunDependents));
+        assert!(actions.contains(&PaletteAction::CellHistory));
+        assert!(actions.contains(&PaletteAction::JumpToError));
+        assert!(actions.contains(&PaletteAction::JumpToActivity));
+        assert!(actions.contains(&PaletteAction::SwitchClassic));
+        assert!(entries
+            .iter()
+            .find(|entry| entry.action == PaletteAction::ExportCsv)
+            .is_some_and(|entry| entry.detail == "selected rows"));
+    }
+
+    #[test]
+    fn notebook_without_output_hides_result_actions() {
+        let actions = action_entries(ActionContext {
+            notebook: true,
+            ..ActionContext::default()
+        })
+        .into_iter()
+        .map(|entry| entry.action)
+        .collect::<Vec<_>>();
+
+        assert!(actions.contains(&PaletteAction::NewCell));
+        assert!(actions.contains(&PaletteAction::RunAll));
+        assert!(!actions.contains(&PaletteAction::Run));
+        assert!(!actions.contains(&PaletteAction::RefineCell));
+        assert!(!actions.contains(&PaletteAction::ExportSql));
+        assert!(!actions.contains(&PaletteAction::JumpToError));
+    }
+
+    #[test]
+    fn notebook_preview_result_does_not_offer_unavailable_refinement() {
+        let actions = action_entries(ActionContext {
+            notebook: true,
+            has_query: true,
+            has_result: true,
+            ..ActionContext::default()
+        })
+        .into_iter()
+        .map(|entry| entry.action)
+        .collect::<Vec<_>>();
+
+        assert!(actions.contains(&PaletteAction::ExportCsv));
+        assert!(actions.contains(&PaletteAction::ExplainCell));
+        assert!(!actions.contains(&PaletteAction::RefineCell));
+    }
+
+    #[test]
+    fn classic_result_palette_offers_contextual_transform_actions() {
+        let actions = action_entries(ActionContext {
+            has_query: true,
+            has_result: true,
+            has_column: true,
+            has_cell: true,
+            has_transform: true,
+            has_filters: true,
+            has_sort: true,
+            ..ActionContext::default()
+        })
+        .into_iter()
+        .map(|entry| entry.action)
+        .collect::<Vec<_>>();
+
+        for action in [
+            PaletteAction::SortAscending,
+            PaletteAction::SortDescending,
+            PaletteAction::AddSortAscending,
+            PaletteAction::AddSortDescending,
+            PaletteAction::FilterCurrentValue,
+            PaletteAction::ExcludeCurrentValue,
+            PaletteAction::FilterNull,
+            PaletteAction::FilterNotNull,
+            PaletteAction::FilterContains,
+            PaletteAction::FilterNotContains,
+            PaletteAction::CustomFilter,
+            PaletteAction::ChooseColumns,
+            PaletteAction::GroupCountCurrentColumn,
+            PaletteAction::ClearFilters,
+            PaletteAction::ClearSorting,
+            PaletteAction::ResetResult,
+            PaletteAction::CopyTransformedSql,
+            PaletteAction::OpenTransformedSql,
+        ] {
+            assert!(actions.contains(&action), "missing action: {action:?}");
+        }
+    }
+
+    #[test]
+    fn classic_empty_result_hides_cell_value_actions_and_inactive_resets() {
+        let actions = action_entries(ActionContext {
+            has_query: true,
+            has_result: true,
+            has_column: true,
+            ..ActionContext::default()
+        })
+        .into_iter()
+        .map(|entry| entry.action)
+        .collect::<Vec<_>>();
+
+        assert!(actions.contains(&PaletteAction::SortAscending));
+        assert!(actions.contains(&PaletteAction::FilterNull));
+        assert!(actions.contains(&PaletteAction::CustomFilter));
+        assert!(actions.contains(&PaletteAction::ChooseColumns));
+        assert!(actions.contains(&PaletteAction::GroupCountCurrentColumn));
+        assert!(!actions.contains(&PaletteAction::FilterCurrentValue));
+        assert!(!actions.contains(&PaletteAction::ExcludeCurrentValue));
+        assert!(!actions.contains(&PaletteAction::FilterContains));
+        assert!(!actions.contains(&PaletteAction::FilterNotContains));
+        assert!(!actions.contains(&PaletteAction::ClearFilters));
+        assert!(!actions.contains(&PaletteAction::ClearSorting));
+        assert!(!actions.contains(&PaletteAction::ResetResult));
+        assert!(!actions.contains(&PaletteAction::CopyTransformedSql));
+        assert!(!actions.contains(&PaletteAction::OpenTransformedSql));
+    }
+
+    #[test]
+    fn notebook_result_hides_classic_transform_actions() {
+        let actions = action_entries(ActionContext {
+            notebook: true,
+            has_query: true,
+            has_result: true,
+            has_column: true,
+            has_cell: true,
+            has_transform: true,
+            has_filters: true,
+            has_sort: true,
+            ..ActionContext::default()
+        })
+        .into_iter()
+        .map(|entry| entry.action)
+        .collect::<Vec<_>>();
+
+        assert!(!actions.contains(&PaletteAction::SortAscending));
+        assert!(!actions.contains(&PaletteAction::FilterCurrentValue));
+        assert!(!actions.contains(&PaletteAction::ChooseColumns));
+        assert!(!actions.contains(&PaletteAction::ClearFilters));
+        assert!(!actions.contains(&PaletteAction::ResetResult));
+    }
+}

--- a/crates/tsql/src/ui/ai_query_modal.rs
+++ b/crates/tsql/src/ui/ai_query_modal.rs
@@ -13,13 +13,15 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
 use tui_textarea::{Input, TextArea};
 
 use crate::ai::{AiProposal, AiTurn};
+
+use super::{overlay_block, UiTheme};
 
 /// Result of handling a single key event inside the AI modal.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,7 +169,7 @@ impl AiQueryModal {
         self.input.lines().join("\n")
     }
 
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let width = modal_dimension(area.width, 90, 70);
         let height = modal_dimension(area.height, 80, 18);
 
@@ -179,11 +181,7 @@ impl AiQueryModal {
         };
 
         frame.render_widget(Clear, popup);
-        let block = Block::default()
-            .title(" AI Query Assistant ")
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Color::Cyan));
+        let block = overlay_block("AI Query Assistant", theme);
         frame.render_widget(block, popup);
 
         let inner = popup.inner(ratatui::layout::Margin {
@@ -204,16 +202,20 @@ impl AiQueryModal {
             Span::raw("Esc close"),
         ]);
         frame.render_widget(
-            Paragraph::new(header).style(Style::default().fg(Color::Gray)),
+            Paragraph::new(header).style(Style::default().fg(theme.text_muted)),
             chunks[0],
         );
 
         self.input.set_block(
             Block::default()
-                .title(" Prompt / Follow-up ")
+                .title(Span::styled(
+                    " Prompt / Follow-up ",
+                    Style::default().fg(theme.accent),
+                ))
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Yellow)),
+                .border_style(theme.overlay_border),
         );
+        self.input.set_cursor_style(theme.editor_cursor);
         frame.render_widget(&self.input, chunks[1]);
 
         let mut details = Vec::new();
@@ -221,7 +223,7 @@ impl AiQueryModal {
             details.push(Line::from(Span::styled(
                 "Generating query...",
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme.accent)
                     .add_modifier(Modifier::BOLD),
             )));
             if let Some(prompt) = self.pending_prompt.as_deref() {
@@ -234,7 +236,7 @@ impl AiQueryModal {
             details.push(Line::from(Span::styled(
                 "Proposed query:",
                 Style::default()
-                    .fg(Color::Green)
+                    .fg(theme.success)
                     .add_modifier(Modifier::BOLD),
             )));
             for line in proposal.query.lines() {
@@ -244,7 +246,7 @@ impl AiQueryModal {
                 details.push(Line::from(""));
                 details.push(Line::from(Span::styled(
                     "Explanation:",
-                    Style::default().fg(Color::Gray),
+                    Style::default().fg(theme.text_muted),
                 )));
                 details.push(Line::from(explanation.to_string()));
             }
@@ -252,7 +254,7 @@ impl AiQueryModal {
         } else {
             details.push(Line::from(Span::styled(
                 "No proposal yet. Type a prompt and press Ctrl+E.",
-                Style::default().fg(Color::Gray),
+                Style::default().fg(theme.text_muted),
             )));
             details.push(Line::from(""));
         }
@@ -261,7 +263,7 @@ impl AiQueryModal {
             details.push(Line::from(Span::styled(
                 "Recent turns:",
                 Style::default()
-                    .fg(Color::Blue)
+                    .fg(theme.accent)
                     .add_modifier(Modifier::BOLD),
             )));
             for turn in self.conversation.iter().rev().take(3).rev() {
@@ -275,9 +277,12 @@ impl AiQueryModal {
             Paragraph::new(details)
                 .block(
                     Block::default()
-                        .title(" Proposal ")
+                        .title(Span::styled(
+                            " Proposal ",
+                            Style::default().fg(theme.accent),
+                        ))
                         .borders(Borders::ALL)
-                        .border_style(Style::default().fg(Color::Blue)),
+                        .border_style(theme.overlay_border),
                 )
                 .wrap(Wrap { trim: false }),
             chunks[2],
@@ -286,17 +291,17 @@ impl AiQueryModal {
         let status = if let Some(err) = self.last_error.as_deref() {
             Line::from(Span::styled(
                 err.to_string(),
-                Style::default().fg(Color::Red),
+                Style::default().fg(theme.error),
             ))
         } else if self.pending {
             Line::from(Span::styled(
                 "Waiting for AI response...",
-                Style::default().fg(Color::Cyan),
+                Style::default().fg(theme.accent),
             ))
         } else {
             Line::from(Span::styled(
                 "Accept replaces the entire query editor content.",
-                Style::default().fg(Color::Gray),
+                Style::default().fg(theme.text_muted),
             ))
         };
         frame.render_widget(Paragraph::new(status), chunks[3]);
@@ -325,7 +330,7 @@ mod tests {
             terminal
                 .draw(|frame| {
                     let area = frame.area();
-                    modal.render(frame, area);
+                    modal.render(frame, area, &UiTheme::fallback());
                 })
                 .unwrap();
         }));

--- a/crates/tsql/src/ui/completion.rs
+++ b/crates/tsql/src/ui/completion.rs
@@ -497,10 +497,8 @@ pub fn determine_context(text: &str, cursor_col: usize) -> CompletionContext {
         let second_last = tokens[tokens.len() - 2];
         match second_last {
             "ORDER" | "GROUP" => return CompletionContext::General,
-            "LEFT" | "RIGHT" | "FULL" | "INNER" | "CROSS" => {
-                if tokens.last() == Some(&"JOIN") {
-                    return CompletionContext::AfterFrom;
-                }
+            "LEFT" | "RIGHT" | "FULL" | "INNER" | "CROSS" if tokens.last() == Some(&"JOIN") => {
+                return CompletionContext::AfterFrom;
             }
             _ => {}
         }

--- a/crates/tsql/src/ui/completion.rs
+++ b/crates/tsql/src/ui/completion.rs
@@ -3,6 +3,7 @@ pub enum CompletionKind {
     Keyword,
     Table,
     Column,
+    Result,
     #[allow(dead_code)]
     Schema,
     #[allow(dead_code)]
@@ -39,6 +40,14 @@ impl CompletionItem {
             label: name,
             kind: CompletionKind::Column,
             detail: table,
+        }
+    }
+
+    pub fn result(label: String, detail: String) -> Self {
+        Self {
+            label,
+            kind: CompletionKind::Result,
+            detail: Some(detail),
         }
     }
 }
@@ -458,17 +467,17 @@ pub fn sql_keywords() -> Vec<&'static str> {
 
 /// Get the word being typed before the cursor position
 pub fn get_word_before_cursor(line: &str, col: usize) -> (String, usize) {
-    let before: String = line.chars().take(col).collect();
+    let before = line.chars().take(col).collect::<Vec<_>>();
 
-    // Find the start of the current word (alphanumeric + underscore)
-    let start = before
-        .char_indices()
-        .rev()
-        .find(|(_, c)| !c.is_alphanumeric() && *c != '_')
-        .map(|(i, _)| i + 1)
-        .unwrap_or(0);
+    let mut start = before
+        .iter()
+        .rposition(|c| !c.is_alphanumeric() && *c != '_')
+        .map_or(0, |index| index + 1);
+    if start > 0 && before[start - 1] == '@' {
+        start -= 1;
+    }
 
-    let prefix: String = before.chars().skip(start).collect();
+    let prefix = before[start..].iter().collect();
     (prefix, start)
 }
 
@@ -505,4 +514,44 @@ pub fn determine_context(text: &str, cursor_col: usize) -> CompletionContext {
     }
 
     CompletionContext::General
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_prefix_includes_the_at_sign_and_uses_character_columns() {
+        assert_eq!(
+            get_word_before_cursor("SELECT * FROM @res", 18),
+            ("@res".to_string(), 14)
+        );
+        assert_eq!(
+            get_word_before_cursor("SELECT 'é' FROM @result_rec", 27),
+            ("@result_rec".to_string(), 16)
+        );
+    }
+
+    #[test]
+    fn result_completion_filters_case_insensitively() {
+        let mut popup = CompletionPopup::new();
+        popup.open(
+            vec![
+                CompletionItem::result("@result_1".to_string(), "cell 1 · 2 rows".to_string()),
+                CompletionItem::result(
+                    "@result_recent_users".to_string(),
+                    "cell 1 · 2 rows".to_string(),
+                ),
+            ],
+            "@RESULT_REC".to_string(),
+            0,
+        );
+
+        assert!(popup.active);
+        assert_eq!(popup.filtered_count(), 1);
+        assert_eq!(
+            popup.selected_item().map(|item| item.label.as_str()),
+            Some("@result_recent_users")
+        );
+    }
 }

--- a/crates/tsql/src/ui/confirm_prompt.rs
+++ b/crates/tsql/src/ui/confirm_prompt.rs
@@ -14,6 +14,7 @@ use ratatui::widgets::{BorderType, Borders};
 use ratatui::Frame;
 use tui_confirm_dialog_with_mouse::{ConfirmDialog, ConfirmDialogState};
 
+use super::UiTheme;
 use crate::config::ConnectionEntry;
 use crate::update::UpdateInfo;
 
@@ -131,18 +132,21 @@ impl ConfirmPrompt {
     }
 
     /// Render the confirmation dialog.
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
+        // Confirmations keep a warning-colored border on purpose: they are the
+        // one overlay that should read as urgent.
         let dialog = ConfirmDialog::new()
+            .bg(theme.overlay.bg.unwrap_or(Color::Reset))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Color::Yellow))
-            .button_style(Style::default().fg(Color::White))
+            .border_style(Style::default().fg(theme.warning))
+            .button_style(Style::default().fg(theme.text))
             .selected_button_style(
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(theme.warning)
                     .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
             )
-            .text_style(Style::default().fg(Color::White));
+            .text_style(Style::default().fg(theme.text));
 
         frame.render_stateful_widget(dialog, area, &mut self.state);
     }

--- a/crates/tsql/src/ui/confirm_prompt.rs
+++ b/crates/tsql/src/ui/confirm_prompt.rs
@@ -12,6 +12,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{BorderType, Borders};
 use ratatui::Frame;
+use std::path::PathBuf;
 use tui_confirm_dialog_with_mouse::{ConfirmDialog, ConfirmDialogState};
 
 use super::UiTheme;
@@ -49,6 +50,8 @@ pub enum ConfirmContext {
     DeleteNotebookCell { cell_id: u64 },
     /// Clearing a notebook cell execution and any dependent executions.
     ClearNotebookCellExecution { cell_id: u64 },
+    /// Replacing the current notebook with another portable notebook document.
+    OpenNotebook { path: PathBuf },
     /// Closing connection form with unsaved changes.
     CloseConnectionForm,
     /// Switching to a new connection with unsaved query changes.
@@ -129,7 +132,8 @@ impl ConfirmPrompt {
             | ConfirmContext::QuitApp
             | ConfirmContext::CloseConnectionForm
             | ConfirmContext::SwitchConnection { .. }
-            | ConfirmContext::OpenAiAssistant { .. } => " Unsaved Changes ",
+            | ConfirmContext::OpenAiAssistant { .. }
+            | ConfirmContext::OpenNotebook { .. } => " Unsaved Changes ",
             ConfirmContext::ReplaceQuery { .. } | ConfirmContext::ReplaceAndExecuteQuery { .. } => {
                 " Replace Query "
             }

--- a/crates/tsql/src/ui/confirm_prompt.rs
+++ b/crates/tsql/src/ui/confirm_prompt.rs
@@ -45,6 +45,10 @@ pub enum ConfirmContext {
     QuitAppClean,
     /// Deleting a saved connection.
     DeleteConnection { name: String },
+    /// Deleting a notebook cell with source, output, or lineage.
+    DeleteNotebookCell { cell_id: u64 },
+    /// Clearing a notebook cell execution and any dependent executions.
+    ClearNotebookCellExecution { cell_id: u64 },
     /// Closing connection form with unsaved changes.
     CloseConnectionForm,
     /// Switching to a new connection with unsaved query changes.
@@ -127,6 +131,8 @@ impl ConfirmPrompt {
             ConfirmContext::ReplaceQuery { .. } => " Replace Query ",
             ConfirmContext::QuitAppClean => " Confirm Quit ",
             ConfirmContext::DeleteConnection { .. } => " Delete Connection ",
+            ConfirmContext::DeleteNotebookCell { .. } => " Delete Notebook Cell ",
+            ConfirmContext::ClearNotebookCellExecution { .. } => " Clear Cell Execution ",
             ConfirmContext::ApplyUpdate { .. } => " Apply Update ",
         }
     }
@@ -265,6 +271,21 @@ mod tests {
             }
             _ => panic!("Expected CloseCellEditor context"),
         }
+    }
+
+    #[test]
+    fn test_clear_notebook_cell_execution_context_and_title() {
+        let context = ConfirmContext::ClearNotebookCellExecution { cell_id: 7 };
+        let prompt = ConfirmPrompt::new("Clear cell 7 and its dependent executions?", context);
+
+        assert!(matches!(
+            prompt.context(),
+            ConfirmContext::ClearNotebookCellExecution { cell_id: 7 }
+        ));
+        assert_eq!(
+            ConfirmPrompt::title_for_context(prompt.context()),
+            " Clear Cell Execution "
+        );
     }
 
     #[test]

--- a/crates/tsql/src/ui/connection_form.rs
+++ b/crates/tsql/src/ui/connection_form.rs
@@ -9,9 +9,11 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::widgets::{Clear, Paragraph};
+
+use super::{overlay_block, UiTheme};
 use ratatui::Frame;
 use url::Url;
 
@@ -1180,7 +1182,7 @@ impl ConnectionFormModal {
     }
 
     /// Render the connection form modal.
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         // Calculate modal size. Taller now that we have metadata fields
         // below the core form.
         let modal_width = 72u16.min(area.width.saturating_sub(4));
@@ -1198,15 +1200,7 @@ impl ConnectionFormModal {
         // Clear the background
         frame.render_widget(Clear, modal_area);
 
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title(format!(" {} ", self.title))
-            .title_style(
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .border_style(Style::default().fg(Color::Cyan));
+        let block = overlay_block(&self.title, theme);
 
         let inner = block.inner(modal_area);
         frame.render_widget(block, modal_area);
@@ -1251,11 +1245,12 @@ impl ConnectionFormModal {
             &self.name,
             self.name_cursor,
             FormField::Name,
+            theme,
         );
         i += 1;
-        self.render_kind_field(frame, chunks[i]);
+        self.render_kind_field(frame, chunks[i], theme);
         i += 1;
-        self.render_separator(frame, chunks[i]);
+        self.render_separator(frame, chunks[i], theme);
         i += 1;
         self.render_text_field(
             frame,
@@ -1264,9 +1259,10 @@ impl ConnectionFormModal {
             &self.user,
             self.user_cursor,
             FormField::User,
+            theme,
         );
         i += 1;
-        self.render_password_field(frame, chunks[i]);
+        self.render_password_field(frame, chunks[i], theme);
         i += 1;
         if self.onepassword_enabled {
             self.render_text_field(
@@ -1276,6 +1272,7 @@ impl ConnectionFormModal {
                 &self.op_ref,
                 self.op_ref_cursor,
                 FormField::OnePasswordRef,
+                theme,
             );
             i += 1;
         }
@@ -1285,11 +1282,12 @@ impl ConnectionFormModal {
             "Save to keychain",
             self.save_password,
             FormField::SavePassword,
+            theme,
         );
         i += 1;
-        self.render_ssl_mode_field(frame, chunks[i]);
+        self.render_ssl_mode_field(frame, chunks[i], theme);
         i += 1;
-        self.render_separator(frame, chunks[i]);
+        self.render_separator(frame, chunks[i], theme);
         i += 1;
         self.render_text_field(
             frame,
@@ -1298,6 +1296,7 @@ impl ConnectionFormModal {
             &self.host,
             self.host_cursor,
             FormField::Host,
+            theme,
         );
         i += 1;
         self.render_text_field(
@@ -1307,6 +1306,7 @@ impl ConnectionFormModal {
             &self.port,
             self.port_cursor,
             FormField::Port,
+            theme,
         );
         i += 1;
         self.render_text_field(
@@ -1316,11 +1316,12 @@ impl ConnectionFormModal {
             &self.database,
             self.database_cursor,
             FormField::Database,
+            theme,
         );
         i += 1;
-        self.render_separator(frame, chunks[i]);
+        self.render_separator(frame, chunks[i], theme);
         i += 1;
-        self.render_color_field(frame, chunks[i]);
+        self.render_color_field(frame, chunks[i], theme);
         i += 1;
         self.render_text_field(
             frame,
@@ -1329,6 +1330,7 @@ impl ConnectionFormModal {
             &self.folder,
             self.folder_cursor,
             FormField::Folder,
+            theme,
         );
         i += 1;
         self.render_text_field(
@@ -1338,6 +1340,7 @@ impl ConnectionFormModal {
             &self.tags_input,
             self.tags_input_cursor,
             FormField::Tags,
+            theme,
         );
         i += 1;
         self.render_text_field(
@@ -1347,6 +1350,7 @@ impl ConnectionFormModal {
             &self.description,
             self.description_cursor,
             FormField::Description,
+            theme,
         );
         i += 1;
         self.render_text_field(
@@ -1356,6 +1360,7 @@ impl ConnectionFormModal {
             &self.application_name,
             self.application_name_cursor,
             FormField::AppName,
+            theme,
         );
         i += 1;
         self.render_text_field(
@@ -1365,15 +1370,17 @@ impl ConnectionFormModal {
             &self.connect_timeout_secs,
             self.connect_timeout_cursor,
             FormField::ConnectTimeout,
+            theme,
         );
         i += 1;
-        self.render_url_paste_field(frame, chunks[i]);
+        self.render_url_paste_field(frame, chunks[i], theme);
         i += 1;
-        self.render_separator(frame, chunks[i]);
+        self.render_separator(frame, chunks[i], theme);
         i += 1;
-        self.render_help(frame, chunks[i]);
+        self.render_help(frame, chunks[i], theme);
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_text_field(
         &self,
         frame: &mut Frame,
@@ -1382,6 +1389,7 @@ impl ConnectionFormModal {
         value: &str,
         cursor: usize,
         field: FormField,
+        theme: &UiTheme,
     ) {
         let is_focused = self.focused == field;
         let label_width = 10;
@@ -1391,31 +1399,31 @@ impl ConnectionFormModal {
 
         // Label
         let label_style = if is_focused {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme.accent)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme.text_muted)
         };
         let label_widget = Paragraph::new(label).style(label_style);
         frame.render_widget(label_widget, chunks[0]);
 
         // Value with cursor
         let value_spans = if is_focused {
-            self.render_text_with_cursor(value, cursor)
+            self.render_text_with_cursor(value, cursor, theme)
         } else {
             vec![Span::raw(value)]
         };
 
         let value_style = if is_focused {
-            Style::default().fg(Color::White)
+            Style::default().fg(theme.text)
         } else {
-            Style::default().fg(Color::Gray)
+            Style::default().fg(theme.text_muted)
         };
 
         let value_widget = Paragraph::new(Line::from(value_spans)).style(value_style);
         frame.render_widget(value_widget, chunks[1]);
     }
 
-    fn render_password_field(&self, frame: &mut Frame, area: Rect) {
+    fn render_password_field(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let is_focused = self.focused == FormField::Password;
         let label_width = 10;
 
@@ -1424,9 +1432,9 @@ impl ConnectionFormModal {
 
         // Label
         let label_style = if is_focused {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme.accent)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme.text_muted)
         };
         let label_widget = Paragraph::new("Password:").style(label_style);
         frame.render_widget(label_widget, chunks[0]);
@@ -1434,15 +1442,15 @@ impl ConnectionFormModal {
         // Masked value with cursor
         let masked: String = "•".repeat(self.password.chars().count());
         let value_spans = if is_focused {
-            self.render_text_with_cursor(&masked, self.password_cursor)
+            self.render_text_with_cursor(&masked, self.password_cursor, theme)
         } else {
             vec![Span::raw(masked)]
         };
 
         let value_style = if is_focused {
-            Style::default().fg(Color::White)
+            Style::default().fg(theme.text)
         } else {
-            Style::default().fg(Color::Gray)
+            Style::default().fg(theme.text_muted)
         };
 
         let value_widget = Paragraph::new(Line::from(value_spans)).style(value_style);
@@ -1456,6 +1464,7 @@ impl ConnectionFormModal {
         label: &str,
         checked: bool,
         field: FormField,
+        theme: &UiTheme,
     ) {
         let is_focused = self.focused == field;
         let label_width = 10;
@@ -1469,16 +1478,16 @@ impl ConnectionFormModal {
         // Checkbox
         let checkbox = if checked { "[x]" } else { "[ ]" };
         let style = if is_focused {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme.accent)
         } else {
-            Style::default().fg(Color::Gray)
+            Style::default().fg(theme.text_muted)
         };
 
         let widget = Paragraph::new(format!("{} {}", checkbox, label)).style(style);
         frame.render_widget(widget, chunks[1]);
     }
 
-    fn render_kind_field(&self, frame: &mut Frame, area: Rect) {
+    fn render_kind_field(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let is_focused = self.focused == FormField::Kind;
         let label_width = 10;
 
@@ -1486,9 +1495,9 @@ impl ConnectionFormModal {
             Layout::horizontal([Constraint::Length(label_width), Constraint::Min(1)]).split(area);
 
         let label_style = if is_focused {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme.accent)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme.text_muted)
         };
         let label_widget = Paragraph::new("Type:").style(label_style);
         frame.render_widget(label_widget, chunks[0]);
@@ -1499,23 +1508,21 @@ impl ConnectionFormModal {
         };
         let mut spans = vec![];
         if is_focused {
-            spans.push(Span::styled("◀ ", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled("◀ ", Style::default().fg(theme.text_muted)));
         }
         spans.push(Span::styled(
             format!("{:<11}", kind_name),
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
         ));
         if is_focused {
-            spans.push(Span::styled(" ▶", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled(" ▶", Style::default().fg(theme.text_muted)));
         }
 
         let widget = Paragraph::new(Line::from(spans));
         frame.render_widget(widget, chunks[1]);
     }
 
-    fn render_color_field(&self, frame: &mut Frame, area: Rect) {
+    fn render_color_field(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let is_focused = self.focused == FormField::Color;
         let label_width = 10;
 
@@ -1524,34 +1531,34 @@ impl ConnectionFormModal {
 
         // Label
         let label_style = if is_focused {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme.accent)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme.text_muted)
         };
         let label_widget = Paragraph::new("Color:").style(label_style);
         frame.render_widget(label_widget, chunks[0]);
 
         // Color value with preview
         let color_name = self.color.to_string();
-        let color_fg = self.color.to_ratatui_color().unwrap_or(Color::White);
+        let color_fg = self.color.to_ratatui_color().unwrap_or(theme.text);
 
         let mut spans = vec![];
         if is_focused {
-            spans.push(Span::styled("◀ ", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled("◀ ", Style::default().fg(theme.text_muted)));
         }
         spans.push(Span::styled(
             format!("{:<8}", color_name),
             Style::default().fg(color_fg).add_modifier(Modifier::BOLD),
         ));
         if is_focused {
-            spans.push(Span::styled(" ▶", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled(" ▶", Style::default().fg(theme.text_muted)));
         }
 
         let widget = Paragraph::new(Line::from(spans));
         frame.render_widget(widget, chunks[1]);
     }
 
-    fn render_ssl_mode_field(&self, frame: &mut Frame, area: Rect) {
+    fn render_ssl_mode_field(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let is_focused = self.focused == FormField::SslMode;
         let label_width = 10;
 
@@ -1560,9 +1567,9 @@ impl ConnectionFormModal {
 
         // Label
         let label_style = if is_focused {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme.accent)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme.text_muted)
         };
         let label_widget = Paragraph::new("SSL:").style(label_style);
         frame.render_widget(label_widget, chunks[0]);
@@ -1574,15 +1581,15 @@ impl ConnectionFormModal {
         };
         let mut spans = vec![];
         if is_focused && self.kind == DbKind::Postgres {
-            spans.push(Span::styled("◀ ", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled("◀ ", Style::default().fg(theme.text_muted)));
         }
         spans.push(Span::styled(
             format!("{:<11}", mode_name), // 11 chars to fit "verify-full"
             Style::default()
                 .fg(if self.kind == DbKind::Mongo {
-                    Color::DarkGray
+                    theme.text_muted
                 } else {
-                    Color::White
+                    theme.text
                 })
                 .add_modifier(if self.kind == DbKind::Mongo {
                     Modifier::empty()
@@ -1591,14 +1598,14 @@ impl ConnectionFormModal {
                 }),
         ));
         if is_focused && self.kind == DbKind::Postgres {
-            spans.push(Span::styled(" ▶", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled(" ▶", Style::default().fg(theme.text_muted)));
         }
 
         let widget = Paragraph::new(Line::from(spans));
         frame.render_widget(widget, chunks[1]);
     }
 
-    fn render_url_paste_field(&self, frame: &mut Frame, area: Rect) {
+    fn render_url_paste_field(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let is_focused = self.focused == FormField::UrlPaste;
         let label_width = 10;
 
@@ -1607,9 +1614,9 @@ impl ConnectionFormModal {
 
         // Label
         let label_style = if is_focused {
-            Style::default().fg(Color::Cyan)
+            Style::default().fg(theme.accent)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme.text_muted)
         };
         let label_widget = Paragraph::new("Paste URL:").style(label_style);
         frame.render_widget(label_widget, chunks[0]);
@@ -1618,17 +1625,17 @@ impl ConnectionFormModal {
         let (value_spans, style) = if self.url_paste.is_empty() && !is_focused {
             (
                 vec![Span::raw("postgres://... or mongodb://...")],
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.text_muted),
             )
         } else if is_focused {
             (
-                self.render_text_with_cursor(&self.url_paste, self.url_paste_cursor),
-                Style::default().fg(Color::White),
+                self.render_text_with_cursor(&self.url_paste, self.url_paste_cursor, theme),
+                Style::default().fg(theme.text),
             )
         } else {
             (
                 vec![Span::raw(&self.url_paste)],
-                Style::default().fg(Color::Gray),
+                Style::default().fg(theme.text_muted),
             )
         };
 
@@ -1636,39 +1643,40 @@ impl ConnectionFormModal {
         frame.render_widget(value_widget, chunks[1]);
     }
 
-    fn render_text_with_cursor(&self, text: &str, cursor: usize) -> Vec<Span<'static>> {
+    fn render_text_with_cursor(
+        &self,
+        text: &str,
+        cursor: usize,
+        theme: &UiTheme,
+    ) -> Vec<Span<'static>> {
         let before: String = text.chars().take(cursor).collect();
         let cursor_char = text.chars().nth(cursor).unwrap_or(' ');
         let after: String = text.chars().skip(cursor + 1).collect();
 
         vec![
             Span::raw(before),
-            Span::styled(
-                cursor_char.to_string(),
-                Style::default().bg(Color::White).fg(Color::Black),
-            ),
+            Span::styled(cursor_char.to_string(), theme.editor_cursor),
             Span::raw(after),
         ]
     }
 
-    fn render_separator(&self, frame: &mut Frame, area: Rect) {
-        let sep = Paragraph::new("─".repeat(area.width as usize))
-            .style(Style::default().fg(Color::DarkGray));
+    fn render_separator(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
+        let sep = Paragraph::new("─".repeat(area.width as usize)).style(theme.overlay_border);
         frame.render_widget(sep, area);
     }
 
-    fn render_help(&self, frame: &mut Frame, area: Rect) {
+    fn render_help(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let save_key = self.save_key_display();
         let test_key = self.test_key_display();
 
         let help_spans = vec![
-            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::styled("Tab", Style::default().fg(theme.warning)),
             Span::raw(" next  "),
-            Span::styled(save_key, Style::default().fg(Color::Yellow)),
+            Span::styled(save_key, Style::default().fg(theme.warning)),
             Span::raw(" save  "),
-            Span::styled(test_key, Style::default().fg(Color::Yellow)),
+            Span::styled(test_key, Style::default().fg(theme.warning)),
             Span::raw(" test  "),
-            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled("Esc", Style::default().fg(theme.warning)),
             Span::raw(" cancel"),
         ];
 

--- a/crates/tsql/src/ui/connection_manager.rs
+++ b/crates/tsql/src/ui/connection_manager.rs
@@ -17,7 +17,7 @@ use ratatui::widgets::{
 use ratatui::Frame;
 
 use super::mouse_util::{is_inside, MOUSE_SCROLL_LINES};
-use super::style::{selected_line, selected_primary_style, selected_row_style};
+use super::{overlay_block, UiTheme};
 use crate::config::{ConnectionEntry, ConnectionsFile, SortMode};
 
 /// Result of handling a key event in the connection manager.
@@ -536,9 +536,7 @@ impl ConnectionManagerModal {
                     .cmp(&a.use_count)
                     .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
             }),
-            SortMode::Alpha => {
-                sorted.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
-            }
+            SortMode::Alpha => sorted.sort_by_key(|a| a.name.to_lowercase()),
             SortMode::Folder => sorted.sort_by(|a, b| {
                 let fa = a.folder.as_deref().unwrap_or("~");
                 let fb = b.folder.as_deref().unwrap_or("~");
@@ -641,7 +639,7 @@ impl ConnectionManagerModal {
     }
 
     /// Render the connection manager modal.
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         // Wider modal now that we also show a detail pane. Falls back
         // gracefully on narrow terminals.
         let modal_width = ((area.width as f32 * 0.85) as u16).clamp(60, 120);
@@ -680,15 +678,7 @@ impl ConnectionManagerModal {
             )
         };
 
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title(title)
-            .title_style(
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .border_style(Style::default().fg(Color::Cyan));
+        let block = overlay_block(title.trim(), theme);
 
         let inner = block.inner(modal_area);
         frame.render_widget(block, modal_area);
@@ -707,7 +697,7 @@ impl ConnectionManagerModal {
 
         let mut idx = 0;
         if show_search_bar {
-            self.render_search_bar(frame, vchunks[idx]);
+            self.render_search_bar(frame, vchunks[idx], theme);
             idx += 1;
         }
         let body_area = vchunks[idx];
@@ -722,45 +712,44 @@ impl ConnectionManagerModal {
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
                 .split(body_area);
-            self.render_list(frame, hchunks[0]);
-            self.render_detail(frame, hchunks[1]);
+            self.render_list(frame, hchunks[0], theme);
+            self.render_detail(frame, hchunks[1], theme);
         } else {
-            self.render_list(frame, body_area);
+            self.render_list(frame, body_area, theme);
         }
 
-        let sep = Paragraph::new("─".repeat(sep_area.width as usize))
-            .style(Style::default().fg(Color::DarkGray));
+        let sep = Paragraph::new("─".repeat(sep_area.width as usize)).style(theme.overlay_border);
         frame.render_widget(sep, sep_area);
 
-        self.render_help(frame, help_area);
+        self.render_help(frame, help_area, theme);
     }
 
-    fn render_search_bar(&self, frame: &mut Frame, area: Rect) {
+    fn render_search_bar(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let mut spans = vec![
             Span::styled(
                 "/",
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(theme.warning)
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw(" "),
             Span::raw(self.search.as_str()),
         ];
         if self.search_active {
-            spans.push(Span::styled("▎", Style::default().fg(Color::Yellow)));
+            spans.push(Span::styled("▎", Style::default().fg(theme.warning)));
         }
         let p = Paragraph::new(Line::from(spans));
         frame.render_widget(p, area);
     }
 
-    fn render_detail(&self, frame: &mut Frame, area: Rect) {
+    fn render_detail(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let Some(entry) = self.selected_connection() else {
             return;
         };
 
         let mut lines: Vec<Line<'_>> = Vec::new();
 
-        let name_color = entry.color.to_ratatui_color().unwrap_or(Color::White);
+        let name_color = entry.color.to_ratatui_color().unwrap_or(theme.text);
         lines.push(Line::from(vec![Span::styled(
             entry.name.as_str(),
             Style::default().fg(name_color).add_modifier(Modifier::BOLD),
@@ -771,29 +760,53 @@ impl ConnectionManagerModal {
         };
         lines.push(Line::from(Span::styled(
             kind_label,
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.text_muted),
         )));
         lines.push(Line::from(""));
 
-        lines.push(detail_row_owned("Target", entry.display_string()));
+        lines.push(detail_row_owned(
+            "Target",
+            entry.display_string(),
+            theme.text_muted,
+        ));
         if let Some(folder) = entry.folder.as_deref() {
-            lines.push(detail_row("Folder", folder));
+            lines.push(detail_row("Folder", folder, theme.text_muted));
         }
         if !entry.tags.is_empty() {
-            lines.push(detail_row_owned("Tags", entry.tags.join(", ")));
+            lines.push(detail_row_owned(
+                "Tags",
+                entry.tags.join(", "),
+                theme.text_muted,
+            ));
         }
         if let Some(app) = entry.application_name.as_deref() {
-            lines.push(detail_row("App name", app));
+            lines.push(detail_row("App name", app, theme.text_muted));
         }
         if let Some(t) = entry.connect_timeout_secs {
-            lines.push(detail_row_owned("Timeout", format!("{}s", t)));
+            lines.push(detail_row_owned(
+                "Timeout",
+                format!("{}s", t),
+                theme.text_muted,
+            ));
         }
         if let Some(ssl) = entry.ssl_mode {
-            lines.push(detail_row("SSL", ssl.as_str()));
+            lines.push(detail_row("SSL", ssl.as_str(), theme.text_muted));
         }
-        lines.push(detail_row("Password", entry.password_source_label()));
-        lines.push(detail_row_owned("Last used", entry.last_used_label()));
-        lines.push(detail_row_owned("Use count", entry.use_count.to_string()));
+        lines.push(detail_row(
+            "Password",
+            entry.password_source_label(),
+            theme.text_muted,
+        ));
+        lines.push(detail_row_owned(
+            "Last used",
+            entry.last_used_label(),
+            theme.text_muted,
+        ));
+        lines.push(detail_row_owned(
+            "Use count",
+            entry.use_count.to_string(),
+            theme.text_muted,
+        ));
 
         if let Some(desc) = entry.description.as_deref() {
             if !desc.trim().is_empty() {
@@ -801,7 +814,7 @@ impl ConnectionManagerModal {
                 lines.push(Line::from(Span::styled(
                     "Notes",
                     Style::default()
-                        .fg(Color::DarkGray)
+                        .fg(theme.text_muted)
                         .add_modifier(Modifier::BOLD),
                 )));
                 lines.push(Line::from(Span::raw(desc)));
@@ -810,14 +823,14 @@ impl ConnectionManagerModal {
 
         let block = Block::default()
             .borders(Borders::LEFT)
-            .border_style(Style::default().fg(Color::DarkGray));
+            .border_style(theme.overlay_border);
         let inner = block.inner(area);
         frame.render_widget(block, area);
         let p = Paragraph::new(lines).wrap(Wrap { trim: true });
         frame.render_widget(p, inner);
     }
 
-    fn render_list(&mut self, frame: &mut Frame, area: Rect) {
+    fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         self.visible_height = area.height as usize;
 
         if self.connections.is_empty() {
@@ -825,12 +838,12 @@ impl ConnectionManagerModal {
                 Line::from(""),
                 Line::from(Span::styled(
                     "No connections saved",
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme.text_muted),
                 )),
                 Line::from(""),
                 Line::from(vec![
                     Span::raw("Press "),
-                    Span::styled("a", Style::default().fg(Color::Yellow)),
+                    Span::styled("a", Style::default().fg(theme.warning)),
                     Span::raw(" to add a new connection"),
                 ]),
             ])
@@ -861,7 +874,7 @@ impl ConnectionManagerModal {
             .enumerate()
             .skip(self.scroll_offset)
             .take(self.visible_height)
-            .map(|(i, conn)| self.render_connection_item(conn, i == self.selected))
+            .map(|(i, conn)| self.render_connection_item(conn, i == self.selected, theme))
             .collect();
 
         let list = List::new(items);
@@ -875,12 +888,14 @@ impl ConnectionManagerModal {
                     .end_symbol(Some("▼"))
                     .thumb_symbol("█")
                     .track_symbol(Some("░"))
+                    .style(theme.scrollbar)
             } else {
                 Scrollbar::new(ScrollbarOrientation::VerticalRight)
                     .begin_symbol(None)
                     .end_symbol(None)
                     .thumb_symbol("█")
                     .track_symbol(Some("│"))
+                    .style(theme.scrollbar)
             };
 
             let mut scrollbar_state = ScrollbarState::new(total_items).position(self.scroll_offset);
@@ -893,6 +908,7 @@ impl ConnectionManagerModal {
         &self,
         conn: &ConnectionEntry,
         is_selected: bool,
+        theme: &UiTheme,
     ) -> ListItem<'static> {
         let mut spans = Vec::new();
 
@@ -900,7 +916,7 @@ impl ConnectionManagerModal {
         if let Some(fav) = conn.favorite {
             spans.push(Span::styled(
                 format!("{}", fav),
-                Style::default().fg(Color::Yellow),
+                Style::default().fg(theme.warning),
             ));
         } else {
             spans.push(Span::raw(" "));
@@ -915,16 +931,16 @@ impl ConnectionManagerModal {
             .unwrap_or(false);
 
         if is_connected {
-            spans.push(Span::styled("●", Style::default().fg(Color::Green)));
+            spans.push(Span::styled("●", Style::default().fg(theme.success)));
         } else {
-            spans.push(Span::styled("○", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled("○", Style::default().fg(theme.text_muted)));
         }
         spans.push(Span::raw(" "));
 
         // Connection name with color
-        let name_color = conn.color.to_ratatui_color().unwrap_or(Color::White);
+        let name_color = conn.color.to_ratatui_color().unwrap_or(theme.text);
         let name_style = if is_selected {
-            selected_primary_style().add_modifier(Modifier::BOLD)
+            theme.selection.add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(name_color).add_modifier(Modifier::BOLD)
         };
@@ -936,57 +952,53 @@ impl ConnectionManagerModal {
 
         // Connection details
         let details = conn.short_display();
-        spans.push(Span::styled(details, Style::default().fg(Color::DarkGray)));
+        spans.push(Span::styled(details, Style::default().fg(theme.text_muted)));
 
-        let line = if is_selected {
-            selected_line(Line::from(spans))
-        } else {
-            Line::from(spans)
-        };
+        let line = Line::from(spans);
 
         if is_selected {
-            ListItem::new(line).style(selected_row_style())
+            ListItem::new(line).style(theme.selection)
         } else {
             ListItem::new(line)
         }
     }
 
-    fn render_help(&self, frame: &mut Frame, area: Rect) {
+    fn render_help(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         if let Some(ref msg) = self.toast {
             let p = Paragraph::new(Line::from(Span::styled(
                 msg.clone(),
-                Style::default().fg(Color::Yellow),
+                Style::default().fg(theme.warning),
             )))
             .alignment(ratatui::layout::Alignment::Center);
             frame.render_widget(p, area);
             return;
         }
         let help_spans = vec![
-            Span::styled("[Enter]", Style::default().fg(Color::Yellow)),
+            Span::styled("[Enter]", Style::default().fg(theme.warning)),
             Span::raw(" connect  "),
-            Span::styled("[a]", Style::default().fg(Color::Yellow)),
+            Span::styled("[a]", Style::default().fg(theme.warning)),
             Span::raw("dd "),
-            Span::styled("[e]", Style::default().fg(Color::Yellow)),
+            Span::styled("[e]", Style::default().fg(theme.warning)),
             Span::raw("dit "),
-            Span::styled("[D]", Style::default().fg(Color::Yellow)),
+            Span::styled("[D]", Style::default().fg(theme.warning)),
             Span::raw("up "),
-            Span::styled("[d]", Style::default().fg(Color::Yellow)),
+            Span::styled("[d]", Style::default().fg(theme.warning)),
             Span::raw("el "),
-            Span::styled("[f]", Style::default().fg(Color::Yellow)),
+            Span::styled("[f]", Style::default().fg(theme.warning)),
             Span::raw("av "),
-            Span::styled("[t]", Style::default().fg(Color::Yellow)),
+            Span::styled("[t]", Style::default().fg(theme.warning)),
             Span::raw("est "),
-            Span::styled("[/]", Style::default().fg(Color::Yellow)),
+            Span::styled("[/]", Style::default().fg(theme.warning)),
             Span::raw("find "),
-            Span::styled("[s]", Style::default().fg(Color::Yellow)),
+            Span::styled("[s]", Style::default().fg(theme.warning)),
             Span::raw("ort "),
-            Span::styled("[y]", Style::default().fg(Color::Yellow)),
+            Span::styled("[y]", Style::default().fg(theme.warning)),
             Span::raw("ank "),
-            Span::styled("[c]", Style::default().fg(Color::Yellow)),
+            Span::styled("[c]", Style::default().fg(theme.warning)),
             Span::raw("li "),
-            Span::styled("[^K/^J]", Style::default().fg(Color::Yellow)),
+            Span::styled("[^K/^J]", Style::default().fg(theme.warning)),
             Span::raw(" reorder "),
-            Span::styled("[q]", Style::default().fg(Color::Yellow)),
+            Span::styled("[q]", Style::default().fg(theme.warning)),
             Span::raw(" close"),
         ];
 
@@ -996,22 +1008,16 @@ impl ConnectionManagerModal {
     }
 }
 
-fn detail_row<'a>(label: &'a str, value: &'a str) -> Line<'a> {
+fn detail_row<'a>(label: &'a str, value: &'a str, muted: Color) -> Line<'a> {
     Line::from(vec![
-        Span::styled(
-            format!("{:<10}", label),
-            Style::default().fg(Color::DarkGray),
-        ),
+        Span::styled(format!("{:<10}", label), Style::default().fg(muted)),
         Span::raw(value),
     ])
 }
 
-fn detail_row_owned(label: &str, value: String) -> Line<'static> {
+fn detail_row_owned(label: &str, value: String, muted: Color) -> Line<'static> {
     Line::from(vec![
-        Span::styled(
-            format!("{:<10}", label),
-            Style::default().fg(Color::DarkGray),
-        ),
+        Span::styled(format!("{:<10}", label), Style::default().fg(muted)),
         Span::raw(value),
     ])
 }

--- a/crates/tsql/src/ui/fuzzy_picker.rs
+++ b/crates/tsql/src/ui/fuzzy_picker.rs
@@ -80,6 +80,8 @@ pub struct FuzzyPicker<T> {
     filter_fn: Option<fn(&T) -> bool>,
     /// Optional function returning a styled prefix string for an item (not fuzzy-matched).
     prefix_fn: Option<PrefixFn<T>>,
+    /// Whether an empty query presents source items newest-first.
+    reverse_empty: bool,
     /// Popup area (set during render, used for mouse hit testing).
     popup_area: Option<Rect>,
     /// List area (set during render, used for mouse item selection).
@@ -126,6 +128,7 @@ impl<T: Clone> FuzzyPicker<T> {
             display_fn,
             filter_fn: None,
             prefix_fn: None,
+            reverse_empty: true,
             popup_area: None,
             list_area: None,
         };
@@ -147,6 +150,13 @@ impl<T: Clone> FuzzyPicker<T> {
     /// Set an optional per-item prefix rendered in a distinct style (not fuzzy-matched).
     pub fn with_prefix(mut self, f: PrefixFn<T>) -> Self {
         self.prefix_fn = Some(f);
+        self
+    }
+
+    /// Keep the source order for an empty query (useful for priority-ordered actions).
+    pub fn with_original_order(mut self) -> Self {
+        self.reverse_empty = false;
+        self.update_filtered();
         self
     }
 
@@ -583,14 +593,13 @@ impl<T: Clone> FuzzyPicker<T> {
         self.filtered.clear();
 
         if self.query.is_empty() {
-            // Show items in reverse order (most recent first for history),
-            // applying any pre-filter.
+            // History defaults to newest-first; callers with a meaningful source order
+            // can opt out. Apply any pre-filter before changing the presentation order.
             self.filtered = self
                 .items
                 .iter()
                 .enumerate()
                 .filter(|(_, item)| self.filter_fn.is_none_or(|f| f(item)))
-                .rev()
                 .map(|(i, item)| FilteredItem {
                     item: item.clone(),
                     original_index: i,
@@ -598,6 +607,9 @@ impl<T: Clone> FuzzyPicker<T> {
                     indices: Vec::new(),
                 })
                 .collect();
+            if self.reverse_empty {
+                self.filtered.reverse();
+            }
         } else {
             let pattern = Pattern::parse(&self.query, CaseMatching::Ignore, Normalization::Smart);
 
@@ -801,6 +813,19 @@ mod tests {
             }
             _ => panic!("Expected Selected action"),
         }
+    }
+
+    #[test]
+    fn test_picker_can_preserve_priority_order_for_empty_query() {
+        let items = vec!["run", "history", "switch"];
+        let mut picker: FuzzyPicker<&str> =
+            FuzzyPicker::new(items, "Actions").with_original_order();
+
+        assert_eq!(picker.selected_original_index(), Some(0));
+        assert_eq!(
+            picker.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            PickerAction::Selected("run")
+        );
     }
 
     #[test]

--- a/crates/tsql/src/ui/fuzzy_picker.rs
+++ b/crates/tsql/src/ui/fuzzy_picker.rs
@@ -13,14 +13,14 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
-        Block, Borders, Clear, List, ListItem, ListState, Paragraph, Scrollbar,
-        ScrollbarOrientation, ScrollbarState,
+        Clear, List, ListItem, ListState, Paragraph, Scrollbar, ScrollbarOrientation,
+        ScrollbarState,
     },
     Frame,
 };
 
 use super::mouse_util::{is_inside, MOUSE_SCROLL_LINES};
-use super::style::{selected_line, selected_row_style};
+use super::{overlay_block, UiTheme};
 
 /// A function that returns an optional styled prefix `(text, style)` for a picker item.
 type PrefixFn<T> = fn(&T) -> Option<(&'static str, Style)>;
@@ -384,7 +384,7 @@ impl<T: Clone> FuzzyPicker<T> {
     }
 
     /// Render the picker as a centered popup.
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         // Calculate popup size based on content.
         let max_width = (area.width as usize * 80 / 100).clamp(40, 100) as u16;
         let max_height = (area.height as usize * 70 / 100).clamp(10, 30) as u16;
@@ -420,10 +420,7 @@ impl<T: Clone> FuzzyPicker<T> {
         frame.render_widget(Clear, popup);
 
         // Create the block.
-        let block = Block::default()
-            .title(format!(" {} ", self.title))
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan));
+        let block = overlay_block(&self.title, theme);
 
         let inner = block.inner(popup);
         frame.render_widget(block, popup);
@@ -438,22 +435,21 @@ impl<T: Clone> FuzzyPicker<T> {
         .split(inner);
 
         // Render input line.
-        self.render_input(frame, chunks[0]);
+        self.render_input(frame, chunks[0], theme);
 
         // Render separator.
-        let sep = Paragraph::new("─".repeat(chunks[1].width as usize))
-            .style(Style::default().fg(Color::DarkGray));
+        let sep = Paragraph::new("─".repeat(chunks[1].width as usize)).style(theme.overlay_border);
         frame.render_widget(sep, chunks[1]);
 
         // Render list.
-        self.render_list(frame, chunks[2]);
+        self.render_list(frame, chunks[2], theme);
 
         // Render status.
-        self.render_status(frame, chunks[3]);
+        self.render_status(frame, chunks[3], theme);
     }
 
-    fn render_input(&self, frame: &mut Frame, area: Rect) {
-        let mut spans = vec![Span::styled("> ", Style::default().fg(Color::Yellow))];
+    fn render_input(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
+        let mut spans = vec![Span::styled("> ", Style::default().fg(theme.accent))];
 
         // Query text with cursor.
         let query_before: String = self.query.chars().take(self.cursor).collect();
@@ -461,17 +457,14 @@ impl<T: Clone> FuzzyPicker<T> {
         let query_after: String = self.query.chars().skip(self.cursor + 1).collect();
 
         spans.push(Span::raw(query_before));
-        spans.push(Span::styled(
-            cursor_char.to_string(),
-            Style::default().bg(Color::White).fg(Color::Black),
-        ));
+        spans.push(Span::styled(cursor_char.to_string(), theme.editor_cursor));
         spans.push(Span::raw(query_after));
 
         let input = Paragraph::new(Line::from(spans));
         frame.render_widget(input, area);
     }
 
-    fn render_list(&mut self, frame: &mut Frame, area: Rect) {
+    fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let visible_height = area.height as usize;
         let total_items = self.filtered.len();
         let needs_scrollbar = total_items > visible_height;
@@ -508,7 +501,7 @@ impl<T: Clone> FuzzyPicker<T> {
                 let mut body_line = if filtered_item.indices.is_empty() {
                     Line::from(text)
                 } else {
-                    highlight_matches(&text, &filtered_item.indices)
+                    highlight_matches(&text, &filtered_item.indices, theme.warning)
                 };
 
                 // Prepend the styled prefix if provided.
@@ -521,7 +514,7 @@ impl<T: Clone> FuzzyPicker<T> {
                 }
 
                 if is_selected {
-                    ListItem::new(selected_line(body_line)).style(selected_row_style())
+                    ListItem::new(body_line).style(theme.selection)
                 } else {
                     ListItem::new(body_line)
                 }
@@ -542,6 +535,7 @@ impl<T: Clone> FuzzyPicker<T> {
                     .end_symbol(Some("▼"))
                     .thumb_symbol("█")
                     .track_symbol(Some("░"))
+                    .style(theme.scrollbar)
             } else {
                 // Minimal scrollbar
                 Scrollbar::new(ScrollbarOrientation::VerticalRight)
@@ -549,6 +543,7 @@ impl<T: Clone> FuzzyPicker<T> {
                     .end_symbol(None)
                     .thumb_symbol("█")
                     .track_symbol(Some("│"))
+                    .style(theme.scrollbar)
             };
 
             let mut scrollbar_state = ScrollbarState::new(total_items).position(self.scroll_offset);
@@ -557,7 +552,7 @@ impl<T: Clone> FuzzyPicker<T> {
         }
     }
 
-    fn render_status(&self, frame: &mut Frame, area: Rect) {
+    fn render_status(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let status = format!(
             " {}/{} ",
             if self.filtered.is_empty() {
@@ -568,7 +563,7 @@ impl<T: Clone> FuzzyPicker<T> {
             self.filtered.len()
         );
 
-        let status_widget = Paragraph::new(status).style(Style::default().fg(Color::DarkGray));
+        let status_widget = Paragraph::new(status).style(Style::default().fg(theme.text_muted));
         frame.render_widget(status_widget, area);
     }
 
@@ -629,7 +624,7 @@ impl<T: Clone> FuzzyPicker<T> {
                 .collect();
 
             // Sort by score descending.
-            matches.sort_by(|a, b| b.score.cmp(&a.score));
+            matches.sort_by_key(|b| std::cmp::Reverse(b.score));
             self.filtered = matches;
         }
 
@@ -640,7 +635,7 @@ impl<T: Clone> FuzzyPicker<T> {
 }
 
 /// Highlight matched characters in a string.
-fn highlight_matches(text: &str, indices: &[u32]) -> Line<'static> {
+fn highlight_matches(text: &str, indices: &[u32], match_fg: Color) -> Line<'static> {
     let indices_set: std::collections::HashSet<usize> =
         indices.iter().map(|&i| i as usize).collect();
 
@@ -654,9 +649,7 @@ fn highlight_matches(text: &str, indices: &[u32]) -> Line<'static> {
         if is_match != current_is_match && !current_span.is_empty() {
             // Flush current span.
             let style = if current_is_match {
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD)
+                Style::default().fg(match_fg).add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
             };
@@ -671,9 +664,7 @@ fn highlight_matches(text: &str, indices: &[u32]) -> Line<'static> {
     // Flush remaining.
     if !current_span.is_empty() {
         let style = if current_is_match {
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD)
+            Style::default().fg(match_fg).add_modifier(Modifier::BOLD)
         } else {
             Style::default()
         };
@@ -699,7 +690,7 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ui::style::assert_selected_bg_has_visible_fg;
+    use crate::ui::style::assert_nonblank_cells_have_explicit_fg;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
@@ -714,33 +705,35 @@ mod tests {
     }
 
     #[test]
-    fn test_selected_row_uses_visible_foreground_on_dark_background() {
+    fn test_selected_row_uses_visible_foreground_on_overlay_surface() {
         let items = vec!["alpha", "beta", "gamma"];
         let mut picker: FuzzyPicker<&str> = FuzzyPicker::new(items, "Test");
+        let theme = UiTheme::fallback();
         let backend = TestBackend::new(80, 20);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|frame| picker.render(frame, frame.area()))
+            .draw(|frame| picker.render(frame, frame.area(), &theme))
             .unwrap();
 
-        assert_selected_bg_has_visible_fg(terminal.backend().buffer());
+        assert_nonblank_cells_have_explicit_fg(terminal.backend().buffer());
     }
 
     #[test]
-    fn test_selected_row_with_fuzzy_match_uses_visible_foreground_on_dark_background() {
+    fn test_selected_row_with_fuzzy_match_uses_visible_foreground_on_overlay_surface() {
         let items = vec!["alpha", "beta", "gamma"];
         let mut picker: FuzzyPicker<&str> = FuzzyPicker::new(items, "Test");
         picker.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
 
+        let theme = UiTheme::fallback();
         let backend = TestBackend::new(80, 20);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|frame| picker.render(frame, frame.area()))
+            .draw(|frame| picker.render(frame, frame.area(), &theme))
             .unwrap();
 
-        assert_selected_bg_has_visible_fg(terminal.backend().buffer());
+        assert_nonblank_cells_have_explicit_fg(terminal.backend().buffer());
     }
 
     #[test]
@@ -897,7 +890,7 @@ mod tests {
         let text = "SELECT * FROM users";
         let indices = vec![0, 1, 2, 14, 15, 16, 17, 18]; // "SEL" and "users"
 
-        let line = highlight_matches(text, &indices);
+        let line = highlight_matches(text, &indices, UiTheme::fallback().warning);
         assert!(!line.spans.is_empty());
     }
 

--- a/crates/tsql/src/ui/grid.rs
+++ b/crates/tsql/src/ui/grid.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::Style;
 use ratatui::text::Line;
 use ratatui::widgets::{
@@ -441,12 +441,10 @@ impl GridState {
             }
 
             // o to open row detail view
-            (KeyCode::Char('o'), KeyModifiers::NONE) => {
-                if row_count > 0 {
-                    return GridKeyResult::OpenRowDetail {
-                        row: self.cursor_row,
-                    };
-                }
+            (KeyCode::Char('o'), KeyModifiers::NONE) if row_count > 0 => {
+                return GridKeyResult::OpenRowDetail {
+                    row: self.cursor_row,
+                };
             }
 
             _ => {}
@@ -1416,9 +1414,17 @@ impl<'a> Widget for DataGrid<'a> {
         }
 
         if self.model.headers.is_empty() {
-            Paragraph::new("No columns")
+            // Center the empty-state hint so the blank zone reads as intentional.
+            let message_area = Rect {
+                x: inner.x,
+                y: inner.y + inner.height / 2,
+                width: inner.width,
+                height: 1,
+            };
+            Paragraph::new("No results · press Enter in the Query pane to run")
+                .alignment(Alignment::Center)
                 .style(Style::default().fg(self.theme.text_muted))
-                .render(inner, buf);
+                .render(message_area, buf);
             return;
         }
 

--- a/crates/tsql/src/ui/grid.rs
+++ b/crates/tsql/src/ui/grid.rs
@@ -1031,7 +1031,14 @@ impl GridModel {
                 .headers
                 .iter()
                 .zip(row.iter())
-                .map(|(h, v)| format!("  \"{}\": \"{}\"", escape_json(h), escape_json(v)))
+                .enumerate()
+                .map(|(col, (header, value))| {
+                    if self.cell_is_null(row_idx, col) {
+                        format!("  \"{}\": null", escape_json(header))
+                    } else {
+                        format!("  \"{}\": \"{}\"", escape_json(header), escape_json(value))
+                    }
+                })
                 .collect();
             format!("{{\n{}\n}}", pairs.join(",\n"))
         })
@@ -1047,7 +1054,18 @@ impl GridModel {
                         .headers
                         .iter()
                         .zip(row.iter())
-                        .map(|(h, v)| format!("    \"{}\": \"{}\"", escape_json(h), escape_json(v)))
+                        .enumerate()
+                        .map(|(col, (header, value))| {
+                            if self.cell_is_null(idx, col) {
+                                format!("    \"{}\": null", escape_json(header))
+                            } else {
+                                format!(
+                                    "    \"{}\": \"{}\"",
+                                    escape_json(header),
+                                    escape_json(value)
+                                )
+                            }
+                        })
                         .collect();
                     format!("  {{\n{}\n  }}", pairs.join(",\n"))
                 })
@@ -2100,6 +2118,29 @@ mod tests {
             decoded[0]["odd\u{0001}header"],
             "back\u{0008} form\u{000c} line\nend"
         );
+    }
+
+    #[test]
+    fn rows_as_json_preserves_sql_null_identity() {
+        let model = GridModel::new(
+            vec![
+                "actual_null".to_string(),
+                "literal_null".to_string(),
+                "empty".to_string(),
+            ],
+            vec![vec!["NULL".to_string(), "NULL".to_string(), String::new()]],
+        )
+        .with_null_cells(vec![vec![true, false, false]]);
+
+        let row: serde_json::Value = serde_json::from_str(&model.row_as_json(0).unwrap()).unwrap();
+        assert!(row["actual_null"].is_null());
+        assert_eq!(row["literal_null"], "NULL");
+        assert_eq!(row["empty"], "");
+
+        let rows: serde_json::Value = serde_json::from_str(&model.rows_as_json(&[0])).unwrap();
+        assert!(rows[0]["actual_null"].is_null());
+        assert_eq!(rows[0]["literal_null"], "NULL");
+        assert_eq!(rows[0]["empty"], "");
     }
 
     #[test]

--- a/crates/tsql/src/ui/grid.rs
+++ b/crates/tsql/src/ui/grid.rs
@@ -5,17 +5,17 @@ use std::collections::HashSet;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::Style;
+use ratatui::text::Line;
 use ratatui::widgets::{
-    Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget,
-    Widget,
+    Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Widget,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::config::Action;
 use crate::util::{is_uuid, looks_like_json};
 
-use super::style::selected_row_style;
+use super::{zone_block, zone_scrollbar_area, UiTheme};
 
 /// Minimum column width for display.
 const MIN_COLUMN_WIDTH: u16 = 3;
@@ -1391,6 +1391,8 @@ fn escape_json(s: &str) -> String {
 pub struct DataGrid<'a> {
     pub model: &'a GridModel,
     pub state: &'a GridState,
+    pub label: Line<'a>,
+    pub theme: &'a UiTheme,
     pub focused: bool,
     pub show_row_numbers: bool,
     pub show_scrollbar: bool,
@@ -1398,35 +1400,13 @@ pub struct DataGrid<'a> {
 
 impl<'a> Widget for DataGrid<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Build a concise title with search info if active.
-        let base_title = if self.focused {
-            " ● Results "
-        } else {
-            " Results "
-        };
-        let title = if let Some(search_info) = self.state.search.match_info() {
-            format!("{} {}", base_title, search_info)
-        } else {
-            base_title.to_string()
-        };
-
-        let border_style = if self.focused {
-            Style::default().fg(Color::Cyan)
-        } else {
-            Style::default().fg(Color::DarkGray)
-        };
-
-        let block = Block::default()
-            .title(title)
-            .title_style(if self.focused {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(Color::DarkGray)
-            })
-            .borders(Borders::ALL)
-            .border_style(border_style);
+        let block = zone_block(
+            self.label,
+            self.theme.bg_base,
+            self.theme.text,
+            self.focused,
+            self.theme.accent,
+        );
 
         let inner = block.inner(area);
         block.render(area, buf);
@@ -1437,7 +1417,7 @@ impl<'a> Widget for DataGrid<'a> {
 
         if self.model.headers.is_empty() {
             Paragraph::new("No columns")
-                .style(Style::default().fg(Color::Gray))
+                .style(Style::default().fg(self.theme.text_muted))
                 .render(inner, buf);
             return;
         }
@@ -1445,7 +1425,7 @@ impl<'a> Widget for DataGrid<'a> {
         // Reserve one line for header.
         if inner.height < 2 {
             Paragraph::new("Window too small")
-                .style(Style::default().fg(Color::Gray))
+                .style(Style::default().fg(self.theme.text_muted))
                 .render(inner, buf);
             return;
         }
@@ -1492,6 +1472,7 @@ impl<'a> Widget for DataGrid<'a> {
             marker_w,
             self.show_row_numbers,
             row_number_width,
+            self.theme,
         );
         render_row_cells(
             data_x,
@@ -1500,9 +1481,7 @@ impl<'a> Widget for DataGrid<'a> {
             &self.model.headers,
             &self.model.col_widths,
             self.state.col_offset,
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
+            self.theme.grid_header,
             None,  // No search highlighting for headers
             false, // Headers never have UUID expansion
             buf,
@@ -1511,7 +1490,7 @@ impl<'a> Widget for DataGrid<'a> {
         // Body rows.
         if self.model.rows.is_empty() {
             Paragraph::new("(no rows)")
-                .style(Style::default().fg(Color::Gray))
+                .style(Style::default().fg(self.theme.text_muted))
                 .render(body_area, buf);
             return;
         }
@@ -1527,7 +1506,7 @@ impl<'a> Widget for DataGrid<'a> {
             let is_selected = self.state.selected_rows.contains(&row_idx);
 
             let row_style = if is_cursor {
-                selected_row_style()
+                self.theme.selection
             } else {
                 Style::default()
             };
@@ -1543,6 +1522,7 @@ impl<'a> Widget for DataGrid<'a> {
                 self.show_row_numbers,
                 row_number_width,
                 row_idx + 1, // 1-based row number
+                self.theme,
             );
 
             // Determine cursor column for this row (only if this is the cursor row)
@@ -1564,6 +1544,7 @@ impl<'a> Widget for DataGrid<'a> {
                 cursor_col,
                 &self.state.search,
                 self.state.uuid_expanded,
+                self.theme,
                 buf,
             );
         }
@@ -1574,19 +1555,14 @@ impl<'a> Widget for DataGrid<'a> {
                 .begin_symbol(Some("▲"))
                 .end_symbol(Some("▼"))
                 .thumb_symbol("█")
-                .track_symbol(Some("░"));
+                .track_symbol(Some("░"))
+                .style(self.theme.scrollbar);
 
             let mut scrollbar_state = ScrollbarState::new(self.model.rows.len())
                 .position(self.state.cursor_row)
                 .viewport_content_length(body_area.height as usize);
 
-            // Render scrollbar on the right edge of the body area
-            let scrollbar_area = Rect {
-                x: body_area.x + body_area.width.saturating_sub(1),
-                y: body_area.y,
-                width: 1,
-                height: body_area.height,
-            };
+            let scrollbar_area = zone_scrollbar_area(area);
 
             scrollbar.render(scrollbar_area, buf, &mut scrollbar_state);
         }
@@ -1599,27 +1575,21 @@ fn render_marker_header(
     marker_w: u16,
     show_row_numbers: bool,
     row_number_width: u16,
+    theme: &UiTheme,
 ) {
     let mut x = area.x;
 
     // Render row number header (e.g., "#" or empty)
     if show_row_numbers && row_number_width > 0 {
         let header = format!("{:>width$}", "#", width = (row_number_width - 1) as usize);
-        buf.set_string(
-            x,
-            area.y,
-            &header,
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        );
+        buf.set_string(x, area.y, &header, theme.grid_header);
         x += row_number_width;
     }
 
     // Fill remaining marker area with spaces
     let remaining = marker_w.saturating_sub(row_number_width);
     for _ in 0..remaining {
-        buf.set_string(x, area.y, " ", Style::default());
+        buf.set_string(x, area.y, " ", theme.grid_header);
         x += 1;
     }
 }
@@ -1636,6 +1606,7 @@ fn render_marker_cell(
     show_row_numbers: bool,
     row_number_width: u16,
     row_number: usize,
+    theme: &UiTheme,
 ) {
     let mut current_x = x;
 
@@ -1646,11 +1617,11 @@ fn render_marker_cell(
             row_number,
             width = (row_number_width - 1) as usize
         );
-        // Use lighter color for cursor row (DarkGray bg) to ensure visibility
+        // Use primary text on the selected row and muted text otherwise.
         let row_num_style = if is_cursor {
-            style.fg(Color::Gray)
+            style.fg(theme.text)
         } else {
-            style.fg(Color::DarkGray)
+            style.fg(theme.text_muted)
         };
         buf.set_string(current_x, y, &row_num_str, row_num_style);
         current_x += row_number_width;
@@ -1731,6 +1702,7 @@ fn render_row_cells_with_search(
     cursor_col: Option<usize>,
     search: &GridSearch,
     uuid_expanded: bool,
+    theme: &UiTheme,
     buf: &mut Buffer,
 ) {
     if available_w == 0 {
@@ -1739,13 +1711,6 @@ fn render_row_cells_with_search(
 
     let padding: u16 = 1;
     let max_x = x.saturating_add(available_w);
-
-    // Styles for search matches and cursor
-    let match_style = Style::default().bg(Color::Yellow).fg(Color::Black);
-    let current_match_style = Style::default()
-        .bg(Color::Rgb(255, 165, 0))
-        .fg(Color::Black); // Orange
-    let cursor_cell_style = Style::default().bg(Color::Cyan).fg(Color::Black);
 
     let mut col = col_offset;
     while col < cells.len() && col < col_widths.len() && x < max_x {
@@ -1763,11 +1728,11 @@ fn render_row_cells_with_search(
         // Determine cell style based on cursor position and search state
         let is_cursor_cell = cursor_col == Some(col);
         let cell_style = if is_cursor_cell {
-            cursor_cell_style
+            theme.cursor_cell
         } else if search.is_current_match(row_idx, col) {
-            current_match_style
+            theme.search_match_current
         } else if search.is_match(row_idx, col) {
-            match_style
+            theme.search_match
         } else {
             base_style
         };
@@ -1927,7 +1892,7 @@ fn truncate_by_display_width(s: &str, width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ui::style::assert_selected_bg_has_visible_fg;
+    use crate::ui::style::assert_nonblank_cells_have_explicit_fg;
 
     fn create_test_model() -> GridModel {
         GridModel::new(
@@ -2045,6 +2010,7 @@ mod tests {
     #[test]
     fn test_cursor_row_uses_visible_foreground_on_dark_background() {
         let model = create_test_model();
+        let theme = UiTheme::fallback();
         let state = GridState {
             cursor_row: 1,
             cursor_col: 1,
@@ -2053,6 +2019,8 @@ mod tests {
         let grid = DataGrid {
             model: &model,
             state: &state,
+            label: Line::from(" RESULTS"),
+            theme: &theme,
             focused: true,
             show_row_numbers: true,
             show_scrollbar: false,
@@ -2062,7 +2030,45 @@ mod tests {
 
         grid.render(area, &mut buf);
 
-        assert_selected_bg_has_visible_fg(&buf);
+        assert_nonblank_cells_have_explicit_fg(&buf);
+    }
+
+    #[test]
+    fn test_built_in_themes_style_labels_and_ordinary_cells() {
+        let model = create_test_model();
+        let state = GridState {
+            cursor_row: 1,
+            ..Default::default()
+        };
+
+        for syntax_theme in [
+            tui_syntax::themes::one_dark(),
+            tui_syntax::themes::github_light(),
+        ] {
+            let theme = UiTheme::from_theme(&syntax_theme);
+            let grid = DataGrid {
+                model: &model,
+                state: &state,
+                label: Line::from(" RESULTS · 2 rows"),
+                theme: &theme,
+                focused: false,
+                show_row_numbers: false,
+                show_scrollbar: false,
+            };
+            let area = Rect::new(0, 0, 40, 6);
+            let mut buffer = Buffer::empty(area);
+
+            grid.render(area, &mut buffer);
+
+            assert_nonblank_cells_have_explicit_fg(&buffer);
+            let alice = buffer
+                .content
+                .iter()
+                .find(|cell| cell.symbol() == "A")
+                .expect("Alice should be rendered");
+            assert_eq!(alice.fg, theme.text);
+            assert_eq!(alice.bg, theme.bg_base);
+        }
     }
 
     #[test]
@@ -2145,6 +2151,7 @@ mod tests {
 
         // Create a model with several columns
         let model = create_wide_test_model();
+        let theme = UiTheme::fallback();
 
         // Create state with cursor at rightmost column but col_offset at 0
         // This simulates the bug: cursor moved right but header hasn't scrolled
@@ -2157,21 +2164,23 @@ mod tests {
         let grid = DataGrid {
             model: &model,
             state: &state,
+            label: Line::from(" RESULTS"),
+            theme: &theme,
             focused: true,
             show_row_numbers: false,
             show_scrollbar: false,
         };
 
         // Render to a small buffer (narrow viewport)
-        // Width of 20 should only fit ~2-3 columns with border + marker
+        // Width of 20 should only fit ~2-3 columns with zone chrome + marker
         let area = Rect::new(0, 0, 20, 10);
         let mut buf = Buffer::empty(area);
         grid.render(area, &mut buf);
 
-        // The header row is at y=1 (after border)
-        // After marker column (3 chars), data starts at x=4
+        // The header row is at y=1 (after the label)
+        // After the left edge, padding, and marker column, data starts at x=5
         // Check that the header shows same columns as body
-        let header_row: String = (4..area.width - 1)
+        let header_row: String = (5..area.width - 1)
             .map(|x| {
                 buf.cell((x, 1))
                     .map(|c| c.symbol().chars().next().unwrap_or(' '))
@@ -2180,7 +2189,7 @@ mod tests {
             .collect();
 
         // Body row is at y=2
-        let body_row: String = (4..area.width - 1)
+        let body_row: String = (5..area.width - 1)
             .map(|x| {
                 buf.cell((x, 2))
                     .map(|c| c.symbol().chars().next().unwrap_or(' '))
@@ -2819,48 +2828,21 @@ mod tests {
     }
 
     #[test]
-    fn test_row_number_cursor_row_uses_visible_color() {
-        // When is_cursor is true, the row number should use Color::Gray (lighter)
-        // to be visible against the DarkGray background of the cursor row.
-        // This is a unit test for the logic, not the actual rendering.
-        let is_cursor = true;
-        let base_style = Style::default().bg(Color::DarkGray);
+    fn test_row_number_cursor_row_uses_theme_text_on_selection() {
+        let theme = UiTheme::fallback();
+        let row_num_style = theme.selection.fg(theme.text);
 
-        // Simulate the logic from render_marker_cell
-        let row_num_style = if is_cursor {
-            base_style.fg(Color::Gray)
-        } else {
-            base_style.fg(Color::DarkGray)
-        };
-
-        // Verify foreground is Gray (not DarkGray which would be invisible)
-        assert_eq!(
-            row_num_style.fg,
-            Some(Color::Gray),
-            "Cursor row should use Gray foreground for visibility"
-        );
+        assert_eq!(row_num_style.fg, Some(theme.text));
+        assert_eq!(row_num_style.bg, theme.selection.bg);
     }
 
     #[test]
-    fn test_row_number_non_cursor_row_uses_dark_gray() {
-        // When is_cursor is false, the row number should use DarkGray
-        // (subdued color since background is default/transparent).
-        let is_cursor = false;
-        let base_style = Style::default();
+    fn test_row_number_non_cursor_row_uses_theme_muted_text() {
+        let theme = UiTheme::fallback();
+        let row_num_style = Style::default().fg(theme.text_muted);
 
-        // Simulate the logic from render_marker_cell
-        let row_num_style = if is_cursor {
-            base_style.fg(Color::Gray)
-        } else {
-            base_style.fg(Color::DarkGray)
-        };
-
-        // Verify foreground is DarkGray for non-cursor rows
-        assert_eq!(
-            row_num_style.fg,
-            Some(Color::DarkGray),
-            "Non-cursor row should use DarkGray foreground"
-        );
+        assert_eq!(row_num_style.fg, Some(theme.text_muted));
+        assert_eq!(row_num_style.bg, None);
     }
 
     // =========================================================================

--- a/crates/tsql/src/ui/grid.rs
+++ b/crates/tsql/src/ui/grid.rs
@@ -1076,11 +1076,18 @@ impl GridModel {
             .join(", ");
         row_indices
             .iter()
-            .filter_map(|&index| self.rows.get(index))
-            .map(|row| {
+            .filter_map(|&row_index| self.rows.get(row_index).map(|row| (row_index, row)))
+            .map(|(row_index, row)| {
                 let values = row
                     .iter()
-                    .map(|value| escape_sql_value(value))
+                    .enumerate()
+                    .map(|(col_index, value)| {
+                        if self.cell_is_null(row_index, col_index) {
+                            "NULL".to_string()
+                        } else {
+                            format!("'{}'", value.replace('\'', "''"))
+                        }
+                    })
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("INSERT INTO {table} ({columns}) VALUES ({values});")
@@ -2103,6 +2110,7 @@ mod tests {
                 "display \"name\"".to_string(),
                 "enabled".to_string(),
                 "missing".to_string(),
+                "empty".to_string(),
             ],
             vec![
                 vec![
@@ -2110,25 +2118,31 @@ mod tests {
                     "O'Reilly".to_string(),
                     "true".to_string(),
                     "NULL".to_string(),
+                    String::new(),
                 ],
                 vec![
                     "2".to_string(),
                     "line one\nline two".to_string(),
                     "false".to_string(),
+                    "NULL".to_string(),
                     String::new(),
                 ],
             ],
-        );
+        )
+        .with_null_cells(vec![
+            vec![false, false, false, true, false],
+            vec![false, false, false, false, false],
+        ]);
 
         assert_eq!(
             model.rows_as_sql_inserts(&[1, 99, 0], "reporting.user \"copy\""),
             concat!(
                 "INSERT INTO reporting.\"user \"\"copy\"\"\" ",
-                "(id, \"display \"\"name\"\"\", enabled, missing) ",
-                "VALUES (2, 'line one\nline two', FALSE, NULL);\n",
+                "(id, \"display \"\"name\"\"\", enabled, missing, empty) ",
+                "VALUES ('2', 'line one\nline two', 'false', 'NULL', '');\n",
                 "INSERT INTO reporting.\"user \"\"copy\"\"\" ",
-                "(id, \"display \"\"name\"\"\", enabled, missing) ",
-                "VALUES (1, 'O''Reilly', TRUE, NULL);"
+                "(id, \"display \"\"name\"\"\", enabled, missing, empty) ",
+                "VALUES ('1', 'O''Reilly', 'true', NULL, '');"
             )
         );
     }

--- a/crates/tsql/src/ui/grid.rs
+++ b/crates/tsql/src/ui/grid.rs
@@ -813,6 +813,8 @@ impl GridState {
 pub struct GridModel {
     pub headers: Vec<String>,
     pub rows: Vec<Vec<String>>,
+    /// Per-cell SQL NULL identity, separate from the rendered cell text.
+    pub null_cells: Vec<Vec<bool>>,
     pub col_widths: Vec<u16>,
     /// The source table name, if known (extracted from simple SELECT queries).
     pub source_table: Option<String>,
@@ -826,9 +828,11 @@ impl GridModel {
     pub fn new(headers: Vec<String>, rows: Vec<Vec<String>>) -> Self {
         let col_widths = compute_column_widths(&headers, &rows);
         let col_count = headers.len();
+        let null_cells = rows.iter().map(|row| vec![false; row.len()]).collect();
         Self {
             headers,
             rows,
+            null_cells,
             col_widths,
             source_table: None,
             primary_keys: Vec::new(),
@@ -851,10 +855,32 @@ impl GridModel {
         self
     }
 
+    /// Attach SQL NULL identity captured while decoding database rows.
+    pub fn with_null_cells(mut self, mut null_cells: Vec<Vec<bool>>) -> Self {
+        null_cells.resize_with(self.rows.len(), Vec::new);
+        null_cells.truncate(self.rows.len());
+        for (row, mask) in self.rows.iter().zip(&mut null_cells) {
+            mask.resize(row.len(), false);
+            mask.truncate(row.len());
+        }
+        self.null_cells = null_cells;
+        self
+    }
+
+    /// Return whether the cell was decoded from an actual SQL NULL.
+    pub fn cell_is_null(&self, row: usize, col: usize) -> bool {
+        self.null_cells
+            .get(row)
+            .and_then(|mask| mask.get(col))
+            .copied()
+            .unwrap_or(false)
+    }
+
     pub fn empty() -> Self {
         Self {
             headers: Vec::new(),
             rows: Vec::new(),
+            null_cells: Vec::new(),
             col_widths: Vec::new(),
             source_table: None,
             primary_keys: Vec::new(),
@@ -870,6 +896,15 @@ impl GridModel {
     /// Note: If new rows have more columns than the existing model, extra columns
     /// are ignored. If new rows have fewer columns, missing columns are not processed.
     pub fn append_rows(&mut self, new_rows: Vec<Vec<String>>) {
+        self.append_rows_with_nulls(new_rows, Vec::new());
+    }
+
+    /// Append rows together with the SQL NULL identity captured for each cell.
+    pub fn append_rows_with_nulls(
+        &mut self,
+        new_rows: Vec<Vec<String>>,
+        mut null_cells: Vec<Vec<bool>>,
+    ) {
         // Update column widths for any cells that are wider than current widths
         for row in &new_rows {
             for (i, cell) in row.iter().enumerate() {
@@ -889,7 +924,14 @@ impl GridModel {
             }
         }
 
+        null_cells.resize_with(new_rows.len(), Vec::new);
+        null_cells.truncate(new_rows.len());
+        for (row, mask) in new_rows.iter().zip(&mut null_cells) {
+            mask.resize(row.len(), false);
+            mask.truncate(row.len());
+        }
         self.rows.extend(new_rows);
+        self.null_cells.extend(null_cells);
     }
 
     /// Get the column type for a given column index.
@@ -1013,6 +1055,38 @@ impl GridModel {
             .collect();
 
         format!("[\n{}\n]", objects.join(",\n"))
+    }
+
+    /// Format rows as one SQL INSERT statement per row.
+    pub fn rows_as_sql_inserts(&self, row_indices: &[usize], table: &str) -> String {
+        if self.headers.is_empty() {
+            return String::new();
+        }
+
+        let table = table
+            .split('.')
+            .map(quote_identifier)
+            .collect::<Vec<_>>()
+            .join(".");
+        let columns = self
+            .headers
+            .iter()
+            .map(|header| quote_identifier(header))
+            .collect::<Vec<_>>()
+            .join(", ");
+        row_indices
+            .iter()
+            .filter_map(|&index| self.rows.get(index))
+            .map(|row| {
+                let values = row
+                    .iter()
+                    .map(|value| escape_sql_value(value))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("INSERT INTO {table} ({columns}) VALUES ({values});")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// Format rows as a GitHub-flavored markdown table (always includes headers).
@@ -1379,11 +1453,21 @@ fn escape_csv(s: &str) -> String {
 
 /// Escape a string for JSON output.
 fn escape_json(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
+    let mut escaped = String::with_capacity(s.len());
+    for character in s.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{0008}' => escaped.push_str("\\b"),
+            '\u{000c}' => escaped.push_str("\\f"),
+            control if control < ' ' => escaped.push_str(&format!("\\u{:04x}", control as u32)),
+            printable => escaped.push(printable),
+        }
+    }
+    escaped
 }
 
 pub struct DataGrid<'a> {
@@ -1993,6 +2077,70 @@ mod tests {
         // Test without headers
         let result = model.rows_as_tsv(&[0], false);
         assert_eq!(result, "1\tAlice", "Should not include header row");
+    }
+
+    #[test]
+    fn rows_as_json_escapes_all_control_characters() {
+        let model = GridModel::new(
+            vec!["odd\u{0001}header".to_string()],
+            vec![vec!["back\u{0008} form\u{000c} line\nend".to_string()]],
+        );
+
+        let encoded = model.rows_as_json(&[0]);
+        let decoded: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(
+            decoded[0]["odd\u{0001}header"],
+            "back\u{0008} form\u{000c} line\nend"
+        );
+    }
+
+    #[test]
+    fn rows_as_sql_inserts_quotes_identifiers_escapes_values_and_skips_missing_rows() {
+        let model = GridModel::new(
+            vec![
+                "id".to_string(),
+                "display \"name\"".to_string(),
+                "enabled".to_string(),
+                "missing".to_string(),
+            ],
+            vec![
+                vec![
+                    "1".to_string(),
+                    "O'Reilly".to_string(),
+                    "true".to_string(),
+                    "NULL".to_string(),
+                ],
+                vec![
+                    "2".to_string(),
+                    "line one\nline two".to_string(),
+                    "false".to_string(),
+                    String::new(),
+                ],
+            ],
+        );
+
+        assert_eq!(
+            model.rows_as_sql_inserts(&[1, 99, 0], "reporting.user \"copy\""),
+            concat!(
+                "INSERT INTO reporting.\"user \"\"copy\"\"\" ",
+                "(id, \"display \"\"name\"\"\", enabled, missing) ",
+                "VALUES (2, 'line one\nline two', FALSE, NULL);\n",
+                "INSERT INTO reporting.\"user \"\"copy\"\"\" ",
+                "(id, \"display \"\"name\"\"\", enabled, missing) ",
+                "VALUES (1, 'O''Reilly', TRUE, NULL);"
+            )
+        );
+    }
+
+    #[test]
+    fn rows_as_sql_inserts_returns_empty_when_there_is_nothing_to_export() {
+        let model = create_test_model();
+        assert!(model.rows_as_sql_inserts(&[], "result").is_empty());
+        assert!(model.rows_as_sql_inserts(&[99], "result").is_empty());
+
+        let no_headers = GridModel::new(Vec::new(), vec![vec!["value".to_string()]]);
+        assert!(no_headers.rows_as_sql_inserts(&[0], "result").is_empty());
     }
 
     #[test]
@@ -3026,6 +3174,46 @@ mod tests {
         // Width should increase for the name column
         assert_eq!(model.col_widths[0], 3); // unchanged
         assert_eq!(model.col_widths[1], 11); // "Christopher"
+    }
+
+    #[test]
+    fn null_metadata_distinguishes_sql_null_from_literal_null_text() {
+        let model = GridModel::new(
+            vec!["actual_null".to_string(), "literal_null".to_string()],
+            vec![vec!["NULL".to_string(), "NULL".to_string()]],
+        )
+        .with_null_cells(vec![vec![true, false]]);
+
+        assert!(model.cell_is_null(0, 0));
+        assert!(!model.cell_is_null(0, 1));
+        assert!(!model.cell_is_null(1, 0));
+        assert!(!model.cell_is_null(0, 2));
+    }
+
+    #[test]
+    fn append_rows_with_nulls_preserves_and_normalizes_null_metadata() {
+        let mut model = GridModel::new(
+            vec!["left".to_string(), "right".to_string()],
+            vec![vec!["NULL".to_string(), "value".to_string()]],
+        )
+        .with_null_cells(vec![vec![true]]);
+
+        model.append_rows_with_nulls(
+            vec![
+                vec!["NULL".to_string(), "NULL".to_string()],
+                vec!["value".to_string(), "NULL".to_string()],
+            ],
+            vec![vec![false, true, true]],
+        );
+
+        assert_eq!(
+            model.null_cells,
+            vec![vec![true, false], vec![false, true], vec![false, false]]
+        );
+        assert!(model.cell_is_null(0, 0));
+        assert!(!model.cell_is_null(1, 0));
+        assert!(model.cell_is_null(1, 1));
+        assert!(!model.cell_is_null(2, 1));
     }
 
     #[test]

--- a/crates/tsql/src/ui/grid.rs
+++ b/crates/tsql/src/ui/grid.rs
@@ -1409,6 +1409,50 @@ impl<'a> Widget for DataGrid<'a> {
         let inner = block.inner(area);
         block.render(area, buf);
 
+        GridViewport {
+            model: self.model,
+            state: self.state,
+            theme: self.theme,
+            focused: true,
+            show_row_numbers: self.show_row_numbers,
+            show_scrollbar: self.show_scrollbar,
+        }
+        .render_with_scrollbar_area(inner, buf, zone_scrollbar_area(area));
+    }
+}
+
+/// A navigable grid viewport without the surrounding results-zone chrome.
+pub struct GridViewport<'a> {
+    pub model: &'a GridModel,
+    pub state: &'a GridState,
+    pub theme: &'a UiTheme,
+    pub focused: bool,
+    pub show_row_numbers: bool,
+    pub show_scrollbar: bool,
+}
+
+impl Widget for GridViewport<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let has_scrollbar =
+            self.show_scrollbar && self.model.rows.len() > area.height.saturating_sub(1) as usize;
+        let viewport = Rect {
+            width: area.width.saturating_sub(u16::from(has_scrollbar)),
+            ..area
+        };
+        let scrollbar_area = Rect {
+            x: area.right().saturating_sub(1),
+            y: area.y,
+            width: u16::from(area.width > 0),
+            height: area.height,
+        };
+        self.render_with_scrollbar_area(viewport, buf, scrollbar_area);
+    }
+}
+
+impl GridViewport<'_> {
+    fn render_with_scrollbar_area(self, area: Rect, buf: &mut Buffer, scrollbar_area: Rect) {
+        let inner = area;
+
         if inner.width == 0 || inner.height == 0 {
             return;
         }
@@ -1508,7 +1552,7 @@ impl<'a> Widget for DataGrid<'a> {
             }
             let y = body_area.y + i as u16;
 
-            let is_cursor = row_idx == self.state.cursor_row;
+            let is_cursor = self.focused && row_idx == self.state.cursor_row;
             let is_selected = self.state.selected_rows.contains(&row_idx);
 
             let row_style = if is_cursor {
@@ -1567,8 +1611,6 @@ impl<'a> Widget for DataGrid<'a> {
             let mut scrollbar_state = ScrollbarState::new(self.model.rows.len())
                 .position(self.state.cursor_row)
                 .viewport_content_length(body_area.height as usize);
-
-            let scrollbar_area = zone_scrollbar_area(area);
 
             scrollbar.render(scrollbar_area, buf, &mut scrollbar_state);
         }
@@ -2037,6 +2079,100 @@ mod tests {
         grid.render(area, &mut buf);
 
         assert_nonblank_cells_have_explicit_fg(&buf);
+    }
+
+    #[test]
+    fn test_grid_viewport_renders_header_cursor_selection_search_and_scrollbar() {
+        let model = GridModel::new(
+            vec!["id".to_string(), "name".to_string()],
+            vec![
+                vec!["1".to_string(), "Alice".to_string()],
+                vec!["2".to_string(), "Bob".to_string()],
+                vec!["3".to_string(), "Carol".to_string()],
+                vec!["4".to_string(), "Diana".to_string()],
+            ],
+        );
+        let theme = UiTheme::fallback();
+        let mut state = GridState {
+            cursor_row: 1,
+            cursor_col: 1,
+            ..Default::default()
+        };
+        state.selected_rows.insert(0);
+        state.search.search("Alice", &model);
+        let area = Rect::new(0, 0, 20, 3);
+        let mut buffer = Buffer::empty(area);
+
+        GridViewport {
+            model: &model,
+            state: &state,
+            theme: &theme,
+            focused: true,
+            show_row_numbers: true,
+            show_scrollbar: true,
+        }
+        .render(area, &mut buffer);
+
+        assert_eq!(buffer.cell((0, 0)).unwrap().symbol(), "#");
+        assert_eq!(buffer.cell((5, 0)).unwrap().symbol(), "i");
+        assert_eq!(buffer.cell((9, 0)).unwrap().symbol(), "n");
+        assert_eq!(
+            buffer.cell((9, 0)).unwrap().fg,
+            theme.grid_header.fg.unwrap()
+        );
+        assert_eq!(
+            buffer.cell((9, 0)).unwrap().bg,
+            theme.grid_header.bg.unwrap()
+        );
+        assert_eq!(buffer.cell((3, 1)).unwrap().symbol(), "*");
+        assert_eq!(buffer.cell((2, 2)).unwrap().symbol(), ">");
+        assert_eq!(
+            buffer.cell((9, 1)).unwrap().bg,
+            theme.search_match_current.bg.unwrap()
+        );
+        assert_eq!(
+            buffer.cell((9, 2)).unwrap().bg,
+            theme.cursor_cell.bg.unwrap()
+        );
+        assert_eq!(buffer.cell((19, 0)).unwrap().symbol(), "▲");
+        assert_eq!(buffer.cell((19, 2)).unwrap().symbol(), "▼");
+    }
+
+    #[test]
+    fn test_unfocused_grid_viewport_hides_cursor_and_keeps_selection_and_search() {
+        let model = create_test_model();
+        let theme = UiTheme::fallback();
+        let mut state = GridState {
+            cursor_row: 1,
+            cursor_col: 1,
+            ..Default::default()
+        };
+        state.selected_rows.insert(0);
+        state.search.search("Alice", &model);
+        let area = Rect::new(0, 0, 20, 4);
+        let mut buffer = Buffer::empty(area);
+
+        GridViewport {
+            model: &model,
+            state: &state,
+            theme: &theme,
+            focused: false,
+            show_row_numbers: true,
+            show_scrollbar: false,
+        }
+        .render(area, &mut buffer);
+
+        assert_eq!(buffer.cell((3, 1)).unwrap().symbol(), "*");
+        assert_eq!(buffer.cell((2, 2)).unwrap().symbol(), " ");
+        assert_eq!(
+            buffer.cell((9, 1)).unwrap().bg,
+            theme.search_match_current.bg.unwrap()
+        );
+        assert_ne!(
+            buffer.cell((9, 2)).unwrap().bg,
+            theme.cursor_cell.bg.unwrap()
+        );
+        assert_ne!(buffer.cell((9, 2)).unwrap().bg, theme.selection.bg.unwrap());
     }
 
     #[test]

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -3,13 +3,14 @@
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
     Frame,
 };
 
 use super::mouse_util::{is_inside, MOUSE_SCROLL_LINES};
+use super::{overlay_block, UiTheme};
 
 /// Result of handling a key event in the help popup.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -617,7 +618,7 @@ impl HelpPopup {
     }
 
     /// Render the help popup centered on the screen.
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         // Calculate popup size (80% width, 80% height, with min/max)
         let width = (area.width * 80 / 100).clamp(60, 100);
         let height = (area.height * 85 / 100).clamp(20, 50);
@@ -630,16 +631,7 @@ impl HelpPopup {
         // Clear background
         frame.render_widget(Clear, popup);
 
-        // Create the outer block
-        let block = Block::default()
-            .title(" Help ")
-            .title_style(
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan));
+        let block = overlay_block("Help", theme);
 
         let inner = block.inner(popup);
         frame.render_widget(block, popup);
@@ -654,57 +646,56 @@ impl HelpPopup {
         .split(inner);
 
         // Render header
-        self.render_header(frame, chunks[0]);
+        self.render_header(frame, chunks[0], theme);
 
         // Render separator
-        let sep = Paragraph::new("─".repeat(chunks[1].width as usize))
-            .style(Style::default().fg(Color::DarkGray));
+        let sep = Paragraph::new("─".repeat(chunks[1].width as usize)).style(theme.overlay_border);
         frame.render_widget(sep, chunks[1]);
 
         // Update visible height for scrolling calculations
         self.visible_height = chunks[2].height as usize;
 
         // Render content with scrolling
-        self.render_content(frame, chunks[2]);
+        self.render_content(frame, chunks[2], theme);
 
         // Render footer with scroll indicator
-        self.render_footer(frame, chunks[3]);
+        self.render_footer(frame, chunks[3], theme);
 
         // Render scrollbar if content overflows
         if self.total_lines > self.visible_height {
-            self.render_scrollbar(frame, chunks[2]);
+            self.render_scrollbar(frame, chunks[2], theme);
         }
     }
 
-    fn render_header(&self, frame: &mut Frame, area: Rect) {
+    fn render_header(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let header = Line::from(vec![
             Span::styled(
                 "tsql",
                 Style::default()
-                    .fg(Color::Green)
+                    .fg(theme.success)
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw(" - PostgreSQL CLI  "),
-            Span::styled("Press ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Press ", Style::default().fg(theme.text_muted)),
             Span::styled(
                 "q",
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(theme.warning)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" or ", Style::default().fg(Color::DarkGray)),
+            Span::styled(" or ", Style::default().fg(theme.text_muted)),
             Span::styled(
                 "Esc",
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(theme.warning)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" to close", Style::default().fg(Color::DarkGray)),
+            Span::styled(" to close", Style::default().fg(theme.text_muted)),
         ]);
         frame.render_widget(Paragraph::new(header), area);
     }
 
-    fn render_content(&self, frame: &mut Frame, area: Rect) {
+    fn render_content(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let filtered = self.filtered_sections();
         let section_count = filtered.len();
         let mut lines: Vec<Line> = Vec::new();
@@ -712,7 +703,7 @@ impl HelpPopup {
         if filtered.is_empty() {
             lines.push(Line::from(vec![Span::styled(
                 format!("  No results for \"{}\"", self.filter),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.text_muted),
             )]));
         }
 
@@ -721,20 +712,20 @@ impl HelpPopup {
             lines.push(Line::from(vec![Span::styled(
                 format!(" {} ", title),
                 Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Cyan)
+                    .fg(theme.pill_fg)
+                    .bg(theme.accent)
                     .add_modifier(Modifier::BOLD),
             )]));
 
             // Separator under header
             lines.push(Line::from(Span::styled(
                 "─".repeat(area.width as usize),
-                Style::default().fg(Color::DarkGray),
+                theme.overlay_border,
             )));
 
             // Keybindings
             for binding in bindings.iter() {
-                lines.push(self.render_keybinding(binding, &self.filter, area.width as usize));
+                lines.push(self.render_keybinding(binding, &self.filter, theme));
             }
 
             // Blank line between sections (except last)
@@ -758,7 +749,7 @@ impl HelpPopup {
         &self,
         binding: &KeyBinding,
         filter: &str,
-        _width: usize,
+        theme: &UiTheme,
     ) -> Line<'static> {
         let keys = format!("{:20}", binding.keys);
         let desc = binding.description.to_string();
@@ -769,44 +760,30 @@ impl HelpPopup {
         let desc_highlighted = !filter.is_empty() && desc.to_lowercase().contains(&filter_lower);
 
         let key_span = if keys_highlighted {
-            Span::styled(
-                keys,
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            )
+            Span::styled(keys, theme.search_match.add_modifier(Modifier::BOLD))
         } else {
             Span::styled(
                 keys,
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(theme.warning)
                     .add_modifier(Modifier::BOLD),
             )
         };
 
         let desc_span = if desc_highlighted {
-            Span::styled(
-                desc,
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            )
+            Span::styled(desc, theme.search_match.add_modifier(Modifier::BOLD))
         } else {
-            Span::styled(desc, Style::default().fg(Color::White))
+            Span::styled(desc, Style::default().fg(theme.text))
         };
 
         Line::from(vec![Span::raw("  "), key_span, desc_span])
     }
 
-    fn render_footer(&self, frame: &mut Frame, area: Rect) {
+    fn render_footer(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let scroll_info = if self.total_lines > self.visible_height {
-            let percent = if self.total_lines == 0 {
-                100
-            } else {
-                ((self.scroll_offset + self.visible_height) * 100 / self.total_lines).min(100)
-            };
+            let percent = ((self.scroll_offset + self.visible_height) * 100)
+                .checked_div(self.total_lines)
+                .map_or(100, |percent| percent.min(100));
             format!("{}%", percent)
         } else {
             "All".to_string()
@@ -823,12 +800,12 @@ impl HelpPopup {
                 Span::styled(
                     prompt,
                     Style::default()
-                        .fg(Color::Yellow)
+                        .fg(theme.warning)
                         .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
                     format!("{}{}", hint, " ".repeat(padding as usize)),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme.text_muted),
                 ),
             ])
         } else if !self.filter.is_empty() {
@@ -842,35 +819,36 @@ impl HelpPopup {
                 Span::styled(
                     filter_info,
                     Style::default()
-                        .fg(Color::Yellow)
+                        .fg(theme.warning)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(fixed, Style::default().fg(Color::DarkGray)),
+                Span::styled(fixed, Style::default().fg(theme.text_muted)),
                 Span::raw(" ".repeat(padding as usize)),
-                Span::styled(scroll_info, Style::default().fg(Color::Cyan)),
+                Span::styled(scroll_info, Style::default().fg(theme.accent)),
             ])
         } else {
             // Normal footer
             Line::from(vec![
-                Span::styled(" j/k ", Style::default().fg(Color::Yellow)),
-                Span::styled("scroll  ", Style::default().fg(Color::DarkGray)),
-                Span::styled(" g/G ", Style::default().fg(Color::Yellow)),
-                Span::styled("top/bottom  ", Style::default().fg(Color::DarkGray)),
-                Span::styled(" / ", Style::default().fg(Color::Yellow)),
-                Span::styled("filter  ", Style::default().fg(Color::DarkGray)),
+                Span::styled(" j/k ", Style::default().fg(theme.warning)),
+                Span::styled("scroll  ", Style::default().fg(theme.text_muted)),
+                Span::styled(" g/G ", Style::default().fg(theme.warning)),
+                Span::styled("top/bottom  ", Style::default().fg(theme.text_muted)),
+                Span::styled(" / ", Style::default().fg(theme.warning)),
+                Span::styled("filter  ", Style::default().fg(theme.text_muted)),
                 Span::raw(" ".repeat(area.width.saturating_sub(50) as usize)),
-                Span::styled(scroll_info, Style::default().fg(Color::Cyan)),
+                Span::styled(scroll_info, Style::default().fg(theme.accent)),
             ])
         };
         frame.render_widget(Paragraph::new(footer), area);
     }
 
-    fn render_scrollbar(&self, frame: &mut Frame, area: Rect) {
+    fn render_scrollbar(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"))
             .track_symbol(Some("│"))
-            .thumb_symbol("█");
+            .thumb_symbol("█")
+            .style(theme.scrollbar);
 
         // The scrollbar needs to know the max scroll position (total - visible)
         // and the current scroll position
@@ -937,12 +915,13 @@ mod tests {
     fn key_span_is_highlighted_when_filter_matches_keys() {
         let popup = HelpPopup::new();
         let binding = KeyBinding::new("Ctrl+o", "Open connection picker");
+        let theme = UiTheme::fallback();
 
-        let line = popup.render_keybinding(&binding, "ctrl", 80);
+        let line = popup.render_keybinding(&binding, "ctrl", &theme);
         let key_span = &line.spans[1];
 
-        assert_eq!(key_span.style.fg, Some(Color::Black));
-        assert_eq!(key_span.style.bg, Some(Color::Yellow));
+        assert_eq!(key_span.style.fg, theme.search_match.fg);
+        assert_eq!(key_span.style.bg, theme.search_match.bg);
         assert!(key_span.style.add_modifier.contains(Modifier::BOLD));
     }
 }

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -153,6 +153,51 @@ const SIDEBAR_SCHEMA: HelpSection = HelpSection::new(
     ],
 );
 
+const NOTEBOOK: HelpSection = HelpSection::new(
+    "Notebook - Cell Focus",
+    &[
+        KeyBinding::new("j/k or arrows", "Select next/previous cell"),
+        KeyBinding::new("gg / G, Home / End", "Select first/last cell"),
+        KeyBinding::new("PageUp/Down, Ctrl-u/d", "Move between cells by page"),
+        KeyBinding::new("Enter / e", "Focus the selected cell editor"),
+        KeyBinding::new("o", "Expand and inspect the selected result"),
+        KeyBinding::new("Ctrl+E", "Execute the selected cell"),
+        KeyBinding::new("E", "Execute cell and advance"),
+        KeyBinding::new("n", "Select or create the trailing draft"),
+        KeyBinding::new("r", "Refine a retained result snapshot"),
+        KeyBinding::new(
+            "@result / @result_N",
+            "Reference the latest result or cell N",
+        ),
+        KeyBinding::new("h / l", "Collapse / expand the selected result"),
+        KeyBinding::new("z", "Collapse/expand cell output"),
+        KeyBinding::new("x", "Clear cell and dependent executions"),
+        KeyBinding::new("dd / Delete", "Delete the selected cell"),
+        KeyBinding::new(":", "Open command prompt"),
+        KeyBinding::new("Esc", "Return from editor/result to cell focus"),
+    ],
+);
+
+const NOTEBOOK_RESULT: HelpSection = HelpSection::new(
+    "Notebook - Result Focus (read-only)",
+    &[
+        KeyBinding::new("o / click result", "Expand result and compact other cells"),
+        KeyBinding::new("h/j/k/l or arrows", "Navigate result cells"),
+        KeyBinding::new("gg / G, 0 / $", "First/last row or column"),
+        KeyBinding::new("PageUp/Down, Ctrl-u/d", "Move between rows by page"),
+        KeyBinding::new(
+            "Space / a / A",
+            "Toggle, select all, or invert row selection",
+        ),
+        KeyBinding::new("c, yy / yY", "Copy cell or yank row(s) as TSV"),
+        KeyBinding::new("yj, yc / yC, ym", "Yank row(s) as JSON, CSV, or Markdown"),
+        KeyBinding::new("/ then n / N", "Search and move between matches"),
+        KeyBinding::new("+ / -, =", "Resize or fit/collapse the current column"),
+        KeyBinding::new("o", "Open row detail"),
+        KeyBinding::new("Esc", "Restore notebook flow and cell focus"),
+    ],
+);
+
 const QUERY_NAVIGATION: HelpSection = HelpSection::new(
     "Query Editor - Navigation",
     &[
@@ -323,6 +368,8 @@ const ALL_SECTIONS: &[HelpSection] = &[
     SIDEBAR_CONNECTIONS,
     CONNECTION_MANAGER,
     SIDEBAR_SCHEMA,
+    NOTEBOOK,
+    NOTEBOOK_RESULT,
     QUERY_NAVIGATION,
     QUERY_EDITING,
     QUERY_VISUAL,
@@ -923,5 +970,74 @@ mod tests {
         assert_eq!(key_span.style.fg, theme.search_match.fg);
         assert_eq!(key_span.style.bg, theme.search_match.bg);
         assert!(key_span.style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn notebook_section_lists_cell_bindings() {
+        let popup = HelpPopup::new();
+        let section = popup
+            .sections
+            .iter()
+            .find(|section| section.title == "Notebook - Cell Focus")
+            .expect("notebook help section should be present");
+        let keys: Vec<_> = section
+            .bindings
+            .iter()
+            .map(|binding| binding.keys)
+            .collect();
+
+        assert_eq!(
+            keys,
+            [
+                "j/k or arrows",
+                "gg / G, Home / End",
+                "PageUp/Down, Ctrl-u/d",
+                "Enter / e",
+                "o",
+                "Ctrl+E",
+                "E",
+                "n",
+                "r",
+                "@result / @result_N",
+                "h / l",
+                "z",
+                "x",
+                "dd / Delete",
+                ":",
+                "Esc",
+            ]
+        );
+    }
+
+    #[test]
+    fn notebook_result_section_lists_table_bindings() {
+        let popup = HelpPopup::new();
+        let section = popup
+            .sections
+            .iter()
+            .find(|section| section.title == "Notebook - Result Focus (read-only)")
+            .expect("notebook result help section should be present");
+        let keys: Vec<_> = section
+            .bindings
+            .iter()
+            .map(|binding| binding.keys)
+            .collect();
+
+        assert_eq!(
+            keys,
+            [
+                "o / click result",
+                "h/j/k/l or arrows",
+                "gg / G, 0 / $",
+                "PageUp/Down, Ctrl-u/d",
+                "Space / a / A",
+                "c, yy / yY",
+                "yj, yc / yC, ym",
+                "/ then n / N",
+                "+ / -, =",
+                "o",
+                "Esc",
+            ]
+        );
     }
 }

--- a/crates/tsql/src/ui/help_popup.rs
+++ b/crates/tsql/src/ui/help_popup.rs
@@ -83,6 +83,7 @@ const GLOBAL: HelpSection = HelpSection::new(
         KeyBinding::new("Ctrl-h/j/k/l", "Move between panes in Normal mode"),
         KeyBinding::new("Alt-h/j/k/l", "Move between panes in any mode"),
         KeyBinding::new("Alt+M", "Toggle maximized results view"),
+        KeyBinding::new("Ctrl+Shift+P / Cmd+K", "Open contextual Actions palette"),
         KeyBinding::new("Esc", "Return to normal mode / close popup"),
         KeyBinding::new("q", "Quit application"),
         KeyBinding::new("?", "Toggle this help  (/ to filter inside)"),
@@ -294,6 +295,10 @@ const GRID_ACTIONS: HelpSection = HelpSection::new(
         KeyBinding::new("o", "Open row detail view"),
         KeyBinding::new("/", "Search in results"),
         KeyBinding::new("n/N", "Next/previous match"),
+        KeyBinding::new(
+            "Ctrl+Shift+P / Cmd+K",
+            "Sort, filter, project, or group the focused Classic/PostgreSQL result",
+        ),
         KeyBinding::new("Ctrl-r", "Rerun last query"),
     ],
 );
@@ -326,9 +331,100 @@ const COMMANDS: HelpSection = HelpSection::new(
     &[
         KeyBinding::new(":connect <url>", "Connect to database"),
         KeyBinding::new(":disconnect", "Disconnect from database"),
-        KeyBinding::new(":export <fmt> <path>", "Export results (csv/json/tsv)"),
+        KeyBinding::new(
+            ":export <fmt> <path>",
+            "Export result or selected rows (csv/json/tsv/sql); retained results stream",
+        ),
         KeyBinding::new(":gen <type>", "Generate SQL (update/delete/insert)"),
         KeyBinding::new(":history", "Open history picker"),
+        KeyBinding::new(":actions / :palette", "Open contextual Actions palette"),
+        KeyBinding::new(
+            ":sort asc|desc|add-asc|add-desc|toggle",
+            "Sort the focused Classic/PostgreSQL result",
+        ),
+        KeyBinding::new(
+            ":filter [#column|name] eq|ne|<|<=|>|>=|contains|not-contains|null|not-null [value]",
+            "Filter the focused Classic/PostgreSQL result",
+        ),
+        KeyBinding::new(
+            ":columns / :group-count",
+            "Choose result columns or group and count the current column",
+        ),
+        KeyBinding::new(
+            ":clear-filters / :clear-sort / :reset-result",
+            "Clear or reset Classic result transformations",
+        ),
+        KeyBinding::new(
+            ":result-sql copy|open",
+            "Copy transformed SQL or open it in the editor",
+        ),
+        KeyBinding::new(
+            ":snippets / :snippet-save <name>",
+            "Load or save reusable named query snippets",
+        ),
+        KeyBinding::new(
+            ":snippet <name> / :snippet-delete <name>",
+            "Load or delete a named query snippet",
+        ),
+        KeyBinding::new(":notebook / :mode notebook", "Switch to Notebook mode"),
+        KeyBinding::new(":mode classic", "Switch to Classic mode"),
+        KeyBinding::new(
+            ":rebase / :rebind",
+            "Rebind a cell to the latest source result",
+        ),
+        KeyBinding::new(":detach", "Remove a cell's result dependency"),
+        KeyBinding::new(
+            ":run-without-snapshot",
+            "Run the selected cell without retaining a snapshot",
+        ),
+        KeyBinding::new(
+            ":run-all / :run-above / :run-below",
+            "Run notebook cells in dependency order",
+        ),
+        KeyBinding::new(
+            ":run-dependents",
+            "Rerun the selected cell and its dependents",
+        ),
+        KeyBinding::new(
+            ":open-notebook / :save-notebook <path>",
+            "Open or save a portable notebook document",
+        ),
+        KeyBinding::new(
+            ":insert-above / :insert-below / :duplicate-cell",
+            "Insert or duplicate a notebook cell",
+        ),
+        KeyBinding::new(
+            ":move-cell-up / :move-cell-down",
+            "Reorder the selected notebook cell",
+        ),
+        KeyBinding::new(
+            ":name <identifier> / :name clear",
+            "Set or clear a stable notebook result name",
+        ),
+        KeyBinding::new(
+            ":outline / :cell <id-or-name>",
+            "List notebook cells or jump to one",
+        ),
+        KeyBinding::new(
+            ":error / :copy-error",
+            "Inspect or copy the selected notebook cell error",
+        ),
+        KeyBinding::new(
+            ":error-jump / :activity",
+            "Go to a mapped error or the latest off-screen cell update",
+        ),
+        KeyBinding::new(
+            ":cell-history / :cell-run <id>",
+            "Browse completed cell runs or restore a previous source",
+        ),
+        KeyBinding::new(
+            ":explain-cell",
+            "Run EXPLAIN for the selected PostgreSQL notebook cell",
+        ),
+        KeyBinding::new(
+            ":collapse-source / :expand-source / :toggle-source",
+            "Compact or reveal the selected notebook source",
+        ),
         KeyBinding::new(":ai [prompt]", "Open AI query assistant"),
         KeyBinding::new(":export-connections <path>", "Export saved connections"),
         KeyBinding::new(
@@ -1039,5 +1135,47 @@ mod tests {
                 "Esc",
             ]
         );
+    }
+
+    #[test]
+    fn commands_section_lists_notebook_commands() {
+        let popup = HelpPopup::new();
+        let section = popup
+            .sections
+            .iter()
+            .find(|section| section.title == "Commands")
+            .expect("commands help section should be present");
+        let keys: Vec<_> = section
+            .bindings
+            .iter()
+            .map(|binding| binding.keys)
+            .collect();
+
+        for command in [
+            ":sort asc|desc|add-asc|add-desc|toggle",
+            ":filter [#column|name] eq|ne|<|<=|>|>=|contains|not-contains|null|not-null [value]",
+            ":columns / :group-count",
+            ":clear-filters / :clear-sort / :reset-result",
+            ":result-sql copy|open",
+            ":notebook / :mode notebook",
+            ":mode classic",
+            ":rebase / :rebind",
+            ":detach",
+            ":run-without-snapshot",
+            ":run-all / :run-above / :run-below",
+            ":run-dependents",
+            ":open-notebook / :save-notebook <path>",
+            ":insert-above / :insert-below / :duplicate-cell",
+            ":move-cell-up / :move-cell-down",
+            ":name <identifier> / :name clear",
+            ":outline / :cell <id-or-name>",
+            ":error / :copy-error",
+            ":error-jump / :activity",
+            ":cell-history / :cell-run <id>",
+            ":explain-cell",
+            ":collapse-source / :expand-source / :toggle-source",
+        ] {
+            assert!(keys.contains(&command), "missing {command}");
+        }
     }
 }

--- a/crates/tsql/src/ui/highlighted_editor.rs
+++ b/crates/tsql/src/ui/highlighted_editor.rs
@@ -5,7 +5,7 @@ use ratatui::layout::{Position, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph, Widget};
-use tui_syntax::{sql, themes, Highlighter};
+use tui_syntax::{sql, Highlighter, Theme};
 use tui_textarea::TextArea;
 use unicode_width::UnicodeWidthChar;
 
@@ -426,8 +426,8 @@ fn apply_style_to_range(
 }
 
 /// Creates a pre-configured highlighter for SQL.
-pub fn create_sql_highlighter() -> Highlighter {
-    let mut highlighter = Highlighter::new(themes::one_dark());
+pub fn create_sql_highlighter(theme: Theme) -> Highlighter {
+    let mut highlighter = Highlighter::new(theme);
     // Ignore errors - SQL should always register successfully
     let _ = highlighter.register_language(sql());
     highlighter
@@ -439,8 +439,57 @@ mod tests {
 
     #[test]
     fn test_create_sql_highlighter() {
-        let _highlighter = create_sql_highlighter();
+        let _highlighter = create_sql_highlighter(tui_syntax::themes::one_dark());
         // Just verify it creates without panicking
+    }
+
+    #[test]
+    fn test_tonal_zone_cursor_geometry_and_built_in_base_styles() {
+        use crate::ui::{zone_block, UiTheme};
+
+        let area = Rect::new(0, 0, 30, 5);
+        let textarea = TextArea::new(vec!["select plain_identifier".to_string()]);
+
+        for syntax_theme in [
+            tui_syntax::themes::one_dark(),
+            tui_syntax::themes::github_light(),
+        ] {
+            let ui_theme = UiTheme::from_theme(&syntax_theme);
+            let mut highlighter = create_sql_highlighter(syntax_theme);
+            let lines = highlighter
+                .highlight("sql", textarea.lines().join("\n").as_str())
+                .unwrap();
+            let block = zone_block(
+                Line::from(" QUERY"),
+                ui_theme.bg_elevated,
+                ui_theme.text,
+                true,
+                ui_theme.accent,
+            );
+            let widget = HighlightedTextArea::new(&textarea, lines.clone())
+                .block(block.clone())
+                .cursor_style(ui_theme.editor_cursor)
+                .selection_style(ui_theme.editor_selection);
+
+            assert_eq!(
+                widget.cursor_screen_position(area),
+                Some(Position::new(2, 1))
+            );
+
+            let mut buffer = Buffer::empty(area);
+            HighlightedTextArea::new(&textarea, lines)
+                .block(block)
+                .cursor_style(ui_theme.editor_cursor)
+                .selection_style(ui_theme.editor_selection)
+                .show_cursor(false)
+                .render(area, &mut buffer);
+
+            for cell in &buffer.content {
+                if !cell.symbol().trim().is_empty() {
+                    assert_ne!(cell.fg, Color::Reset);
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/tsql/src/ui/highlighted_editor.rs
+++ b/crates/tsql/src/ui/highlighted_editor.rs
@@ -5,7 +5,7 @@ use ratatui::layout::{Position, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph, Widget};
-use tui_syntax::{sql, Highlighter, Theme};
+use tui_syntax::{javascript, sql, Highlighter, Theme};
 use tui_textarea::TextArea;
 use unicode_width::UnicodeWidthChar;
 
@@ -425,11 +425,12 @@ fn apply_style_to_range(
     result
 }
 
-/// Creates a pre-configured highlighter for SQL.
+/// Creates a pre-configured highlighter for SQL and Mongo shell JavaScript.
 pub fn create_sql_highlighter(theme: Theme) -> Highlighter {
     let mut highlighter = Highlighter::new(theme);
-    // Ignore errors - SQL should always register successfully
+    // Ignore errors - bundled language definitions should always register successfully.
     let _ = highlighter.register_language(sql());
+    let _ = highlighter.register_language(javascript());
     highlighter
 }
 
@@ -439,8 +440,11 @@ mod tests {
 
     #[test]
     fn test_create_sql_highlighter() {
-        let _highlighter = create_sql_highlighter(tui_syntax::themes::one_dark());
-        // Just verify it creates without panicking
+        let mut highlighter = create_sql_highlighter(tui_syntax::themes::one_dark());
+        assert!(highlighter.highlight("sql", "SELECT 1").is_ok());
+        assert!(highlighter
+            .highlight("javascript", "db.users.find({ active: true }).limit(5)")
+            .is_ok());
     }
 
     #[test]

--- a/crates/tsql/src/ui/json_editor.rs
+++ b/crates/tsql/src/ui/json_editor.rs
@@ -133,6 +133,12 @@ impl<'a> JsonEditorModal<'a> {
         self.textarea.lines().join("\n")
     }
 
+    /// Insert bracketed-paste text literally, independent of the current Vim mode.
+    pub fn paste_text(&mut self, text: &str) {
+        self.textarea.insert_str(text);
+        self.update_validity();
+    }
+
     /// Check if the content has been modified from the original.
     pub fn is_modified(&self) -> bool {
         self.content() != self.original_value
@@ -825,6 +831,22 @@ mod tests {
         // Plain text should be detected as Plain type
         let content_type = detect_content_type(&editor.content());
         assert_eq!(content_type, ContentType::Plain);
+    }
+
+    #[test]
+    fn test_bracketed_paste_inserts_literally_in_normal_mode() {
+        let mut editor = JsonEditorModal::new(
+            String::new(),
+            "data".to_string(),
+            "text".to_string(),
+            0,
+            0,
+            themes::one_dark(),
+        );
+
+        editor.paste_text("SELECT * FROM source\nWHERE value > 1");
+
+        assert_eq!(editor.content(), "SELECT * FROM source\nWHERE value > 1");
     }
 
     #[test]

--- a/crates/tsql/src/ui/json_editor.rs
+++ b/crates/tsql/src/ui/json_editor.rs
@@ -9,15 +9,13 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{
-    Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-};
+use ratatui::widgets::{Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState};
 use ratatui::Frame;
 use tui_textarea::{CursorMove, TextArea};
 
-use tui_syntax::{html, json, themes, Highlighter};
+use tui_syntax::{html, json, Highlighter, Theme};
 
 use crate::ui::HighlightedTextArea;
 use crate::util::{
@@ -25,7 +23,7 @@ use crate::util::{
 };
 use crate::vim::{Motion, VimCommand, VimConfig, VimHandler, VimMode};
 
-use super::style::{selected_muted_style, selected_row_style};
+use super::{overlay_block, UiTheme};
 
 /// The result of handling a key event in the JSON editor.
 pub enum JsonEditorAction {
@@ -86,6 +84,7 @@ impl<'a> JsonEditorModal<'a> {
         column_type: String,
         row: usize,
         col: usize,
+        syntax_theme: Theme,
     ) -> Self {
         // Try to pretty-print the JSON
         let formatted_value = try_format_json(&value).unwrap_or_else(|| value.clone());
@@ -105,7 +104,7 @@ impl<'a> JsonEditorModal<'a> {
         textarea.set_cursor_style(Style::default().add_modifier(Modifier::REVERSED));
 
         // Create highlighter with JSON and HTML support
-        let mut highlighter = Highlighter::new(themes::one_dark());
+        let mut highlighter = Highlighter::new(syntax_theme);
         let _ = highlighter.register_language(json());
         let _ = highlighter.register_language(html());
 
@@ -531,7 +530,7 @@ impl<'a> JsonEditorModal<'a> {
     }
 
     /// Render the JSON editor modal.
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         // Calculate modal size (80% of screen)
         let modal_width = (area.width as f32 * 0.8) as u16;
         let modal_height = (area.height as f32 * 0.8) as u16;
@@ -563,7 +562,7 @@ impl<'a> JsonEditorModal<'a> {
         // Build title with [+] indicator if modified
         let modified_indicator = if self.is_modified() { " [+]" } else { "" };
         let title = format!(
-            " Edit: {} ({}){} - {} ",
+            "Edit: {} ({}){} - {}",
             self.column_name,
             self.column_type,
             modified_indicator,
@@ -574,27 +573,27 @@ impl<'a> JsonEditorModal<'a> {
         let content = self.content();
         let content_type = detect_content_type(&content);
 
-        // Border color: green for valid JSON (if JSON column), yellow otherwise, red for invalid JSON in JSON column
+        // Semantic border override: validation state matters more than the
+        // calm overlay recipe here (green = valid JSON, red = invalid).
         let border_color = if self.is_json_column() {
             if self.is_valid_json {
-                Color::Green
+                Some(theme.success)
             } else {
-                Color::Red
+                Some(theme.error)
             }
         } else {
-            // Non-JSON column: show detected type in title color
             match content_type {
-                ContentType::Json => Color::Green,
-                ContentType::Html => Color::Cyan,
-                ContentType::Sql => Color::Yellow,
-                ContentType::Plain => Color::White,
+                ContentType::Json => Some(theme.success),
+                ContentType::Html => Some(theme.accent),
+                ContentType::Sql => Some(theme.warning),
+                ContentType::Plain => None,
             }
         };
 
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title(title)
-            .border_style(Style::default().fg(border_color));
+        let mut block = overlay_block(&title, theme);
+        if let Some(color) = border_color {
+            block = block.border_style(Style::default().fg(color));
+        }
 
         // Apply syntax highlighting based on detected content type
         let highlighted_lines = if let Some(lang) = content_type.language_name() {
@@ -609,6 +608,8 @@ impl<'a> JsonEditorModal<'a> {
         // Render highlighted textarea
         let highlighted_textarea = HighlightedTextArea::new(&self.textarea, highlighted_lines)
             .block(block.clone())
+            .cursor_style(theme.editor_cursor)
+            .selection_style(theme.editor_selection)
             .scroll(self.scroll_offset);
 
         frame.render_widget(highlighted_textarea, editor_area);
@@ -639,12 +640,14 @@ impl<'a> JsonEditorModal<'a> {
                     .end_symbol(Some("▼"))
                     .thumb_symbol("█")
                     .track_symbol(Some("░"))
+                    .style(theme.scrollbar)
             } else {
                 Scrollbar::new(ScrollbarOrientation::VerticalRight)
                     .begin_symbol(None)
                     .end_symbol(None)
                     .thumb_symbol("█")
                     .track_symbol(Some("│"))
+                    .style(theme.scrollbar)
             };
 
             let mut scrollbar_state =
@@ -661,34 +664,37 @@ impl<'a> JsonEditorModal<'a> {
         let type_span = match content_type {
             ContentType::Json => {
                 if self.is_valid_json {
-                    Span::styled(" ✓ JSON ", Style::default().fg(Color::Green))
+                    Span::styled(" ✓ JSON ", Style::default().fg(theme.success))
                 } else {
-                    Span::styled(" ✗ JSON ", Style::default().fg(Color::Red))
+                    Span::styled(" ✗ JSON ", Style::default().fg(theme.error))
                 }
             }
-            ContentType::Html => Span::styled(" HTML ", Style::default().fg(Color::Cyan)),
-            ContentType::Sql => Span::styled(" SQL ", Style::default().fg(Color::Yellow)),
-            ContentType::Plain => Span::styled(" TEXT ", Style::default().fg(Color::White)),
+            ContentType::Html => Span::styled(" HTML ", Style::default().fg(theme.accent)),
+            ContentType::Sql => Span::styled(" SQL ", Style::default().fg(theme.warning)),
+            ContentType::Plain => Span::styled(" TEXT ", Style::default().fg(theme.text)),
         };
 
         // For JSON columns, also show validation status
         let validity_span = if self.is_json_column() && !self.is_valid_json {
             Some(Span::styled(
                 " (invalid for JSONB) ",
-                Style::default().fg(Color::Red),
+                Style::default().fg(theme.error),
             ))
         } else {
             None
         };
 
         let mode_color = match self.mode {
-            VimMode::Normal => Color::Cyan,
-            VimMode::Insert => Color::Green,
-            VimMode::Visual => Color::Magenta,
+            VimMode::Normal => theme.accent,
+            VimMode::Insert => theme.accent_insert,
+            VimMode::Visual => theme.accent_visual,
         };
         let mode_span = Span::styled(
             format!(" {} ", self.mode.label()),
-            Style::default().fg(mode_color).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.pill_fg)
+                .bg(mode_color)
+                .add_modifier(Modifier::BOLD),
         );
 
         let pos_span = Span::raw(format!(
@@ -698,28 +704,27 @@ impl<'a> JsonEditorModal<'a> {
             cursor_col + 1
         ));
 
+        // Status strip shares the app status-bar tone.
+        let strip_style = Style::default().fg(theme.text).bg(theme.bg_status);
+        let muted = Style::default().fg(theme.text_muted);
+
         // If command mode is active, show command prompt instead of help
         if self.command_active {
             let command_line = Line::from(vec![
-                Span::styled(":", Style::default().fg(Color::Yellow)),
+                Span::styled(":", Style::default().fg(theme.warning)),
                 Span::raw(&self.command_buffer),
                 Span::styled("_", Style::default().add_modifier(Modifier::SLOW_BLINK)),
             ]);
-            let status = Paragraph::new(command_line).style(selected_row_style());
+            let status = Paragraph::new(command_line).style(strip_style);
             frame.render_widget(status, status_area);
         } else {
             let help_span = match self.mode {
                 VimMode::Normal => Span::styled(
                     " i:insert  v:visual  :format  Ctrl+S:save  q/Esc:close ",
-                    selected_muted_style(),
+                    muted,
                 ),
-                VimMode::Insert => {
-                    Span::styled(" Esc:normal  Ctrl+Enter:save ", selected_muted_style())
-                }
-                VimMode::Visual => Span::styled(
-                    " y:yank  d:delete  c:change  Esc:cancel ",
-                    selected_muted_style(),
-                ),
+                VimMode::Insert => Span::styled(" Esc:normal  Ctrl+Enter:save ", muted),
+                VimMode::Visual => Span::styled(" y:yank  d:delete  c:change  Esc:cancel ", muted),
             };
 
             let mut spans = vec![mode_span, type_span];
@@ -731,7 +736,7 @@ impl<'a> JsonEditorModal<'a> {
 
             let status_line = Line::from(spans);
 
-            let status = Paragraph::new(status_line).style(selected_row_style());
+            let status = Paragraph::new(status_line).style(strip_style);
 
             frame.render_widget(status, status_area);
         }
@@ -741,10 +746,11 @@ impl<'a> JsonEditorModal<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ui::style::assert_selected_bg_has_visible_fg;
+    use crate::ui::style::assert_nonblank_cells_have_explicit_fg;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
     use std::time::{Duration, Instant};
+    use tui_syntax::themes;
 
     #[test]
     fn test_json_editor_with_valid_json() {
@@ -754,6 +760,7 @@ mod tests {
             "jsonb".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
         assert!(editor.is_valid_json);
         // JSON content should be detected as JSON type
@@ -769,15 +776,16 @@ mod tests {
             "jsonb".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
         let backend = TestBackend::new(100, 30);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|frame| editor.render(frame, frame.area()))
+            .draw(|frame| editor.render(frame, frame.area(), &UiTheme::fallback()))
             .unwrap();
 
-        assert_selected_bg_has_visible_fg(terminal.backend().buffer());
+        assert_nonblank_cells_have_explicit_fg(terminal.backend().buffer());
     }
 
     #[test]
@@ -788,6 +796,7 @@ mod tests {
             "jsonb".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
         editor.command_active = true;
         editor.command_buffer = "format".to_string();
@@ -796,10 +805,10 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|frame| editor.render(frame, frame.area()))
+            .draw(|frame| editor.render(frame, frame.area(), &UiTheme::fallback()))
             .unwrap();
 
-        assert_selected_bg_has_visible_fg(terminal.backend().buffer());
+        assert_nonblank_cells_have_explicit_fg(terminal.backend().buffer());
     }
 
     #[test]
@@ -810,6 +819,7 @@ mod tests {
             "text".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
         assert!(!editor.is_valid_json);
         // Plain text should be detected as Plain type
@@ -827,6 +837,7 @@ mod tests {
             "text".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
         assert!(!editor.is_valid_json);
         let content_type = detect_content_type(&editor.content());
@@ -850,6 +861,7 @@ mod tests {
             "text".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
         let creation_time = start.elapsed();
 
@@ -878,6 +890,7 @@ mod tests {
             "jsonb".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         // Content should be formatted (pretty-printed)
@@ -894,6 +907,7 @@ mod tests {
             "jsonb".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
         assert_eq!(editor.mode, VimMode::Normal);
     }
@@ -908,6 +922,7 @@ mod tests {
             "jsonb".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         // Press ':' to enter command mode
@@ -948,6 +963,7 @@ mod tests {
             "jsonb".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         // Press ':' to enter command mode
@@ -980,6 +996,7 @@ mod tests {
             "jsonb".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         // For formatted JSON, content equals original so not modified
@@ -1006,6 +1023,7 @@ mod tests {
             "jsonb".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         // After formatting, content differs from the input
@@ -1030,6 +1048,7 @@ mod tests {
             "text".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         assert_eq!(editor.content(), plain);
@@ -1052,6 +1071,7 @@ mod tests {
             "text".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         // Press Esc in Normal mode with no changes
@@ -1074,6 +1094,7 @@ mod tests {
             "text".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         // Should start unmodified
@@ -1122,6 +1143,7 @@ mod tests {
             "text".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         // Press 'q' in Normal mode
@@ -1144,6 +1166,7 @@ mod tests {
             "text".to_string(),
             0,
             0,
+            themes::one_dark(),
         );
 
         // Should start unmodified

--- a/crates/tsql/src/ui/key_hint_popup.rs
+++ b/crates/tsql/src/ui/key_hint_popup.rs
@@ -5,14 +5,15 @@
 
 use ratatui::{
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Clear, Paragraph},
     Frame,
 };
 use unicode_width::UnicodeWidthStr;
 
 use super::key_sequence::PendingKey;
+use super::{overlay_block, UiTheme};
 
 /// A single hint entry showing a key and its description.
 #[derive(Debug, Clone)]
@@ -129,7 +130,7 @@ impl KeyHintPopup {
     }
 
     /// Renders the popup to the frame.
-    pub fn render(&self, frame: &mut Frame, frame_area: Rect) {
+    pub fn render(&self, frame: &mut Frame, frame_area: Rect, theme: &UiTheme) {
         let area = self.popup_area(frame_area);
 
         // Clear the background
@@ -144,28 +145,17 @@ impl KeyHintPopup {
                     Span::styled(
                         format!(" {}", hint.key),
                         Style::default()
-                            .fg(Color::Yellow)
+                            .fg(theme.warning)
                             .add_modifier(Modifier::BOLD),
                     ),
                     Span::raw("  "),
-                    Span::styled(hint.description, Style::default().fg(Color::Gray)),
+                    Span::styled(hint.description, Style::default().fg(theme.text_muted)),
                     Span::raw(" "),
                 ])
             })
             .collect();
 
-        // Create the paragraph with a titled border
-        let title = format!(" {} ", self.title_char());
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::DarkGray))
-            .title(Span::styled(
-                title,
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ));
-
+        let block = overlay_block(&self.title_char().to_string(), theme);
         let paragraph = Paragraph::new(lines).block(block);
 
         frame.render_widget(paragraph, area);

--- a/crates/tsql/src/ui/mod.rs
+++ b/crates/tsql/src/ui/mod.rs
@@ -1,3 +1,4 @@
+mod action_palette;
 mod ai_query_modal;
 mod completion;
 mod confirm_prompt;
@@ -20,6 +21,7 @@ mod status_line;
 mod style;
 mod theme;
 
+pub use action_palette::{action_entries, ActionContext, ActionEntry, PaletteAction};
 pub use ai_query_modal::{AiQueryModal, AiQueryModalAction};
 pub use completion::{
     determine_context, get_word_before_cursor, ColumnInfo, CompletionContext, CompletionItem,

--- a/crates/tsql/src/ui/mod.rs
+++ b/crates/tsql/src/ui/mod.rs
@@ -32,7 +32,7 @@ pub use editor::{CommandPrompt, QueryEditor, SearchPrompt};
 pub use fuzzy_picker::{FilteredItem, FuzzyPicker, PickerAction};
 pub use grid::{
     escape_sql_value, quote_identifier, DataGrid, GridKeyResult, GridModel, GridSearch, GridState,
-    ResizeAction,
+    GridViewport, ResizeAction,
 };
 pub use help_popup::{HelpAction, HelpPopup};
 pub use highlighted_editor::{create_sql_highlighter, CursorShape, HighlightedTextArea};

--- a/crates/tsql/src/ui/mod.rs
+++ b/crates/tsql/src/ui/mod.rs
@@ -46,4 +46,6 @@ pub use password_prompt::{PasswordPrompt, PasswordPromptResult};
 pub use row_detail::{RowDetailAction, RowDetailModal, YankFormat};
 pub use sidebar::{Sidebar, SidebarAction};
 pub use status_line::{ConnectionInfo, Priority, StatusLineBuilder, StatusSegment};
-pub use theme::{load_theme, zone_block, zone_inner, zone_label, zone_scrollbar_area, UiTheme};
+pub use theme::{
+    load_theme, overlay_block, zone_block, zone_inner, zone_label, zone_scrollbar_area, UiTheme,
+};

--- a/crates/tsql/src/ui/mod.rs
+++ b/crates/tsql/src/ui/mod.rs
@@ -18,6 +18,7 @@ mod row_detail;
 pub mod sidebar;
 mod status_line;
 mod style;
+mod theme;
 
 pub use ai_query_modal::{AiQueryModal, AiQueryModalAction};
 pub use completion::{
@@ -45,3 +46,4 @@ pub use password_prompt::{PasswordPrompt, PasswordPromptResult};
 pub use row_detail::{RowDetailAction, RowDetailModal, YankFormat};
 pub use sidebar::{Sidebar, SidebarAction};
 pub use status_line::{ConnectionInfo, Priority, StatusLineBuilder, StatusSegment};
+pub use theme::{load_theme, zone_block, zone_inner, zone_label, zone_scrollbar_area, UiTheme};

--- a/crates/tsql/src/ui/password_prompt.rs
+++ b/crates/tsql/src/ui/password_prompt.rs
@@ -8,11 +8,12 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
+use ratatui::widgets::{Clear, Paragraph};
 use ratatui::Frame;
 
+use super::{overlay_block, UiTheme};
 use crate::config::ConnectionEntry;
 
 /// Result of handling input in the password prompt.
@@ -69,7 +70,7 @@ impl PasswordPrompt {
     }
 
     /// Render the password prompt dialog.
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         // Calculate centered dialog size
         let dialog_width = 50u16.min(area.width.saturating_sub(4));
         let dialog_height = 7u16;
@@ -82,13 +83,7 @@ impl PasswordPrompt {
         // Clear the area behind the dialog
         frame.render_widget(Clear, dialog_area);
 
-        // Create the dialog block
-        let title = format!(" Password for {} ", self.entry.name);
-        let block = Block::default()
-            .title(title)
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Color::Cyan));
+        let block = overlay_block(&format!("Password for {}", self.entry.name), theme);
 
         let inner = block.inner(dialog_area);
         frame.render_widget(block, dialog_area);
@@ -109,7 +104,7 @@ impl PasswordPrompt {
             self.entry.user, self.entry.host, self.entry.port, self.entry.database
         );
         let info_paragraph = Paragraph::new(info)
-            .style(Style::default().fg(Color::Gray))
+            .style(Style::default().fg(theme.text_muted))
             .alignment(ratatui::layout::Alignment::Center);
         frame.render_widget(info_paragraph, chunks[0]);
 
@@ -119,8 +114,8 @@ impl PasswordPrompt {
         let display = format!("{}{}", masked, cursor);
 
         let password_line = Line::from(vec![
-            Span::styled("Password: ", Style::default().fg(Color::White)),
-            Span::styled(display, Style::default().fg(Color::Yellow)),
+            Span::styled("Password: ", Style::default().fg(theme.text)),
+            Span::styled(display, Style::default().fg(theme.warning)),
         ]);
         let password_paragraph = Paragraph::new(password_line);
         frame.render_widget(password_paragraph, chunks[2]);
@@ -130,13 +125,15 @@ impl PasswordPrompt {
             Span::styled(
                 "Enter",
                 Style::default()
-                    .fg(Color::Green)
+                    .fg(theme.success)
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw(" submit  "),
             Span::styled(
                 "Esc",
-                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme.error)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::raw(" cancel"),
         ]);

--- a/crates/tsql/src/ui/row_detail.rs
+++ b/crates/tsql/src/ui/row_detail.rs
@@ -71,6 +71,8 @@ pub struct RowDetailModal {
     highlighter: Highlighter,
     /// True when `y` has been pressed and we are waiting for the format key.
     pending_yank: bool,
+    /// Whether the source result can be edited.
+    read_only: bool,
 }
 
 impl RowDetailModal {
@@ -100,7 +102,14 @@ impl RowDetailModal {
             visible_height: 10,
             highlighter,
             pending_yank: false,
+            read_only: false,
         }
+    }
+
+    /// Mark this row detail view as read-only.
+    pub fn with_read_only(mut self) -> Self {
+        self.read_only = true;
+        self
     }
 
     /// Get the currently selected column index.
@@ -481,8 +490,18 @@ impl RowDetailModal {
         let footer = Line::from(vec![
             Span::styled(" j/k ", Style::default().fg(theme.warning)),
             Span::styled("navigate  ", Style::default().fg(theme.text_muted)),
-            Span::styled("e/Enter ", Style::default().fg(theme.warning)),
-            Span::styled("edit  ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                if self.read_only {
+                    "read-only  "
+                } else {
+                    "e/Enter "
+                },
+                Style::default().fg(theme.warning),
+            ),
+            Span::styled(
+                if self.read_only { "" } else { "edit  " },
+                Style::default().fg(theme.text_muted),
+            ),
             Span::styled("y… ", Style::default().fg(theme.warning)),
             Span::styled("yank  ", Style::default().fg(theme.text_muted)),
             Span::styled("g/G ", Style::default().fg(theme.warning)),
@@ -591,6 +610,28 @@ mod tests {
             .unwrap();
 
         assert_nonblank_cells_have_explicit_fg(terminal.backend().buffer());
+    }
+
+    #[test]
+    fn test_read_only_footer_hides_edit_hint() {
+        let mut modal = create_test_modal().with_read_only();
+        let theme = UiTheme::fallback();
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| modal.render(frame, frame.area(), &theme))
+            .unwrap();
+        let text = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(text.contains("read-only"));
+        assert!(!text.contains("e/Enter edit"));
     }
 
     #[test]

--- a/crates/tsql/src/ui/row_detail.rs
+++ b/crates/tsql/src/ui/row_detail.rs
@@ -8,18 +8,16 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{
-    Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-};
+use ratatui::widgets::{Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState};
 use ratatui::Frame;
 
-use tui_syntax::{html, json, themes, Highlighter};
+use tui_syntax::{html, json, Highlighter, Theme};
 
 use crate::util::{detect_content_type, ContentType};
 
-use super::style::{on_selected_bg, selected_muted_style, selected_row_style};
+use super::{overlay_block, UiTheme};
 
 /// Format to use when yanking from the row detail view.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,11 +80,12 @@ impl RowDetailModal {
         values: Vec<String>,
         col_types: Vec<String>,
         row_index: usize,
+        syntax_theme: Theme,
     ) -> Self {
         let field_count = headers.len();
 
         // Create highlighter with JSON and HTML support
-        let mut highlighter = Highlighter::new(themes::one_dark());
+        let mut highlighter = Highlighter::new(syntax_theme);
         let _ = highlighter.register_language(json());
         let _ = highlighter.register_language(html());
 
@@ -260,7 +259,7 @@ impl RowDetailModal {
     }
 
     /// Render the row detail modal.
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         // Calculate modal size (80% of screen)
         let modal_width = (area.width as f32 * 0.85) as u16;
         let modal_height = (area.height as f32 * 0.85) as u16;
@@ -279,20 +278,12 @@ impl RowDetailModal {
 
         // Build title
         let title = format!(
-            " Row {} Details ({} columns) ",
+            "Row {} Details ({} columns)",
             self.row_index + 1,
             self.field_count
         );
 
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title(title)
-            .title_style(
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .border_style(Style::default().fg(Color::Cyan));
+        let block = overlay_block(&title, theme);
 
         let inner = block.inner(modal_area);
         frame.render_widget(block, modal_area);
@@ -311,18 +302,27 @@ impl RowDetailModal {
         self.visible_height = content_area.height as usize;
 
         // Render content with scrolling
-        self.render_content(frame, content_area);
+        self.render_content(frame, content_area, theme);
 
         // Render footer with navigation hints
-        self.render_footer(frame, footer_area);
+        self.render_footer(frame, footer_area, theme);
 
         // Render scrollbar if content overflows
         if self.field_count > self.visible_height / 3 {
-            self.render_scrollbar(frame, content_area);
+            self.render_scrollbar(frame, content_area, theme);
         }
     }
 
-    fn render_content(&mut self, frame: &mut Frame, area: Rect) {
+    fn render_content(&mut self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
+        // Selected-value spans keep their syntax fg but sit on the selection bg.
+        let on_selection_bg = |style: Style| -> Style {
+            let mut style = style.bg(theme.selection.bg.unwrap_or_default());
+            if style.fg.is_none() {
+                style.fg = theme.selection.fg;
+            }
+            style
+        };
+
         let mut lines: Vec<Line> = Vec::new();
 
         // Calculate which fields to show based on scroll offset
@@ -346,11 +346,11 @@ impl RowDetailModal {
             // Field header line with type info
             let header_style = if is_selected {
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme.accent)
                     .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
             } else {
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(theme.warning)
                     .add_modifier(Modifier::BOLD)
             };
 
@@ -363,15 +363,15 @@ impl RowDetailModal {
             let selector = if is_selected { "> " } else { "  " };
 
             lines.push(Line::from(vec![
-                Span::styled(selector, Style::default().fg(Color::Cyan)),
+                Span::styled(selector, Style::default().fg(theme.accent)),
                 Span::styled(header, header_style),
-                Span::styled(type_info, Style::default().fg(Color::DarkGray)),
+                Span::styled(type_info, Style::default().fg(theme.text_muted)),
             ]));
 
             // Value line(s) with syntax highlighting
             let content_type = detect_content_type(&value);
             let value_style = if is_selected {
-                selected_row_style()
+                theme.selection
             } else {
                 Style::default()
             };
@@ -389,9 +389,9 @@ impl RowDetailModal {
                     value.clone()
                 };
                 let display_style = if is_selected {
-                    selected_muted_style()
+                    theme.selection
                 } else {
-                    value_style.fg(Color::DarkGray)
+                    value_style.fg(theme.text_muted)
                 };
                 lines.push(Line::from(vec![
                     Span::styled("    ", value_style),
@@ -405,7 +405,7 @@ impl RowDetailModal {
                 let mut spans = vec![Span::styled("    ", value_style)];
                 for span in highlighted {
                     spans.push(if is_selected {
-                        Span::styled(span.content.to_string(), on_selected_bg(span.style))
+                        Span::styled(span.content.to_string(), on_selection_bg(span.style))
                     } else {
                         span
                     });
@@ -422,7 +422,7 @@ impl RowDetailModal {
                     let mut spans = vec![Span::styled("    ", value_style)];
                     for span in highlighted {
                         spans.push(if is_selected {
-                            Span::styled(span.content.to_string(), on_selected_bg(span.style))
+                            Span::styled(span.content.to_string(), on_selection_bg(span.style))
                         } else {
                             span
                         });
@@ -436,9 +436,9 @@ impl RowDetailModal {
                             Span::styled(
                                 format!("... ({} more lines)", value_lines_count - max_lines),
                                 if is_selected {
-                                    selected_muted_style()
+                                    theme.selection
                                 } else {
-                                    Style::default().fg(Color::DarkGray)
+                                    Style::default().fg(theme.text_muted)
                                 },
                             ),
                         ]));
@@ -477,33 +477,34 @@ impl RowDetailModal {
         vec![Span::raw(value.to_string())]
     }
 
-    fn render_footer(&self, frame: &mut Frame, area: Rect) {
+    fn render_footer(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let footer = Line::from(vec![
-            Span::styled(" j/k ", Style::default().fg(Color::Yellow)),
-            Span::styled("navigate  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("e/Enter ", Style::default().fg(Color::Yellow)),
-            Span::styled("edit  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("y… ", Style::default().fg(Color::Yellow)),
-            Span::styled("yank  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("g/G ", Style::default().fg(Color::Yellow)),
-            Span::styled("top/bottom  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("q/Esc ", Style::default().fg(Color::Yellow)),
-            Span::styled("close  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(" j/k ", Style::default().fg(theme.warning)),
+            Span::styled("navigate  ", Style::default().fg(theme.text_muted)),
+            Span::styled("e/Enter ", Style::default().fg(theme.warning)),
+            Span::styled("edit  ", Style::default().fg(theme.text_muted)),
+            Span::styled("y… ", Style::default().fg(theme.warning)),
+            Span::styled("yank  ", Style::default().fg(theme.text_muted)),
+            Span::styled("g/G ", Style::default().fg(theme.warning)),
+            Span::styled("top/bottom  ", Style::default().fg(theme.text_muted)),
+            Span::styled("q/Esc ", Style::default().fg(theme.warning)),
+            Span::styled("close  ", Style::default().fg(theme.text_muted)),
             Span::raw(" ".repeat(area.width.saturating_sub(80) as usize)),
             Span::styled(
                 format!("{}/{}", self.selected_field + 1, self.field_count),
-                Style::default().fg(Color::Cyan),
+                Style::default().fg(theme.accent),
             ),
         ]);
         frame.render_widget(Paragraph::new(footer), area);
     }
 
-    fn render_scrollbar(&self, frame: &mut Frame, area: Rect) {
+    fn render_scrollbar(&self, frame: &mut Frame, area: Rect, theme: &UiTheme) {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼"))
             .track_symbol(Some("│"))
-            .thumb_symbol("█");
+            .thumb_symbol("█")
+            .style(theme.scrollbar);
 
         let mut scrollbar_state =
             ScrollbarState::new(self.field_count).position(self.selected_field);
@@ -536,9 +537,10 @@ fn truncate_for_display(s: &str, max_width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ui::style::assert_selected_bg_has_visible_fg;
+    use crate::ui::style::assert_nonblank_cells_have_explicit_fg;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
+    use tui_syntax::themes;
 
     fn create_test_modal() -> RowDetailModal {
         RowDetailModal::new(
@@ -550,6 +552,7 @@ mod tests {
             ],
             vec!["int4".to_string(), "text".to_string(), "jsonb".to_string()],
             0,
+            themes::one_dark(),
         )
     }
 
@@ -562,30 +565,32 @@ mod tests {
     }
 
     #[test]
-    fn test_selected_plain_value_uses_visible_foreground_on_dark_background() {
+    fn test_selected_plain_value_uses_visible_foreground_on_overlay_surface() {
         let mut modal = create_test_modal();
+        let theme = UiTheme::fallback();
         let backend = TestBackend::new(100, 30);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|frame| modal.render(frame, frame.area()))
+            .draw(|frame| modal.render(frame, frame.area(), &theme))
             .unwrap();
 
-        assert_selected_bg_has_visible_fg(terminal.backend().buffer());
+        assert_nonblank_cells_have_explicit_fg(terminal.backend().buffer());
     }
 
     #[test]
-    fn test_selected_highlighted_value_uses_visible_foreground_on_dark_background() {
+    fn test_selected_highlighted_value_uses_visible_foreground_on_overlay_surface() {
         let mut modal = create_test_modal();
         modal.selected_field = 2;
+        let theme = UiTheme::fallback();
         let backend = TestBackend::new(100, 30);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|frame| modal.render(frame, frame.area()))
+            .draw(|frame| modal.render(frame, frame.area(), &theme))
             .unwrap();
 
-        assert_selected_bg_has_visible_fg(terminal.backend().buffer());
+        assert_nonblank_cells_have_explicit_fg(terminal.backend().buffer());
     }
 
     #[test]

--- a/crates/tsql/src/ui/sidebar.rs
+++ b/crates/tsql/src/ui/sidebar.rs
@@ -76,8 +76,17 @@ impl Sidebar {
         has_focus: bool,
         theme: &UiTheme,
     ) {
+        // Size connections to its content (label row + one row per entry,
+        // or the empty-state hint), capped so schema keeps most of the space.
+        let connection_count = connections.sorted().len();
+        let connections_height = if connection_count == 0 {
+            6
+        } else {
+            connection_count as u16 + 1
+        };
+        let connections_cap = (area.height * 2 / 5).max(3);
         let chunks = Layout::vertical([
-            Constraint::Percentage(30),
+            Constraint::Length(connections_height.min(connections_cap)),
             Constraint::Length(1),
             Constraint::Min(0),
         ])
@@ -120,15 +129,22 @@ impl Sidebar {
         focused: bool,
         theme: &UiTheme,
     ) {
+        let sorted = connections.sorted();
+        let details = if sorted.is_empty() {
+            Vec::new()
+        } else {
+            vec![Span::styled(
+                format!(" · {}", sorted.len()),
+                theme.text_muted,
+            )]
+        };
         let block = zone_block(
-            zone_label("CONNECTIONS", Vec::new(), focused, theme.accent, theme),
+            zone_label("CONNECTIONS", details, focused, theme.accent, theme),
             theme.bg_panel,
             theme.text,
             focused,
             theme.accent,
         );
-
-        let sorted = connections.sorted();
         if sorted.is_empty() {
             let empty = Paragraph::new(vec![
                 Line::from(""),
@@ -199,8 +215,17 @@ impl Sidebar {
         focused: bool,
         theme: &UiTheme,
     ) {
+        let table_count: usize = schema_items.iter().map(|item| item.children().len()).sum();
+        let details = if table_count == 0 {
+            Vec::new()
+        } else {
+            vec![Span::styled(
+                format!(" · {table_count} tables"),
+                theme.text_muted,
+            )]
+        };
         let block = zone_block(
-            zone_label("SCHEMA", Vec::new(), focused, theme.accent, theme),
+            zone_label("SCHEMA", details, focused, theme.accent, theme),
             theme.bg_panel,
             theme.text,
             focused,

--- a/crates/tsql/src/ui/sidebar.rs
+++ b/crates/tsql/src/ui/sidebar.rs
@@ -2,13 +2,14 @@
 
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph, Wrap};
 use ratatui::Frame;
 use tui_tree_widget::{Tree, TreeItem, TreeState};
 
 use super::mouse_util::{is_inside, MOUSE_SCROLL_LINES};
+use super::{zone_block, zone_label, UiTheme};
 use crate::app::SidebarSection;
 use crate::config::{ConnectionEntry, ConnectionsFile};
 
@@ -73,14 +74,23 @@ impl Sidebar {
         schema_error: Option<&str>,
         focused_section: SidebarSection,
         has_focus: bool,
+        theme: &UiTheme,
     ) {
-        // Split sidebar into connections (30%) and schema (70%)
-        let chunks =
-            Layout::vertical([Constraint::Percentage(30), Constraint::Percentage(70)]).split(area);
+        let chunks = Layout::vertical([
+            Constraint::Percentage(30),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ])
+        .split(area);
 
         // Store areas for mouse hit testing
         self.connections_area = Some(chunks[0]);
-        self.schema_area = Some(chunks[1]);
+        self.schema_area = Some(chunks[2]);
+
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().fg(theme.text).bg(theme.bg_panel)),
+            chunks[1],
+        );
 
         self.render_connections(
             frame,
@@ -88,14 +98,16 @@ impl Sidebar {
             connections,
             current_connection,
             has_focus && focused_section == SidebarSection::Connections,
+            theme,
         );
         self.render_schema(
             frame,
-            chunks[1],
+            chunks[2],
             schema_items,
             schema_loading,
             schema_error,
             has_focus && focused_section == SidebarSection::Schema,
+            theme,
         );
     }
 
@@ -106,29 +118,15 @@ impl Sidebar {
         connections: &ConnectionsFile,
         current: Option<&str>,
         focused: bool,
+        theme: &UiTheme,
     ) {
-        let border_style = if focused {
-            Style::default().fg(Color::Cyan)
-        } else {
-            Style::default().fg(Color::DarkGray)
-        };
-
-        let title = if focused {
-            " ● Connections "
-        } else {
-            " Connections "
-        };
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title(title)
-            .title_style(if focused {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(Color::DarkGray)
-            })
-            .border_style(border_style);
+        let block = zone_block(
+            zone_label("CONNECTIONS", Vec::new(), focused, theme.accent, theme),
+            theme.bg_panel,
+            theme.text,
+            focused,
+            theme.accent,
+        );
 
         let sorted = connections.sorted();
         if sorted.is_empty() {
@@ -141,11 +139,11 @@ impl Sidebar {
                 Line::from(""),
                 Line::from(vec![
                     Span::raw("Press "),
-                    Span::styled("a", Style::default().fg(Color::Yellow)),
+                    Span::styled("a", Style::default().fg(theme.warning)),
                     Span::raw(" to add one, or"),
                 ]),
                 Line::from(vec![
-                    Span::styled("Ctrl+Shift+C", Style::default().fg(Color::Yellow)),
+                    Span::styled("Ctrl+Shift+C", Style::default().fg(theme.warning)),
                     Span::raw(" for the full manager."),
                 ]),
             ])
@@ -163,7 +161,7 @@ impl Sidebar {
 
                 let style = if is_current {
                     Style::default()
-                        .fg(Color::Green)
+                        .fg(theme.success)
                         .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default()
@@ -177,9 +175,9 @@ impl Sidebar {
             .collect();
 
         let highlight_style = if focused {
-            Style::default().bg(Color::DarkGray).fg(Color::White)
+            theme.selection
         } else {
-            Style::default().fg(Color::Yellow)
+            Style::default().fg(theme.accent)
         };
 
         let list = List::new(items)
@@ -190,6 +188,7 @@ impl Sidebar {
         frame.render_stateful_widget(list, area, &mut self.connections_state);
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_schema(
         &mut self,
         frame: &mut Frame,
@@ -198,31 +197,21 @@ impl Sidebar {
         loading: bool,
         error: Option<&str>,
         focused: bool,
+        theme: &UiTheme,
     ) {
-        let border_style = if focused {
-            Style::default().fg(Color::Cyan)
-        } else {
-            Style::default().fg(Color::DarkGray)
-        };
-
-        let title = if focused { " ● Schema " } else { " Schema " };
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title(title)
-            .title_style(if focused {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(Color::DarkGray)
-            })
-            .border_style(border_style);
+        let block = zone_block(
+            zone_label("SCHEMA", Vec::new(), focused, theme.accent, theme),
+            theme.bg_panel,
+            theme.text,
+            focused,
+            theme.accent,
+        );
 
         // Handle loading state
         if loading {
             let loading_text = Paragraph::new("Loading schema...")
                 .block(block)
-                .style(Style::default().fg(Color::Yellow));
+                .style(Style::default().fg(theme.warning));
             frame.render_widget(loading_text, area);
             return;
         }
@@ -231,7 +220,7 @@ impl Sidebar {
         if let Some(err) = error {
             let error_text = Paragraph::new(format!("Error: {}\nPress 'r' to retry", err))
                 .block(block)
-                .style(Style::default().fg(Color::Red));
+                .style(Style::default().fg(theme.error));
             frame.render_widget(error_text, area);
             return;
         }
@@ -240,15 +229,15 @@ impl Sidebar {
         if schema_items.is_empty() {
             let empty = Paragraph::new("Connect to view schema")
                 .block(block)
-                .style(Style::default().fg(Color::DarkGray));
+                .style(Style::default().fg(theme.text_muted));
             frame.render_widget(empty, area);
             return;
         }
 
         let highlight_style = if focused {
-            Style::default().bg(Color::DarkGray).fg(Color::White)
+            theme.selection
         } else {
-            Style::default().fg(Color::Yellow)
+            Style::default().fg(theme.accent)
         };
 
         match Tree::new(schema_items) {
@@ -263,7 +252,7 @@ impl Sidebar {
                 let err =
                     Paragraph::new(format!("Schema tree build failed: {}\n(retry with `r`)", e))
                         .block(block)
-                        .style(Style::default().fg(Color::Red));
+                        .style(Style::default().fg(theme.error));
                 frame.render_widget(err, area);
             }
         }
@@ -509,5 +498,65 @@ impl Sidebar {
         for path in paths {
             self.schema_state.open(path.clone());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    use super::*;
+
+    #[test]
+    fn render_uses_stable_zones_and_excludes_spacer_from_hit_areas() {
+        let backend = TestBackend::new(32, 18);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut sidebar = Sidebar::new();
+        let connections = ConnectionsFile::new();
+        let theme = UiTheme::fallback();
+
+        terminal
+            .draw(|frame| {
+                sidebar.render(
+                    frame,
+                    frame.area(),
+                    &connections,
+                    None,
+                    &[],
+                    false,
+                    None,
+                    SidebarSection::Connections,
+                    true,
+                    &theme,
+                );
+            })
+            .unwrap();
+
+        let connections_area = sidebar.connections_area.unwrap();
+        let schema_area = sidebar.schema_area.unwrap();
+        let spacer_y = connections_area.bottom();
+        let buffer = terminal.backend().buffer();
+
+        let first_row = row_text(buffer, 0);
+        assert!(first_row.contains("CONNECTIONS"));
+        assert!(row_text(buffer, schema_area.y).contains("SCHEMA"));
+        assert_eq!(
+            buffer.cell((0, connections_area.y + 1)).unwrap().fg,
+            theme.accent
+        );
+        assert_eq!(
+            buffer.cell((0, schema_area.y + 1)).unwrap().fg,
+            theme.bg_panel
+        );
+        assert_eq!(buffer.cell((5, spacer_y)).unwrap().bg, theme.bg_panel);
+        assert!(!sidebar.is_over_connections(5, spacer_y));
+        assert!(!sidebar.is_over_schema(5, spacer_y));
+    }
+
+    fn row_text(buffer: &ratatui::buffer::Buffer, y: u16) -> String {
+        (buffer.area.x..buffer.area.right())
+            .map(|x| buffer.cell((x, y)).unwrap().symbol())
+            .collect()
     }
 }

--- a/crates/tsql/src/ui/sidebar.rs
+++ b/crates/tsql/src/ui/sidebar.rs
@@ -250,9 +250,9 @@ impl Sidebar {
             return;
         }
 
-        // Handle empty/not connected state
+        // Handle an empty cache (either disconnected or a database with no visible relations).
         if schema_items.is_empty() {
-            let empty = Paragraph::new("Connect to view schema")
+            let empty = Paragraph::new("No schema items · r refresh")
                 .block(block)
                 .style(Style::default().fg(theme.text_muted));
             frame.render_widget(empty, area);
@@ -566,6 +566,7 @@ mod tests {
         let first_row = row_text(buffer, 0);
         assert!(first_row.contains("CONNECTIONS"));
         assert!(row_text(buffer, schema_area.y).contains("SCHEMA"));
+        assert!(row_text(buffer, schema_area.y + 1).contains("No schema items"));
         assert_eq!(
             buffer.cell((0, connections_area.y + 1)).unwrap().fg,
             theme.accent

--- a/crates/tsql/src/ui/sidebar.rs
+++ b/crates/tsql/src/ui/sidebar.rs
@@ -70,6 +70,7 @@ impl Sidebar {
         connections: &ConnectionsFile,
         current_connection: Option<&str>,
         schema_items: &[TreeItem<'static, String>],
+        schema_connected: bool,
         schema_loading: bool,
         schema_error: Option<&str>,
         focused_section: SidebarSection,
@@ -113,6 +114,7 @@ impl Sidebar {
             frame,
             chunks[2],
             schema_items,
+            schema_connected,
             schema_loading,
             schema_error,
             has_focus && focused_section == SidebarSection::Schema,
@@ -210,6 +212,7 @@ impl Sidebar {
         frame: &mut Frame,
         area: Rect,
         schema_items: &[TreeItem<'static, String>],
+        connected: bool,
         loading: bool,
         error: Option<&str>,
         focused: bool,
@@ -250,9 +253,14 @@ impl Sidebar {
             return;
         }
 
-        // Handle an empty cache (either disconnected or a database with no visible relations).
+        // Distinguish a disconnected workspace from a connected database with no relations.
         if schema_items.is_empty() {
-            let empty = Paragraph::new("No schema items · r refresh")
+            let message = if connected {
+                "No schema items · r refresh"
+            } else {
+                "Connect to view schema"
+            };
+            let empty = Paragraph::new(message)
                 .block(block)
                 .style(Style::default().fg(theme.text_muted));
             frame.render_widget(empty, area);
@@ -549,6 +557,7 @@ mod tests {
                     &connections,
                     None,
                     &[],
+                    true,
                     false,
                     None,
                     SidebarSection::Connections,
@@ -578,6 +587,37 @@ mod tests {
         assert_eq!(buffer.cell((5, spacer_y)).unwrap().bg, theme.bg_panel);
         assert!(!sidebar.is_over_connections(5, spacer_y));
         assert!(!sidebar.is_over_schema(5, spacer_y));
+    }
+
+    #[test]
+    fn disconnected_schema_prompts_for_connection() {
+        let backend = TestBackend::new(32, 18);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut sidebar = Sidebar::new();
+        let connections = ConnectionsFile::new();
+        let theme = UiTheme::fallback();
+
+        terminal
+            .draw(|frame| {
+                sidebar.render(
+                    frame,
+                    frame.area(),
+                    &connections,
+                    None,
+                    &[],
+                    false,
+                    false,
+                    None,
+                    SidebarSection::Schema,
+                    true,
+                    &theme,
+                );
+            })
+            .unwrap();
+
+        let schema_area = sidebar.schema_area.unwrap();
+        assert!(row_text(terminal.backend().buffer(), schema_area.y + 1)
+            .contains("Connect to view schema"));
     }
 
     fn row_text(buffer: &ratatui::buffer::Buffer, y: u16) -> String {

--- a/crates/tsql/src/ui/status_line.rs
+++ b/crates/tsql/src/ui/status_line.rs
@@ -276,6 +276,11 @@ impl StatusLineBuilder {
         self
     }
 
+    pub fn separator_style(mut self, style: Style) -> Self {
+        self.separator_style = style;
+        self
+    }
+
     pub fn segment(mut self, segment: StatusSegment) -> Self {
         self.segments.push(segment);
         self
@@ -541,5 +546,22 @@ mod tests {
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("ALWAYS"));
         assert!(!text.contains("WIDE_ONLY")); // min_width not met
+    }
+
+    #[test]
+    fn test_status_line_builder_applies_separator_style() {
+        let separator_style = Style::default().fg(Color::LightBlue);
+        let line = StatusLineBuilder::new()
+            .separator_style(separator_style)
+            .segment(StatusSegment::new("LEFT", Priority::Critical))
+            .segment(StatusSegment::new("RIGHT", Priority::Critical))
+            .build(30);
+
+        let separator = line
+            .spans
+            .iter()
+            .find(|span| span.content.contains('│'))
+            .unwrap();
+        assert_eq!(separator.style, separator_style);
     }
 }

--- a/crates/tsql/src/ui/style.rs
+++ b/crates/tsql/src/ui/style.rs
@@ -62,3 +62,19 @@ pub(crate) fn assert_selected_bg_has_visible_fg(buf: &Buffer) {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) fn assert_nonblank_cells_have_explicit_fg(buf: &Buffer) {
+    for y in buf.area.y..buf.area.y.saturating_add(buf.area.height) {
+        for x in buf.area.x..buf.area.x.saturating_add(buf.area.width) {
+            let cell = buf.cell((x, y)).expect("cell in buffer");
+            if !cell.symbol().trim().is_empty() {
+                assert_ne!(
+                    cell.fg,
+                    Color::Reset,
+                    "nonblank cell at ({x}, {y}) has reset foreground"
+                );
+            }
+        }
+    }
+}

--- a/crates/tsql/src/ui/style.rs
+++ b/crates/tsql/src/ui/style.rs
@@ -1,68 +1,18 @@
-use ratatui::style::{Color, Style};
-use ratatui::text::Line;
+//! Shared style test helpers.
+//!
+//! Runtime styling lives in [`super::theme`]; the helpers here back the
+//! render tests that assert legibility invariants on painted surfaces.
 
 #[cfg(test)]
 use ratatui::buffer::Buffer;
-
-/// Shared highlighted-row background.
-pub(crate) const SELECTED_BG: Color = Color::DarkGray;
-
-/// Secondary text that remains visible on `SELECTED_BG`.
-pub(crate) const SELECTED_MUTED_FG: Color = Color::Gray;
-
-/// Primary text for selected rows.
-pub(crate) const SELECTED_PRIMARY_FG: Color = Color::White;
-
-pub(crate) fn selected_row_style() -> Style {
-    Style::default().bg(SELECTED_BG).fg(SELECTED_MUTED_FG)
-}
-
-pub(crate) fn selected_primary_style() -> Style {
-    Style::default().bg(SELECTED_BG).fg(SELECTED_PRIMARY_FG)
-}
-
-pub(crate) fn selected_muted_style() -> Style {
-    Style::default().bg(SELECTED_BG).fg(SELECTED_MUTED_FG)
-}
-
-pub(crate) fn on_selected_bg(style: Style) -> Style {
-    let style = style.bg(SELECTED_BG);
-    if matches!(style.fg, None | Some(Color::DarkGray)) {
-        style.fg(SELECTED_MUTED_FG)
-    } else {
-        style
-    }
-}
-
-pub(crate) fn selected_line<'a>(mut line: Line<'a>) -> Line<'a> {
-    line.style = on_selected_bg(line.style);
-    for span in &mut line.spans {
-        span.style = on_selected_bg(span.style);
-    }
-    line
-}
-
 #[cfg(test)]
-pub(crate) fn assert_selected_bg_has_visible_fg(buf: &Buffer) {
-    for y in buf.area.y..buf.area.y.saturating_add(buf.area.height) {
-        for x in buf.area.x..buf.area.x.saturating_add(buf.area.width) {
-            let cell = buf.cell((x, y)).expect("cell in buffer");
-            if cell.bg == SELECTED_BG {
-                assert_ne!(
-                    cell.fg,
-                    Color::Reset,
-                    "selected-bg cell at ({x}, {y}) has reset foreground"
-                );
-                assert_ne!(
-                    cell.fg,
-                    Color::DarkGray,
-                    "selected-bg cell at ({x}, {y}) has dark gray foreground"
-                );
-            }
-        }
-    }
-}
+use ratatui::style::Color;
 
+/// Assert every non-blank cell carries an explicit foreground color.
+///
+/// On tonal-zone and overlay surfaces a `Color::Reset` foreground would fall
+/// back to the terminal default, which is not guaranteed to be legible on the
+/// painted background.
 #[cfg(test)]
 pub(crate) fn assert_nonblank_cells_have_explicit_fg(buf: &Buffer) {
     for y in buf.area.y..buf.area.y.saturating_add(buf.area.height) {

--- a/crates/tsql/src/ui/theme.rs
+++ b/crates/tsql/src/ui/theme.rs
@@ -1,0 +1,602 @@
+//! UI theme resolution and shared tonal-zone geometry.
+
+use std::path::{Component, Path};
+
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::symbols::border;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Padding};
+use tui_syntax::{themes, Theme};
+
+use crate::app::Mode;
+use crate::config::config_dir;
+
+/// Pre-resolved styles used by the application's primary UI chrome.
+#[derive(Clone, Debug, PartialEq)]
+pub struct UiTheme {
+    pub bg_base: Color,
+    pub bg_panel: Color,
+    pub bg_elevated: Color,
+    pub bg_status: Color,
+    pub text: Color,
+    pub text_muted: Color,
+    pub label: Style,
+    pub label_focused: Style,
+    pub accent: Color,
+    pub accent_insert: Color,
+    pub accent_visual: Color,
+    pub selection: Style,
+    pub cursor_cell: Style,
+    pub editor_cursor: Style,
+    pub editor_selection: Style,
+    pub search_match: Style,
+    pub search_match_current: Style,
+    pub success: Color,
+    pub warning: Color,
+    pub error: Color,
+    pub pill_fg: Color,
+    pub scrollbar: Style,
+    pub grid_header: Style,
+}
+
+impl Default for UiTheme {
+    fn default() -> Self {
+        Self::fallback()
+    }
+}
+
+impl UiTheme {
+    /// Build the canonical One Dark UI fallback.
+    pub fn fallback() -> Self {
+        let text = rgb(0xDC, 0xDF, 0xE4);
+        let text_muted = rgb(0x9D, 0xA5, 0xB4);
+        let accent = rgb(0x56, 0xB6, 0xC2);
+        let ink = rgb(0x1D, 0x20, 0x25);
+        let selection_bg = rgb(0x3E, 0x44, 0x51);
+
+        Self {
+            bg_base: rgb(0x28, 0x2C, 0x34),
+            bg_panel: rgb(0x21, 0x25, 0x2B),
+            bg_elevated: rgb(0x2C, 0x31, 0x3A),
+            bg_status: ink,
+            text,
+            text_muted,
+            label: Style::default().fg(text_muted),
+            label_focused: Style::default().fg(accent).add_modifier(Modifier::BOLD),
+            accent,
+            accent_insert: rgb(0x98, 0xC3, 0x79),
+            accent_visual: rgb(0xE5, 0xC0, 0x7B),
+            selection: Style::default().fg(text).bg(selection_bg),
+            cursor_cell: Style::default().fg(ink).bg(accent),
+            editor_cursor: Style::default().fg(ink).bg(accent),
+            editor_selection: Style::default().fg(text).bg(selection_bg),
+            search_match: Style::default().fg(ink).bg(rgb(0xE5, 0xC0, 0x7B)),
+            search_match_current: Style::default().fg(ink).bg(rgb(0xD1, 0x9A, 0x66)),
+            success: rgb(0x98, 0xC3, 0x79),
+            warning: rgb(0xE5, 0xC0, 0x7B),
+            error: rgb(0xE0, 0x6C, 0x75),
+            pill_fg: ink,
+            scrollbar: Style::default().fg(text_muted),
+            grid_header: Style::default()
+                .fg(text)
+                .bg(rgb(0x2C, 0x31, 0x3A))
+                .add_modifier(Modifier::BOLD),
+        }
+    }
+
+    /// Resolve UI chrome from a syntax theme, preserving complete fallbacks for
+    /// fields omitted by parent or child scopes.
+    pub fn from_theme(theme: &Theme) -> Self {
+        let fallback = Self::fallback();
+
+        let background = resolve_style(
+            theme,
+            "ui.background",
+            Style::default().fg(fallback.text).bg(fallback.bg_base),
+        );
+        let panel = resolve_style(
+            theme,
+            "ui.background.panel",
+            Style::default().fg(fallback.text).bg(fallback.bg_panel),
+        );
+        let elevated = resolve_style(
+            theme,
+            "ui.background.elevated",
+            Style::default().fg(fallback.text).bg(fallback.bg_elevated),
+        );
+        let statusline = resolve_style(
+            theme,
+            "ui.statusline",
+            Style::default().fg(fallback.text).bg(fallback.bg_status),
+        );
+        let text_style = resolve_style(theme, "ui.text", Style::default().fg(fallback.text));
+        let muted_style = resolve_style(
+            theme,
+            "ui.text.muted",
+            Style::default().fg(fallback.text_muted),
+        );
+
+        Self {
+            bg_base: background.bg.unwrap_or(fallback.bg_base),
+            bg_panel: panel.bg.unwrap_or(fallback.bg_panel),
+            bg_elevated: elevated.bg.unwrap_or(fallback.bg_elevated),
+            bg_status: statusline.bg.unwrap_or(fallback.bg_status),
+            text: text_style.fg.unwrap_or(fallback.text),
+            text_muted: muted_style.fg.unwrap_or(fallback.text_muted),
+            label: resolve_style(theme, "ui.label", fallback.label),
+            label_focused: resolve_style(theme, "ui.label.focused", fallback.label_focused),
+            accent: resolve_color(theme, "ui.accent", fallback.accent),
+            accent_insert: resolve_color(theme, "ui.accent.insert", fallback.accent_insert),
+            accent_visual: resolve_color(theme, "ui.accent.visual", fallback.accent_visual),
+            selection: normalize_explicit(resolve_style(theme, "ui.selection", fallback.selection)),
+            cursor_cell: normalize_explicit(resolve_style(
+                theme,
+                "ui.cursor.cell",
+                fallback.cursor_cell,
+            )),
+            editor_cursor: normalize_explicit(resolve_style(
+                theme,
+                "ui.cursor",
+                fallback.editor_cursor,
+            )),
+            editor_selection: normalize_explicit(resolve_style(
+                theme,
+                "ui.selection.editor",
+                fallback.editor_selection,
+            )),
+            search_match: normalize_explicit(resolve_style(
+                theme,
+                "ui.search.match",
+                fallback.search_match,
+            )),
+            search_match_current: normalize_explicit(resolve_style(
+                theme,
+                "ui.search.match.current",
+                fallback.search_match_current,
+            )),
+            success: resolve_color(theme, "ui.success", fallback.success),
+            warning: resolve_color(theme, "ui.warning", fallback.warning),
+            error: resolve_color(theme, "ui.error", fallback.error),
+            pill_fg: resolve_color(theme, "ui.statusline.mode", fallback.pill_fg),
+            scrollbar: resolve_style(theme, "ui.scrollbar", fallback.scrollbar),
+            grid_header: resolve_style(theme, "ui.grid.header", fallback.grid_header),
+        }
+    }
+
+    /// Return the focus accent associated with a vim mode.
+    pub fn mode_accent(&self, mode: Mode) -> Color {
+        match mode {
+            Mode::Normal => self.accent,
+            Mode::Insert => self.accent_insert,
+            Mode::Visual => self.accent_visual,
+        }
+    }
+}
+
+fn rgb(red: u8, green: u8, blue: u8) -> Color {
+    Color::Rgb(red, green, blue)
+}
+
+fn resolve_color(theme: &Theme, scope: &str, fallback: Color) -> Color {
+    resolve_style(theme, scope, Style::default().fg(fallback))
+        .fg
+        .unwrap_or(fallback)
+}
+
+fn resolve_style(theme: &Theme, scope: &str, fallback: Style) -> Style {
+    let mut resolved = fallback;
+
+    for (index, character) in scope.char_indices() {
+        if character == '.' {
+            if let Some(style) = theme.style_for_exact(&scope[..index]) {
+                resolved = resolved.patch(style);
+            }
+        }
+    }
+
+    if let Some(style) = theme.style_for_exact(scope) {
+        resolved = resolved.patch(style);
+    }
+
+    resolved
+}
+
+fn normalize_explicit(mut style: Style) -> Style {
+    style.add_modifier.remove(Modifier::REVERSED);
+    style.sub_modifier.remove(Modifier::REVERSED);
+    style
+}
+
+/// Left-edge symbols used by every tonal zone.
+pub const ZONE_EDGE_SET: border::Set = border::Set {
+    vertical_left: "▍",
+    ..border::PLAIN
+};
+
+/// Build a primary-pane block with stable geometry in both focus states.
+pub fn zone_block<'a>(
+    label: Line<'a>,
+    tone: Color,
+    text: Color,
+    focused: bool,
+    accent: Color,
+) -> Block<'a> {
+    let edge = if focused {
+        Style::default().fg(accent).bg(tone)
+    } else {
+        Style::default().fg(tone).bg(tone)
+    };
+
+    Block::default()
+        .style(Style::default().fg(text).bg(tone))
+        .borders(Borders::LEFT)
+        .border_set(ZONE_EDGE_SET)
+        .border_style(edge)
+        .title_top(label)
+        .padding(Padding::new(1, 1, 0, 0))
+}
+
+/// Return the shared content rectangle for a tonal zone.
+pub fn zone_inner(area: Rect) -> Rect {
+    let mut inner = area;
+    inner.x = inner.x.saturating_add(1).min(inner.right());
+    inner.width = inner.width.saturating_sub(1);
+    inner.y = inner.y.saturating_add(1).min(inner.bottom());
+    inner.height = inner.height.saturating_sub(1);
+    inner.x = inner.x.saturating_add(1);
+    inner.width = inner.width.saturating_sub(2);
+    inner
+}
+
+/// Return the right-padding column below a zone's label.
+pub fn zone_scrollbar_area(area: Rect) -> Rect {
+    Rect {
+        x: if area.width == 0 {
+            area.x
+        } else {
+            area.right().saturating_sub(1)
+        },
+        y: area.y.saturating_add(1).min(area.bottom()),
+        width: u16::from(area.width > 0),
+        height: area.height.saturating_sub(1),
+    }
+}
+
+/// Build a consistently styled uppercase zone label.
+pub fn zone_label(
+    name: &str,
+    detail_spans: Vec<Span<'static>>,
+    focused: bool,
+    accent: Color,
+    theme: &UiTheme,
+) -> Line<'static> {
+    let label_style = if focused {
+        theme.label_focused.fg(accent)
+    } else {
+        theme.label
+    };
+    let mut spans = Vec::with_capacity(detail_spans.len() + 1);
+    spans.push(Span::styled(format!(" {name}"), label_style));
+    spans.extend(detail_spans);
+    Line::from(spans)
+}
+
+/// Load a built-in or custom theme from the configured themes directory.
+pub fn load_theme(name: &str) -> (Theme, Option<String>) {
+    let themes_dir = config_dir().map(|path| path.join("themes"));
+    load_theme_from(name, themes_dir.as_deref())
+}
+
+/// Load a built-in or custom theme from an explicit themes directory.
+pub fn load_theme_from(name: &str, themes_dir: Option<&Path>) -> (Theme, Option<String>) {
+    match name {
+        "" | "default" | "one_dark" => return (themes::one_dark(), None),
+        "github_light" => return (themes::github_light(), None),
+        _ => {}
+    }
+
+    if !is_valid_theme_name(name) {
+        return fallback_with_warning(name, "theme name must be a single file stem");
+    }
+
+    let Some(themes_dir) = themes_dir else {
+        return fallback_with_warning(name, "configuration directory is unavailable");
+    };
+    let path = themes_dir.join(format!("{name}.toml"));
+
+    match Theme::from_file(&path) {
+        Ok(theme) => (theme, None),
+        Err(error) => fallback_with_warning(name, &error.to_string()),
+    }
+}
+
+fn is_valid_theme_name(name: &str) -> bool {
+    if name.contains(['/', '\\']) {
+        return false;
+    }
+
+    let mut components = Path::new(name).components();
+    matches!(
+        (components.next(), components.next()),
+        (Some(Component::Normal(_)), None)
+    )
+}
+
+fn fallback_with_warning(name: &str, reason: &str) -> (Theme, Option<String>) {
+    (
+        themes::one_dark(),
+        Some(format!(
+            "Failed to load theme '{name}': {reason}; using one_dark"
+        )),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use ratatui::buffer::Buffer;
+    use ratatui::widgets::Widget;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn empty_theme_uses_complete_fallback() {
+        let theme = Theme::from_toml("").unwrap();
+
+        assert_eq!(UiTheme::from_theme(&theme), UiTheme::fallback());
+    }
+
+    #[test]
+    fn child_style_merges_parent_and_fallback_components() {
+        let theme = Theme::from_toml(
+            r##"
+            ["ui.selection"]
+            fg = "#F0F0F0"
+            modifiers = ["bold"]
+
+            ["ui.selection.editor"]
+            bg = "#303030"
+            "##,
+        )
+        .unwrap();
+
+        let ui = UiTheme::from_theme(&theme);
+
+        assert_eq!(ui.editor_selection.fg, Some(rgb(0xF0, 0xF0, 0xF0)));
+        assert_eq!(ui.editor_selection.bg, Some(rgb(0x30, 0x30, 0x30)));
+        assert!(ui.editor_selection.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn normalized_explicit_styles_drop_reversed_modifier() {
+        let theme = Theme::from_toml(
+            r##"
+            ["ui.cursor"]
+            modifiers = ["reversed", "bold"]
+            "##,
+        )
+        .unwrap();
+
+        let cursor = UiTheme::from_theme(&theme).editor_cursor;
+
+        assert!(!cursor.add_modifier.contains(Modifier::REVERSED));
+        assert!(cursor.add_modifier.contains(Modifier::BOLD));
+        assert!(cursor.fg.is_some());
+        assert!(cursor.bg.is_some());
+    }
+
+    #[test]
+    fn built_in_themes_define_required_ui_scopes() {
+        for theme in [themes::one_dark(), themes::github_light()] {
+            for scope in [
+                "ui.background",
+                "ui.background.panel",
+                "ui.background.elevated",
+                "ui.text",
+                "ui.text.muted",
+                "ui.label",
+                "ui.label.focused",
+                "ui.accent",
+                "ui.accent.insert",
+                "ui.accent.visual",
+                "ui.selection",
+                "ui.selection.editor",
+                "ui.cursor",
+                "ui.cursor.cell",
+                "ui.search.match",
+                "ui.search.match.current",
+                "ui.statusline",
+                "ui.statusline.mode",
+                "ui.success",
+                "ui.warning",
+                "ui.error",
+                "ui.scrollbar",
+                "ui.grid.header",
+            ] {
+                assert!(
+                    theme.style_for_exact(scope).is_some(),
+                    "{} is missing {scope}",
+                    theme.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn built_in_base_text_has_readable_contrast() {
+        for theme in [themes::one_dark(), themes::github_light()] {
+            let ui = UiTheme::from_theme(&theme);
+            for background in [ui.bg_base, ui.bg_panel, ui.bg_elevated, ui.bg_status] {
+                assert!(
+                    contrast_ratio(ui.text, background) >= 4.5,
+                    "{} text contrast is too low on {background:?}",
+                    theme.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn built_in_explicit_styles_have_readable_contrast_and_distinct_tones() {
+        for theme in [themes::one_dark(), themes::github_light()] {
+            let ui = UiTheme::from_theme(&theme);
+            assert_ne!(ui.bg_base, ui.bg_panel);
+            assert_ne!(ui.bg_base, ui.bg_elevated);
+            assert_ne!(ui.bg_panel, ui.bg_elevated);
+
+            for style in [
+                ui.selection,
+                ui.cursor_cell,
+                ui.editor_cursor,
+                ui.editor_selection,
+                ui.search_match,
+                ui.search_match_current,
+            ] {
+                let foreground = style.fg.expect("explicit style foreground");
+                let background = style.bg.expect("explicit style background");
+                assert!(
+                    contrast_ratio(foreground, background) >= 4.5,
+                    "{} explicit style contrast is too low: {style:?}",
+                    theme.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn zone_geometry_matches_block_inner_for_small_and_normal_areas() {
+        let theme = UiTheme::fallback();
+        for width in 0..12 {
+            for height in 0..8 {
+                let area = Rect::new(4, 7, width, height);
+                let block = zone_block(
+                    Line::from(" QUERY"),
+                    theme.bg_elevated,
+                    theme.text,
+                    true,
+                    theme.accent,
+                );
+                assert_eq!(zone_inner(area), block.inner(area));
+            }
+        }
+    }
+
+    #[test]
+    fn zone_block_sets_base_foreground_and_background() {
+        let theme = UiTheme::fallback();
+        let area = Rect::new(0, 0, 12, 4);
+        let mut buffer = Buffer::empty(area);
+        zone_block(
+            Line::from(" QUERY"),
+            theme.bg_elevated,
+            theme.text,
+            false,
+            theme.accent,
+        )
+        .render(area, &mut buffer);
+
+        let cell = buffer.cell((5, 2)).unwrap();
+        assert_eq!(cell.fg, theme.text);
+        assert_eq!(cell.bg, theme.bg_elevated);
+    }
+
+    #[test]
+    fn focus_changes_zone_edge_style_without_changing_symbols() {
+        let theme = UiTheme::fallback();
+        let area = Rect::new(0, 0, 12, 4);
+        let mut focused = Buffer::empty(area);
+        let mut unfocused = Buffer::empty(area);
+
+        zone_block(
+            Line::from(" QUERY"),
+            theme.bg_elevated,
+            theme.text,
+            true,
+            theme.accent,
+        )
+        .render(area, &mut focused);
+        zone_block(
+            Line::from(" QUERY"),
+            theme.bg_elevated,
+            theme.text,
+            false,
+            theme.accent,
+        )
+        .render(area, &mut unfocused);
+
+        let focused_symbols: Vec<_> = focused.content.iter().map(|cell| cell.symbol()).collect();
+        let unfocused_symbols: Vec<_> =
+            unfocused.content.iter().map(|cell| cell.symbol()).collect();
+        assert_eq!(focused_symbols, unfocused_symbols);
+        assert_eq!(focused.cell((0, 1)).unwrap().fg, theme.accent);
+        assert_eq!(unfocused.cell((0, 1)).unwrap().fg, theme.bg_elevated);
+    }
+
+    #[test]
+    fn load_theme_from_handles_built_ins_and_custom_files() {
+        let directory = tempdir().unwrap();
+        fs::write(
+            directory.path().join("custom.toml"),
+            r##"["ui.background"]
+            fg = "#010203"
+            bg = "#F0F0F0"
+            "##,
+        )
+        .unwrap();
+
+        let (built_in, warning) = load_theme_from("github_light", Some(directory.path()));
+        assert_eq!(built_in.name, "github_light");
+        assert_eq!(warning, None);
+
+        let (custom, warning) = load_theme_from("custom", Some(directory.path()));
+        assert_eq!(custom.name, "custom");
+        assert_eq!(warning, None);
+        assert_eq!(
+            custom.style_for_exact("ui.background").unwrap().bg,
+            Some(rgb(0xF0, 0xF0, 0xF0))
+        );
+    }
+
+    #[test]
+    fn load_theme_from_falls_back_for_missing_malformed_and_escaping_names() {
+        let directory = tempdir().unwrap();
+        fs::write(directory.path().join("malformed.toml"), "not = [valid").unwrap();
+
+        for name in [
+            "missing",
+            "malformed",
+            "../outside",
+            "nested/theme",
+            "nested\\theme",
+        ] {
+            let (theme, warning) = load_theme_from(name, Some(directory.path()));
+            assert_eq!(theme.name, "one_dark");
+            assert!(warning.unwrap().contains(name));
+        }
+    }
+
+    fn contrast_ratio(foreground: Color, background: Color) -> f64 {
+        let foreground = luminance(foreground);
+        let background = luminance(background);
+        (foreground.max(background) + 0.05) / (foreground.min(background) + 0.05)
+    }
+
+    fn luminance(color: Color) -> f64 {
+        let Color::Rgb(red, green, blue) = color else {
+            panic!("contrast tests require RGB colors, got {color:?}");
+        };
+        let component = |value: u8| {
+            let value = f64::from(value) / 255.0;
+            if value <= 0.04045 {
+                value / 12.92
+            } else {
+                ((value + 0.055) / 1.055).powf(2.4)
+            }
+        };
+
+        0.2126 * component(red) + 0.7152 * component(green) + 0.0722 * component(blue)
+    }
+}

--- a/crates/tsql/src/ui/theme.rs
+++ b/crates/tsql/src/ui/theme.rs
@@ -138,17 +138,23 @@ impl UiTheme {
             "ui.text.muted",
             Style::default().fg(fallback.text_muted),
         );
+        let bg_base = background.bg.unwrap_or(fallback.bg_base);
+        let bg_elevated = elevated.bg.unwrap_or(fallback.bg_elevated);
+        let text = text_style.fg.unwrap_or(fallback.text);
+        let text_muted = muted_style.fg.unwrap_or(fallback.text_muted);
+        let accent = resolve_color(theme, "ui.accent", fallback.accent);
+        let warning = resolve_color(theme, "ui.warning", fallback.warning);
 
         Self {
-            bg_base: background.bg.unwrap_or(fallback.bg_base),
+            bg_base,
             bg_panel: panel.bg.unwrap_or(fallback.bg_panel),
-            bg_elevated: elevated.bg.unwrap_or(fallback.bg_elevated),
+            bg_elevated,
             bg_status: statusline.bg.unwrap_or(fallback.bg_status),
-            text: text_style.fg.unwrap_or(fallback.text),
-            text_muted: muted_style.fg.unwrap_or(fallback.text_muted),
+            text,
+            text_muted,
             label: resolve_style(theme, "ui.label", fallback.label),
             label_focused: resolve_style(theme, "ui.label.focused", fallback.label_focused),
-            accent: resolve_color(theme, "ui.accent", fallback.accent),
+            accent,
             accent_insert: resolve_color(theme, "ui.accent.insert", fallback.accent_insert),
             accent_visual: resolve_color(theme, "ui.accent.visual", fallback.accent_visual),
             selection: normalize_explicit(resolve_style(theme, "ui.selection", fallback.selection)),
@@ -178,7 +184,7 @@ impl UiTheme {
                 fallback.search_match_current,
             )),
             success: resolve_color(theme, "ui.success", fallback.success),
-            warning: resolve_color(theme, "ui.warning", fallback.warning),
+            warning,
             error: resolve_color(theme, "ui.error", fallback.error),
             transaction: resolve_color(theme, "ui.transaction", fallback.transaction),
             pill_fg: resolve_color(theme, "ui.statusline.mode", fallback.pill_fg),
@@ -190,26 +196,30 @@ impl UiTheme {
             notebook_canvas: normalize_explicit(resolve_style(
                 theme,
                 "ui.notebook.canvas",
-                fallback.notebook_canvas,
+                Style::default().fg(text).bg(bg_base),
             )),
             notebook_composer: normalize_explicit(resolve_style(
                 theme,
                 "ui.notebook.composer",
-                fallback.notebook_composer,
+                Style::default().fg(text).bg(bg_elevated),
             )),
             notebook_composer_focused: normalize_explicit(resolve_style(
                 theme,
                 "ui.notebook.composer.focused",
-                fallback.notebook_composer_focused,
+                Style::default().fg(text).bg(bg_elevated),
             )),
-            notebook_rail: resolve_style(theme, "ui.notebook.rail", fallback.notebook_rail),
+            notebook_rail: resolve_style(theme, "ui.notebook.rail", Style::default().fg(accent)),
             notebook_output: normalize_explicit(resolve_style(
                 theme,
                 "ui.notebook.output",
-                fallback.notebook_output,
+                Style::default().fg(text).bg(bg_base),
             )),
-            notebook_meta: resolve_style(theme, "ui.notebook.meta", fallback.notebook_meta),
-            notebook_stale: resolve_style(theme, "ui.notebook.stale", fallback.notebook_stale),
+            notebook_meta: resolve_style(
+                theme,
+                "ui.notebook.meta",
+                Style::default().fg(text_muted),
+            ),
+            notebook_stale: resolve_style(theme, "ui.notebook.stale", Style::default().fg(warning)),
         }
     }
 
@@ -453,6 +463,43 @@ mod tests {
         assert!(cursor.add_modifier.contains(Modifier::BOLD));
         assert!(cursor.fg.is_some());
         assert!(cursor.bg.is_some());
+    }
+
+    #[test]
+    fn notebook_scopes_inherit_partial_light_theme() {
+        let theme = Theme::from_toml(
+            r##"
+            ["ui.background"]
+            bg = "#F7F7F7"
+
+            ["ui.background.elevated"]
+            bg = "#FFFFFF"
+
+            ["ui.text"]
+            fg = "#202428"
+
+            ["ui.text.muted"]
+            fg = "#606870"
+
+            ["ui.accent"]
+            fg = "#185ABC"
+
+            ["ui.warning"]
+            fg = "#9A5B00"
+            "##,
+        )
+        .unwrap();
+
+        let ui = UiTheme::from_theme(&theme);
+
+        assert_eq!(ui.notebook_canvas.bg, Some(rgb(0xF7, 0xF7, 0xF7)));
+        assert_eq!(ui.notebook_output.bg, Some(rgb(0xF7, 0xF7, 0xF7)));
+        assert_eq!(ui.notebook_composer.bg, Some(rgb(0xFF, 0xFF, 0xFF)));
+        assert_eq!(ui.notebook_composer_focused.bg, Some(rgb(0xFF, 0xFF, 0xFF)));
+        assert_eq!(ui.notebook_canvas.fg, Some(rgb(0x20, 0x24, 0x28)));
+        assert_eq!(ui.notebook_meta.fg, Some(rgb(0x60, 0x68, 0x70)));
+        assert_eq!(ui.notebook_rail.fg, Some(rgb(0x18, 0x5A, 0xBC)));
+        assert_eq!(ui.notebook_stale.fg, Some(rgb(0x9A, 0x5B, 0x00)));
     }
 
     #[test]

--- a/crates/tsql/src/ui/theme.rs
+++ b/crates/tsql/src/ui/theme.rs
@@ -6,7 +6,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::symbols::border;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Padding};
+use ratatui::widgets::{Block, BorderType, Borders, Padding};
 use tui_syntax::{themes, Theme};
 
 use crate::app::Mode;
@@ -35,9 +35,13 @@ pub struct UiTheme {
     pub success: Color,
     pub warning: Color,
     pub error: Color,
+    pub transaction: Color,
     pub pill_fg: Color,
     pub scrollbar: Style,
     pub grid_header: Style,
+    pub overlay: Style,
+    pub overlay_border: Style,
+    pub overlay_title: Style,
 }
 
 impl Default for UiTheme {
@@ -76,12 +80,16 @@ impl UiTheme {
             success: rgb(0x98, 0xC3, 0x79),
             warning: rgb(0xE5, 0xC0, 0x7B),
             error: rgb(0xE0, 0x6C, 0x75),
+            transaction: rgb(0xC6, 0x78, 0xDD),
             pill_fg: ink,
             scrollbar: Style::default().fg(text_muted),
             grid_header: Style::default()
                 .fg(text)
                 .bg(rgb(0x2C, 0x31, 0x3A))
                 .add_modifier(Modifier::BOLD),
+            overlay: Style::default().fg(text).bg(rgb(0x33, 0x3B, 0x49)),
+            overlay_border: Style::default().fg(rgb(0x5C, 0x66, 0x73)),
+            overlay_title: Style::default().fg(accent).add_modifier(Modifier::BOLD),
         }
     }
 
@@ -158,9 +166,13 @@ impl UiTheme {
             success: resolve_color(theme, "ui.success", fallback.success),
             warning: resolve_color(theme, "ui.warning", fallback.warning),
             error: resolve_color(theme, "ui.error", fallback.error),
+            transaction: resolve_color(theme, "ui.transaction", fallback.transaction),
             pill_fg: resolve_color(theme, "ui.statusline.mode", fallback.pill_fg),
             scrollbar: resolve_style(theme, "ui.scrollbar", fallback.scrollbar),
             grid_header: resolve_style(theme, "ui.grid.header", fallback.grid_header),
+            overlay: normalize_explicit(resolve_style(theme, "ui.overlay", fallback.overlay)),
+            overlay_border: resolve_style(theme, "ui.overlay.border", fallback.overlay_border),
+            overlay_title: resolve_style(theme, "ui.overlay.title", fallback.overlay_title),
         }
     }
 
@@ -260,6 +272,24 @@ pub fn zone_scrollbar_area(area: Rect) -> Rect {
         y: area.y.saturating_add(1).min(area.bottom()),
         width: u16::from(area.width > 0),
         height: area.height.saturating_sub(1),
+    }
+}
+
+/// Build the standard floating-overlay block: a rounded border and themed
+/// title on the overlay surface tone.
+pub fn overlay_block(title: &str, theme: &UiTheme) -> Block<'static> {
+    let block = Block::default()
+        .style(theme.overlay)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(theme.overlay_border);
+    if title.is_empty() {
+        block
+    } else {
+        block.title_top(Line::from(Span::styled(
+            format!(" {title} "),
+            theme.overlay_title,
+        )))
     }
 }
 
@@ -413,6 +443,10 @@ mod tests {
                 "ui.success",
                 "ui.warning",
                 "ui.error",
+                "ui.transaction",
+                "ui.overlay",
+                "ui.overlay.border",
+                "ui.overlay.title",
                 "ui.scrollbar",
                 "ui.grid.header",
             ] {
@@ -454,6 +488,7 @@ mod tests {
                 ui.editor_selection,
                 ui.search_match,
                 ui.search_match_current,
+                ui.overlay,
             ] {
                 let foreground = style.fg.expect("explicit style foreground");
                 let background = style.bg.expect("explicit style background");

--- a/crates/tsql/src/ui/theme.rs
+++ b/crates/tsql/src/ui/theme.rs
@@ -42,6 +42,13 @@ pub struct UiTheme {
     pub overlay: Style,
     pub overlay_border: Style,
     pub overlay_title: Style,
+    pub notebook_canvas: Style,
+    pub notebook_composer: Style,
+    pub notebook_composer_focused: Style,
+    pub notebook_rail: Style,
+    pub notebook_output: Style,
+    pub notebook_meta: Style,
+    pub notebook_stale: Style,
 }
 
 impl Default for UiTheme {
@@ -90,6 +97,13 @@ impl UiTheme {
             overlay: Style::default().fg(text).bg(rgb(0x33, 0x3B, 0x49)),
             overlay_border: Style::default().fg(rgb(0x5C, 0x66, 0x73)),
             overlay_title: Style::default().fg(accent).add_modifier(Modifier::BOLD),
+            notebook_canvas: Style::default().fg(text).bg(rgb(0x28, 0x2C, 0x34)),
+            notebook_composer: Style::default().fg(text).bg(rgb(0x2C, 0x31, 0x3A)),
+            notebook_composer_focused: Style::default().fg(text).bg(rgb(0x2C, 0x31, 0x3A)),
+            notebook_rail: Style::default().fg(accent),
+            notebook_output: Style::default().fg(text).bg(rgb(0x28, 0x2C, 0x34)),
+            notebook_meta: Style::default().fg(text_muted),
+            notebook_stale: Style::default().fg(rgb(0xE5, 0xC0, 0x7B)),
         }
     }
 
@@ -173,6 +187,29 @@ impl UiTheme {
             overlay: normalize_explicit(resolve_style(theme, "ui.overlay", fallback.overlay)),
             overlay_border: resolve_style(theme, "ui.overlay.border", fallback.overlay_border),
             overlay_title: resolve_style(theme, "ui.overlay.title", fallback.overlay_title),
+            notebook_canvas: normalize_explicit(resolve_style(
+                theme,
+                "ui.notebook.canvas",
+                fallback.notebook_canvas,
+            )),
+            notebook_composer: normalize_explicit(resolve_style(
+                theme,
+                "ui.notebook.composer",
+                fallback.notebook_composer,
+            )),
+            notebook_composer_focused: normalize_explicit(resolve_style(
+                theme,
+                "ui.notebook.composer.focused",
+                fallback.notebook_composer_focused,
+            )),
+            notebook_rail: resolve_style(theme, "ui.notebook.rail", fallback.notebook_rail),
+            notebook_output: normalize_explicit(resolve_style(
+                theme,
+                "ui.notebook.output",
+                fallback.notebook_output,
+            )),
+            notebook_meta: resolve_style(theme, "ui.notebook.meta", fallback.notebook_meta),
+            notebook_stale: resolve_style(theme, "ui.notebook.stale", fallback.notebook_stale),
         }
     }
 
@@ -449,6 +486,13 @@ mod tests {
                 "ui.overlay.title",
                 "ui.scrollbar",
                 "ui.grid.header",
+                "ui.notebook.canvas",
+                "ui.notebook.composer",
+                "ui.notebook.composer.focused",
+                "ui.notebook.rail",
+                "ui.notebook.output",
+                "ui.notebook.meta",
+                "ui.notebook.stale",
             ] {
                 assert!(
                     theme.style_for_exact(scope).is_some(),

--- a/crates/tsql/src/util.rs
+++ b/crates/tsql/src/util.rs
@@ -1,18 +1,54 @@
 use std::error::Error as StdError;
 
 use serde_json::Value as JsonValue;
+use tokio_postgres::error::ErrorPosition;
 
 /// Format a postgres error with its full chain of causes
 pub fn format_pg_error(e: &tokio_postgres::Error) -> String {
-    let mut msg = e.to_string();
+    format_pg_error_with_position(e, |_| None)
+}
 
-    // Try to get the database error details
+/// Formats a PostgreSQL error, allowing generated SQL positions to be mapped to user source.
+pub(crate) fn format_pg_error_with_position(
+    e: &tokio_postgres::Error,
+    map_position: impl FnOnce(u32) -> Option<(u32, usize, usize)>,
+) -> String {
     if let Some(db_err) = e.as_db_error() {
-        msg = db_err.to_string();
-    } else if let Some(source) = e.source() {
-        // Fall back to source error
-        msg = format!("{}: {}", msg, source);
+        let mut lines = vec![format!("{} [{}]", db_err.message(), db_err.code().code())];
+        if let Some(detail) = db_err.detail() {
+            lines.push(format!("DETAIL: {detail}"));
+        }
+        if let Some(hint) = db_err.hint() {
+            lines.push(format!("HINT: {hint}"));
+        }
+        if let Some(position) = db_err.position() {
+            match position {
+                ErrorPosition::Original(position) => {
+                    if let Some((position, line, column)) = map_position(*position) {
+                        lines.push(format!(
+                            "POSITION: {position} (line {line}, column {column})"
+                        ));
+                    } else {
+                        lines.push(format!("POSITION: {position}"));
+                    }
+                }
+                ErrorPosition::Internal { position, query } => {
+                    lines.push(format!("INTERNAL POSITION: {position}"));
+                    lines.push(format!("INTERNAL QUERY: {query}"));
+                }
+            }
+        }
+        if let Some(context) = db_err.where_() {
+            lines.push(format!("CONTEXT: {context}"));
+        }
+        return lines.join("\n");
     }
+
+    let msg = if let Some(source) = e.source() {
+        format!("{}: {}", e, source)
+    } else {
+        e.to_string()
+    };
 
     let hint = pg_error_hint(&msg);
     if !hint.is_empty() {
@@ -20,6 +56,42 @@ pub fn format_pg_error(e: &tokio_postgres::Error) -> String {
     } else {
         msg
     }
+}
+
+/// Converts a formatted PostgreSQL `POSITION:` into a zero-based textarea cursor.
+///
+/// PostgreSQL counts Unicode scalar values rather than UTF-8 bytes. Rejecting positions beyond
+/// the current source prevents stale or unmapped generated-SQL diagnostics from jumping to an
+/// unrelated location in an edited cell.
+pub(crate) fn pg_error_cursor_position(error: &str, source: &str) -> Option<(usize, usize)> {
+    let position = error.lines().find_map(|line| {
+        let rest = line.trim_start().strip_prefix("POSITION:")?.trim_start();
+        let digits = rest
+            .find(|character: char| !character.is_ascii_digit())
+            .map_or(rest, |end| &rest[..end]);
+        if digits.is_empty() {
+            None
+        } else {
+            digits.parse::<usize>().ok()
+        }
+    })?;
+    let offset = position.checked_sub(1)?;
+    if offset > source.chars().count() {
+        return None;
+    }
+
+    Some(
+        source
+            .chars()
+            .take(offset)
+            .fold((0usize, 0usize), |(row, column), character| {
+                if character == '\n' {
+                    (row + 1, 0)
+                } else {
+                    (row, column + 1)
+                }
+            }),
+    )
 }
 
 /// Strip the password component from a connection URL, preserving the
@@ -476,6 +548,82 @@ mod tests {
         assert!(pg_error_hint("timeout expired").contains("unreachable"));
         assert!(pg_error_hint("SSL connection is required").contains("SSL"));
         assert!(pg_error_hint("totally unrelated").is_empty());
+    }
+
+    #[test]
+    fn test_pg_error_cursor_position_handles_unicode_and_mapped_locations() {
+        let source = "SELECT 'é🙂' AS note\nWHERE broken";
+        let position = source[..source.find("broken").unwrap()].chars().count() + 1;
+
+        assert_eq!(
+            pg_error_cursor_position(&format!("syntax error\nPOSITION: {position}"), source),
+            Some((1, 6))
+        );
+        assert_eq!(
+            pg_error_cursor_position(
+                &format!("syntax error [42601]\n  POSITION: {position} (line 2, column 7)"),
+                source
+            ),
+            Some((1, 6))
+        );
+        assert_eq!(
+            pg_error_cursor_position(
+                &format!("syntax error\nPOSITION: {}", source.chars().count() + 1),
+                source
+            ),
+            Some((1, "WHERE broken".chars().count()))
+        );
+    }
+
+    #[test]
+    fn test_pg_error_cursor_position_rejects_internal_stale_and_invalid_locations() {
+        let source = "SELECT 1";
+
+        for error in [
+            "syntax error\nINTERNAL POSITION: 2",
+            "syntax error\nPOSITION: 0",
+            "syntax error\nPOSITION:",
+            "syntax error\nPOSITION: nope",
+            "syntax error\nPOSITION: 99999999999999999999999999",
+            "syntax error\nPOSITION: 99 (line 1, column 99)",
+        ] {
+            assert_eq!(pg_error_cursor_position(error, source), None, "{error}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_format_pg_error_preserves_sqlstate_position_detail_and_hint() {
+        let Ok(url) = std::env::var("TEST_DATABASE_URL") else {
+            return;
+        };
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+
+        let syntax_error = client.simple_query("SELEC 1").await.unwrap_err();
+        let syntax = format_pg_error(&syntax_error);
+        assert!(syntax.contains("[42601]"), "{syntax}");
+        assert!(syntax.contains("POSITION:"), "{syntax}");
+        let mapped = format_pg_error_with_position(&syntax_error, |_| Some((3, 2, 4)));
+        assert!(
+            mapped.contains("POSITION: 3 (line 2, column 4)"),
+            "{mapped}"
+        );
+
+        let raised_error = client
+            .simple_query(
+                "DO $$ BEGIN RAISE EXCEPTION 'notebook failure' USING DETAIL = 'missing row', HINT = 'rerun the source'; END $$",
+            )
+            .await
+            .unwrap_err();
+        let raised = format_pg_error(&raised_error);
+        assert!(raised.contains("notebook failure [P0001]"), "{raised}");
+        assert!(raised.contains("DETAIL: missing row"), "{raised}");
+        assert!(raised.contains("HINT: rerun the source"), "{raised}");
+        assert!(raised.contains("CONTEXT:"), "{raised}");
     }
 
     #[test]

--- a/crates/tsql/tests/integration_tests.rs
+++ b/crates/tsql/tests/integration_tests.rs
@@ -62,6 +62,31 @@ async fn test_query_error_message() {
         "Error message should mention the table name or indicate it doesn't exist. Got: {}",
         error_message
     );
+    assert!(
+        error_message.contains("[42P01]"),
+        "Error message should include the undefined-table SQLSTATE. Got: {error_message}"
+    );
+    assert!(
+        error_message.contains("POSITION:"),
+        "Error message should include the query position. Got: {error_message}"
+    );
+
+    let err = client
+        .simple_query(
+            "DO $$ BEGIN RAISE EXCEPTION 'notebook diagnostic' USING ERRCODE = '22023', DETAIL = 'extra context', HINT = 'check the input'; END $$",
+        )
+        .await
+        .unwrap_err();
+    let error_message = tsql::util::format_pg_error(&err);
+    assert!(error_message.contains("[22023]"), "{error_message}");
+    assert!(
+        error_message.contains("DETAIL: extra context"),
+        "{error_message}"
+    );
+    assert!(
+        error_message.contains("HINT: check the input"),
+        "{error_message}"
+    );
 }
 
 /// Test that we can execute DDL statements.

--- a/crates/tui-syntax/Cargo.toml
+++ b/crates/tui-syntax/Cargo.toml
@@ -20,6 +20,7 @@ tree-sitter-highlight.workspace = true
 tree-sitter-sequel.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter-html.workspace = true
+tree-sitter-javascript.workspace = true
 serde.workspace = true
 toml.workspace = true
 

--- a/crates/tui-syntax/src/highlighter.rs
+++ b/crates/tui-syntax/src/highlighter.rs
@@ -271,7 +271,7 @@ impl Highlighter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::languages::{html, sql};
+    use crate::languages::{html, javascript, sql};
     use crate::themes;
 
     #[test]
@@ -350,5 +350,20 @@ mod tests {
 </html>"#;
         let lines = highlighter.highlight("html", html_content).unwrap();
         assert_eq!(lines.len(), 8);
+    }
+
+    #[test]
+    fn test_highlight_mongo_shell_javascript() {
+        let theme = themes::one_dark();
+        let mut highlighter = Highlighter::new(theme);
+        highlighter.register_language(javascript()).unwrap();
+
+        let source =
+            "// recent users\ndb.users.find({ active: true, score: { $gte: 10 } }).limit(5)";
+        let lines = highlighter.highlight("javascript", source).unwrap();
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines.iter().all(|line| !line.spans.is_empty()));
+        assert!(lines[1].spans.len() > 1);
     }
 }

--- a/crates/tui-syntax/src/languages/javascript.rs
+++ b/crates/tui-syntax/src/languages/javascript.rs
@@ -1,0 +1,17 @@
+//! JavaScript language support using tree-sitter-javascript.
+
+use super::Language;
+
+/// Returns the JavaScript language configuration.
+///
+/// Mongo shell queries use JavaScript syntax, including method calls,
+/// object literals, comments, and template strings.
+pub fn javascript() -> Language {
+    Language {
+        name: "javascript",
+        ts_language: tree_sitter_javascript::LANGUAGE.into(),
+        highlights_query: tree_sitter_javascript::HIGHLIGHT_QUERY,
+        injections_query: "",
+        locals_query: tree_sitter_javascript::LOCALS_QUERY,
+    }
+}

--- a/crates/tui-syntax/src/languages/mod.rs
+++ b/crates/tui-syntax/src/languages/mod.rs
@@ -3,10 +3,12 @@
 //! Each language provides a tree-sitter grammar and highlight queries.
 
 mod html;
+mod javascript;
 mod json;
 mod sql;
 
 pub use html::html;
+pub use javascript::javascript;
 pub use json::json;
 pub use sql::sql;
 

--- a/crates/tui-syntax/src/lib.rs
+++ b/crates/tui-syntax/src/lib.rs
@@ -36,5 +36,5 @@ mod theme;
 pub mod themes;
 
 pub use highlighter::{HighlightError, Highlighter};
-pub use languages::{html, json, sql, Language, LanguageError};
+pub use languages::{html, javascript, json, sql, Language, LanguageError};
 pub use theme::{Style as ThemeStyle, StyleModifier, Theme, ThemeError};

--- a/crates/tui-syntax/src/theme.rs
+++ b/crates/tui-syntax/src/theme.rs
@@ -286,6 +286,15 @@ impl Theme {
         RatatuiStyle::default()
     }
 
+    /// Get the ratatui style defined for an exact capture name.
+    ///
+    /// Unlike [`Theme::style_for`], this does not fall back to parent captures.
+    /// It is useful when callers need to merge parent and child style fields
+    /// themselves.
+    pub fn style_for_exact(&self, capture: &str) -> Option<RatatuiStyle> {
+        self.cached_styles.get(capture).copied()
+    }
+
     /// Cache all styles as ratatui styles.
     fn cache_styles(&mut self) {
         self.cached_styles.clear();
@@ -356,6 +365,29 @@ mod tests {
         // "keyword.control" should fall back to "keyword"
         let style = theme.style_for("keyword.control");
         assert_eq!(style.fg, Some(Color::Rgb(255, 0, 0)));
+    }
+
+    #[test]
+    fn test_exact_style_lookup_does_not_fall_back() {
+        let toml = r##"
+            ["ui.selection"]
+            fg = "#FFFFFF"
+
+            ["ui.selection.editor"]
+            bg = "#333333"
+        "##;
+
+        let theme = Theme::from_toml(toml).unwrap();
+
+        let selection = theme.style_for_exact("ui.selection").unwrap();
+        assert_eq!(selection.fg, Some(Color::Rgb(255, 255, 255)));
+        assert_eq!(selection.bg, None);
+
+        let editor = theme.style_for_exact("ui.selection.editor").unwrap();
+        assert_eq!(editor.fg, None);
+        assert_eq!(editor.bg, Some(Color::Rgb(51, 51, 51)));
+
+        assert_eq!(theme.style_for_exact("ui.selection.missing"), None);
     }
 
     #[test]

--- a/crates/tui-syntax/src/themes/mod.rs
+++ b/crates/tui-syntax/src/themes/mod.rs
@@ -280,6 +280,31 @@ fg = "#9DA5B4"
 fg = "#DCDFE4"
 bg = "#2C313A"
 modifiers = ["bold"]
+
+["ui.notebook.canvas"]
+fg = "#DCDFE4"
+bg = "#282C34"
+
+["ui.notebook.composer"]
+fg = "#DCDFE4"
+bg = "#2C313A"
+
+["ui.notebook.composer.focused"]
+fg = "#DCDFE4"
+bg = "#333B49"
+
+["ui.notebook.rail"]
+fg = "#56B6C2"
+
+["ui.notebook.output"]
+fg = "#DCDFE4"
+bg = "#282C34"
+
+["ui.notebook.meta"]
+fg = "#9DA5B4"
+
+["ui.notebook.stale"]
+fg = "#E5C07B"
 "##;
 
 /// GitHub Light theme TOML.
@@ -546,4 +571,29 @@ fg = "#57606A"
 fg = "#1F2328"
 bg = "#EAEEF2"
 modifiers = ["bold"]
+
+["ui.notebook.canvas"]
+fg = "#1F2328"
+bg = "#FFFFFF"
+
+["ui.notebook.composer"]
+fg = "#1F2328"
+bg = "#EAEEF2"
+
+["ui.notebook.composer.focused"]
+fg = "#1F2328"
+bg = "#DDE8F5"
+
+["ui.notebook.rail"]
+fg = "#0969DA"
+
+["ui.notebook.output"]
+fg = "#1F2328"
+bg = "#FFFFFF"
+
+["ui.notebook.meta"]
+fg = "#57606A"
+
+["ui.notebook.stale"]
+fg = "#9A6700"
 "##;

--- a/crates/tui-syntax/src/themes/mod.rs
+++ b/crates/tui-syntax/src/themes/mod.rs
@@ -259,6 +259,20 @@ fg = "#E5C07B"
 ["ui.error"]
 fg = "#E06C75"
 
+["ui.transaction"]
+fg = "#C678DD"
+
+["ui.overlay"]
+fg = "#DCDFE4"
+bg = "#333B49"
+
+["ui.overlay.border"]
+fg = "#5C6673"
+
+["ui.overlay.title"]
+fg = "#56B6C2"
+modifiers = ["bold"]
+
 ["ui.scrollbar"]
 fg = "#9DA5B4"
 
@@ -510,6 +524,20 @@ fg = "#9A6700"
 
 ["ui.error"]
 fg = "#CF222E"
+
+["ui.transaction"]
+fg = "#8250DF"
+
+["ui.overlay"]
+fg = "#1F2328"
+bg = "#FFFFFF"
+
+["ui.overlay.border"]
+fg = "#AFB8C1"
+
+["ui.overlay.title"]
+fg = "#0969DA"
+modifiers = ["bold"]
 
 ["ui.scrollbar"]
 fg = "#57606A"

--- a/crates/tui-syntax/src/themes/mod.rs
+++ b/crates/tui-syntax/src/themes/mod.rs
@@ -188,6 +188,84 @@ fg = "cyan"
 # Escape sequences
 [escape]
 fg = "cyan"
+
+# UI chrome
+["ui.background"]
+fg = "#ABB2BF"
+bg = "#282C34"
+
+["ui.background.panel"]
+bg = "#21252B"
+
+["ui.background.elevated"]
+bg = "#2C313A"
+
+["ui.text"]
+fg = "#DCDFE4"
+
+["ui.text.muted"]
+fg = "#9DA5B4"
+
+["ui.label"]
+fg = "#9DA5B4"
+
+["ui.label.focused"]
+fg = "#56B6C2"
+modifiers = ["bold"]
+
+["ui.accent"]
+fg = "#56B6C2"
+
+["ui.accent.insert"]
+fg = "#98C379"
+
+["ui.accent.visual"]
+fg = "#E5C07B"
+
+["ui.selection"]
+fg = "#DCDFE4"
+bg = "#3E4451"
+
+["ui.selection.editor"]
+bg = "#3E4451"
+
+["ui.cursor"]
+fg = "#1D2025"
+bg = "#56B6C2"
+
+["ui.cursor.cell"]
+bg = "#56B6C2"
+
+["ui.search.match"]
+fg = "#1D2025"
+bg = "#E5C07B"
+
+["ui.search.match.current"]
+bg = "#D19A66"
+
+["ui.statusline"]
+fg = "#DCDFE4"
+bg = "#1D2025"
+
+["ui.statusline.mode"]
+fg = "#1D2025"
+
+["ui.success"]
+fg = "#98C379"
+
+["ui.warning"]
+fg = "#E5C07B"
+
+["ui.error"]
+fg = "#E06C75"
+
+["ui.scrollbar"]
+fg = "#9DA5B4"
+
+["ui.grid.header"]
+fg = "#DCDFE4"
+bg = "#2C313A"
+modifiers = ["bold"]
 "##;
 
 /// GitHub Light theme TOML.
@@ -362,4 +440,82 @@ fg = "dark_gray"
 # Escape sequences
 [escape]
 fg = "cyan"
+
+# UI chrome
+["ui.background"]
+fg = "#1F2328"
+bg = "#FFFFFF"
+
+["ui.background.panel"]
+bg = "#F6F8FA"
+
+["ui.background.elevated"]
+bg = "#EAEEF2"
+
+["ui.text"]
+fg = "#1F2328"
+
+["ui.text.muted"]
+fg = "#57606A"
+
+["ui.label"]
+fg = "#57606A"
+
+["ui.label.focused"]
+fg = "#0969DA"
+modifiers = ["bold"]
+
+["ui.accent"]
+fg = "#0969DA"
+
+["ui.accent.insert"]
+fg = "#1A7F37"
+
+["ui.accent.visual"]
+fg = "#9A6700"
+
+["ui.selection"]
+fg = "#1F2328"
+bg = "#DDE8F5"
+
+["ui.selection.editor"]
+bg = "#DDE8F5"
+
+["ui.cursor"]
+fg = "#FFFFFF"
+bg = "#0969DA"
+
+["ui.cursor.cell"]
+bg = "#0969DA"
+
+["ui.search.match"]
+fg = "#1F2328"
+bg = "#FFF8C5"
+
+["ui.search.match.current"]
+bg = "#FFD8A8"
+
+["ui.statusline"]
+fg = "#1F2328"
+bg = "#D8DEE4"
+
+["ui.statusline.mode"]
+fg = "#FFFFFF"
+
+["ui.success"]
+fg = "#1A7F37"
+
+["ui.warning"]
+fg = "#9A6700"
+
+["ui.error"]
+fg = "#CF222E"
+
+["ui.scrollbar"]
+fg = "#57606A"
+
+["ui.grid.header"]
+fg = "#1F2328"
+bg = "#EAEEF2"
+modifiers = ["bold"]
 "##;

--- a/docs/NOTEBOOK_MODE_FOLLOW_UP_PLAN.md
+++ b/docs/NOTEBOOK_MODE_FOLLOW_UP_PLAN.md
@@ -1,0 +1,648 @@
+# Notebook Mode Follow-up Plan
+
+Status: implemented (P0-P2, F1-F2, core F3 tooling, and Actions/workflow sweep)
+Date: 2026-07-11
+Original baseline: `feat/notebook-mode` at `918e16b` / PR #44
+Integrated baseline: `origin/master` through `802f092` (merge `ceba832`)
+Primary reference: `docs/NOTEBOOK_MODE_PLAN.md`
+
+This plan records the post-MVP notebook sweep: correctness and lifecycle bugs,
+user-facing gaps, performance risks, and the most useful next features. It is
+intended to make the next implementation pass incremental and reviewable, not
+to broaden the MVP in one large change.
+
+## Implementation outcome (2026-07-11)
+
+The follow-up implementation is complete for the prioritized correctness,
+resource-bound, UX, and workflow work. The findings and reproduction notes
+below are retained as historical context; they describe the original baseline,
+not the behavior of the integrated branch.
+
+Shipped in this pass:
+
+- **Classic reconciliation and execution safety.** Integrated the current
+  schema-select and `Alt+M` workspace changes, scoped asynchronous Classic and
+  Notebook events by execution/connection identity, fixed savepoint and
+  ambiguous transaction handling, and made cancellation, stale completion,
+  deletion, reconnect, and snapshot cleanup ownership-safe.
+- **SQL and snapshot correctness.** Added a shared UTF-8-safe PostgreSQL lexer
+  for escape strings, quotes, dollar bodies, and nested comments; structural
+  logical references; semantic eligibility checks; unique physical TEMP names;
+  identity-checked reads/drops; immutable pinned versions; true snapshot LRU;
+  independent row/byte limits; zero-row metadata; and safe preview fallback.
+- **Bounded, navigable results.** Non-snapshot PostgreSQL and Mongo previews
+  now stream within row/byte/timeout budgets. Retained tables page on demand,
+  `G` reaches the last row, paging/cancellation is scoped, and older previews
+  compact under the aggregate display budget. Search explicitly reports
+  incomplete data; full retained results stream to disk and selected loaded
+  rows can be exported immediately.
+- **Notebook workflows.** Added latest, numbered, named, and multiple result
+  references; serial dependency-aware run-all/above/below/dependents; portable
+  versioned notebook open/save; insert, duplicate, move, source collapse,
+  outline/jump, dependency-aware clear/delete, dirty prompts, and per-editor
+  query history. `:explain-cell` creates a safe non-materialized PostgreSQL
+  EXPLAIN cell with inherited dependencies.
+- **User-facing polish and performance.** Restored editor/keymap parity,
+  mouse/table focus, Visual selection, SQL and Mongo-shell highlighting,
+  clipping and source-availability cues, theme fallbacks, accurate row-count
+  status, wrapped SQLSTATE/detail/hint/position diagnostics with
+  `:error`/`:copy-error`, ASCII disclosure/rail fallback (`TSQL_ASCII=1`), and
+  bounded visible-cell rendering for 100 long-source cells. The narrow-terminal
+  smoke also caught and fixed hidden-editor horizontal-scroll corruption in Cell
+  focus.
+- **Actions and workflow sweep (items 1-7).** Added a contextual, keyboard/mouse
+  Actions palette (`Ctrl+Shift+P`, `Cmd+K`, or `:actions`); live PostgreSQL
+  `@result`/numbered/named completion with source metadata; persistent named
+  snippets; bounded session-local per-cell run history with source restoration;
+  full retained-result streaming export (CSV/JSON/TSV/SQL INSERT) and selected
+  row export; Unicode-aware source-mapped PostgreSQL diagnostics with
+  `:error-jump`; and bounded, jumpable off-screen cell activity notifications.
+  Portable notebook documents remain source-and-lineage-only and never embed
+  historical result previews.
+
+Validation completed against local PostgreSQL 18.4:
+
+```sh
+cargo fmt --all -- --check
+git diff --check
+cargo clippy --locked --offline --all --all-targets -- -D warnings
+TEST_DATABASE_URL=postgresql://127.0.0.1/sqatch cargo test --locked --offline --quiet --lib --bins
+TEST_DATABASE_URL=postgresql://127.0.0.1/sqatch cargo test --locked --offline --quiet -p tsql --test integration_tests
+TEST_DATABASE_URL=postgresql://127.0.0.1/sqatch cargo test --locked --offline --quiet -p tsql --test startup_nonblocking
+cargo build --locked --offline --quiet -p tsql
+```
+
+Results: **826 library tests passed, 3 pre-existing keychain tests ignored;
+22 binary tests, 14 syntax-highlighter tests, 8 PostgreSQL integration tests,
+and 2 startup tests passed; clippy, formatting, and whitespace checks clean.**
+The 100-cell/4 KiB-source focused-result render regression completes in about
+70 ms in the debug test binary and renders only the seven-cell visible window.
+
+The tmux smoke covered snapshot creation and paging, trailing comments and
+escape strings, joins across numbered/named sources, restore and Run All,
+clear plus Run Dependents, collapse/expand, EXPLAIN, rich mapped errors and
+error-jump, named-reference completion, bracketed paste, snippets, restored
+cell-run history/output previews, off-screen activity, contextual Actions in
+Classic and Notebook, selected CSV plus full retained CSV/JSON/TSV/SQL export,
+a 250,000-row snapshot-off preview, Classic schema-select/`Alt+M`, and a 60x20
+ASCII terminal.
+
+Remaining optional follow-ons, deliberately outside these passes:
+- Add a typed, bounded Mongo refinement provider and Mongo-specific result
+  references once a Mongo-backed integration environment is available.
+- Add a dedicated release-profile benchmark harness and phase-level timings;
+  the debug render regression guards the visible-window invariant but is not a
+  substitute for repeatable latency/peak-memory benchmarks.
+
+## Executive summary
+
+The core notebook flow works, but several boundaries need hardening before it
+can safely become a dependable daily workspace:
+
+1. PR #44 is currently unmergeable with `master`. The two newer Classic-mode
+   changes (`c02e022` and `802f092`) conflict primarily in `app.rs` and must be
+   reconciled before further notebook work.
+2. Execution/transaction ownership is not yet fully target-aware. Stale events,
+   an incorrect savepoint classification, and edits during an in-flight
+   execution can make the app believe a transaction is idle and allow a
+   snapshot commit to commit user work.
+3. Snapshot eligibility, logical-reference compilation, identity validation,
+   and cleanup have several correctness holes. Valid SQL can fail, an evicted
+   immutable dependency can silently rebind, and cleanup can drop an unrelated
+   replacement TEMP relation.
+4. Result and memory limits are not independent or consistently enforced.
+   Complete snapshots can expose only their initial display rows, while
+   non-snapshot execution buffers the entire server response before truncating.
+5. The notebook renderer/input model needs a focused UX and performance pass:
+   invisible Visual selections, false snapshot badges, hidden focus, clipped
+   SQL/errors, expensive hidden Classic rendering, and repeated whole-document
+   scans are all observable.
+
+The recommended order is: mergeability, execution safety, snapshot/reference
+correctness, bounded results, UX, performance, then new features.
+
+## Sweep evidence
+
+The sweep inspected the full `918e16b` diff and related callers, then exercised
+the debug binary against PostgreSQL 18.4 in tmux with both normal and deliberately
+small limits. The following failures were reproduced live:
+
+- A complete 20-row retained result with `connection.max_rows = 5` displays and
+  navigates only five rows, reports `at least 6 total`, and cannot reach row 6.
+- With `snapshot_max_rows = 1` and display max 5, a five-row query displays only
+  two rows because staging uses `snapshot_max_rows + 1`.
+- Replacing a dependent cell's SQL with `SELECT 42 AS standalone_value` fails
+  with `dependent cell is missing its logical result reference`; clearing the
+  execution does not make the cell reusable.
+- After a source is rerun and deleted, a dependent pinned to its older result
+  still reruns successfully. Inspecting the active TEMP schema shows the old
+  `__tsql_nb_*` relation remains.
+- Editing a slow query while it runs finishes with a `SUCCEEDED` header but no
+  output and leaves another unreachable TEMP relation.
+- `SELECT E'it\'s @result_1' AS note` succeeds directly in PostgreSQL but
+  fails in Notebook with `unterminated SQL literal`.
+- Data-changing CTEs, `SELECT ... INTO`, `SELECT ROW(1,2)`, a trailing `--`
+  comment, an alias following `@result_N`, and generated-name collisions all
+  produce avoidable notebook failures.
+- Hiding a focused schema sidebar leaves the status at `NOTEBOOK · RESULTS`
+  with keyboard focus on an invisible Classic grid.
+- Disconnecting after a successful snapshot continues to show `SESSION
+  SNAPSHOT · COMPLETE`; restoring a saved, unchanged notebook immediately
+  produces an unsaved-changes prompt.
+- A configured editor binding such as `ctrl+s = execute_query` executes into
+  the hidden Classic grid instead of the notebook cell.
+
+Static and PostgreSQL probes additionally confirmed transaction, cancellation,
+eligibility, and resource-limit problems described below. Existing automated
+tests predominantly exercise the three-row snapshot happy path and do not
+cover these boundaries.
+
+## Prioritized findings
+
+### P0 - unblock delivery and protect user data
+
+#### P0.1 Reconcile the branch with current `master`
+
+PR #44 reports `mergeStateStatus: DIRTY`. `master` has two commits that are not
+in the notebook branch:
+
+- `c02e022 fix(schema): execute generated select query`
+- `802f092 feat(ui): maximize results with alt-m`
+
+`git merge-tree` reports overlapping changes in `README.md`,
+`crates/tsql/src/app/app.rs`, `crates/tsql/src/config/keymap.rs`,
+`crates/tsql/src/ui/confirm_prompt.rs`, and
+`crates/tsql/src/ui/help_popup.rs`, with actual conflict markers in `app.rs`.
+
+Implementation:
+
+- Rebase or merge current `master` before changing notebook behavior.
+- Preserve the new Classic results-maximization state and schema-table execution
+  behavior while retaining the notebook workspace/focus and target-aware
+  execution paths.
+- Add a small regression matrix for Classic `Alt+M`, schema-table selection,
+  notebook entry/exit, and switching modes during execution.
+
+Exit: the branch is mergeable and both newer Classic features work unchanged.
+
+#### P0.2 Make the execution coordinator and transaction state authoritative
+
+Relevant paths: `crates/tsql/src/app/execution.rs`,
+`crates/tsql/src/app/app.rs` (`DbEvent`, `execute_*`, `cancel_query`, and event
+handling).
+
+Problems:
+
+- `ROLLBACK TRANSACTION TO SAVEPOINT ...` is classified as a full rollback
+  because the classifier checks only whether the first remaining word is `TO`.
+  PostgreSQL keeps the transaction active. A later snapshot starts and commits
+  its transaction, which can commit the user's outer transaction. This was
+  verified against PostgreSQL 18.
+- On an in-flight source edit or deletion, success/error handling can return
+  before transaction reduction. A non-snapshot multi-statement cell can leave a
+  transaction open while the app continues to report `Idle`.
+- Classic completion/error/paging/metadata and cancellation events remain
+  unscoped. A delayed event from an old connection/execution can clear
+  `db.running`, overwrite current state, or permit a second execution.
+- A connection-global cancel can hit schema loading/cleanup while a notebook
+  query waits on the shared-client lock; the queued query can then execute and
+  publish successfully despite cancellation.
+
+Implementation:
+
+- Give every database event an execution ID, target, and connection generation;
+  reject stale events uniformly. Make one coordinator the source of truth
+  instead of independently mutating `db.running`, `active_query_kind`, and
+  `active_execution`.
+- Capture submitted SQL/transaction intent in the immutable active execution.
+  Always reduce transaction state from that captured SQL, even when the editor
+  revision or destination cell changes.
+- Correctly recognize optional `WORK`/`TRANSACTION` before `TO SAVEPOINT`,
+  conservatively mark ambiguous transaction-control-containing multi-statements
+  as unsafe, and refuse snapshot materialization whenever transaction safety is
+  uncertain.
+- Scope cancellation to the execution and check its cancellation flag after
+  acquiring the client lock but before dispatching SQL.
+
+Required tests:
+
+- savepoint rollback followed by snapshot and final rollback leaves no committed
+  user rows;
+- successful/failed in-flight edits and deletion still update transaction state;
+- stale Classic completion/error/cancel/paging events cannot affect a newer
+  notebook execution or connection;
+- cancel while schema load/cleanup owns the client lock prevents the queued
+  cell from running.
+
+#### P0.3 Never read or drop an untracked/replaced TEMP relation
+
+Relevant paths: snapshot execution/cleanup in `app.rs` and
+`crates/tsql/src/app/pg_snapshot.rs`.
+
+Problems:
+
+- Delete, clear, invalidation, and eviction issue `DROP TABLE IF EXISTS
+  pg_temp."name"` without verifying the recorded backend PID and relation OID.
+  If the original snapshot was dropped/recreated, or a pooler changes backend,
+  cleanup can delete an unrelated user TEMP table.
+- Dependent execution through `:run-without-snapshot`, an active transaction,
+  or another simple-query fallback compiles the physical TEMP name but skips
+  PID/OID validation. It can silently read a replacement relation.
+- Snapshot physical names contain only execution/revision information. A
+  leaked relation on a reused backend can collide with a fresh process.
+
+Implementation:
+
+- Centralize a conditional, identity-checked drop: under the same client lock,
+  compare `pg_backend_pid()` and `to_regclass(... )::oid`, drop only on exact
+  match, and report cleanup failures without destroying unknown objects.
+- Validate source identity immediately before every dependent execution,
+  including simple/no-snapshot paths.
+- Add a session nonce or collision-resistant component to generated physical
+  names while respecting the 63-byte identifier limit.
+
+Required tests: replace a backing relation under the same name, change backend
+identity, and simulate cleanup during an aborted transaction; no unrelated
+relation may be read or dropped.
+
+### P1 - snapshot and logical-reference correctness
+
+#### P1.1 Replace the three handwritten SQL scanners with one dialect-aware lexer
+
+Relevant paths: `execution.rs::single_statement`,
+`pg_snapshot.rs::snapshot_source`, and
+`refinement.rs::visit_logical_result_references`.
+
+The scanners duplicate quote/comment/semicolon logic and do not understand
+PostgreSQL escape strings. A valid `E'...'` containing a backslash-escaped
+quote, semicolon, comment marker, or apparent `@result_N` can be mis-tokenized
+and rejected before it reaches PostgreSQL. The new production scanners also
+contain unchecked `unwrap()` character advances.
+
+Implementation:
+
+- Introduce one small, tested PostgreSQL-aware lexical iterator that yields
+  structural tokens/ranges while skipping single/double quotes, escape strings,
+  dollar quotes, line comments, and nested block comments. Keep byte offsets
+  UTF-8-safe and use checked character advancement.
+- Reuse it for statement counting, transaction classification, logical-reference
+  detection/rewrite, and source-position mapping.
+- Do not run the SQL lexer over Mongo shell/JavaScript input. Until Mongo has a
+  provider, execute Mongo cells directly and report refinement unavailable.
+
+Required tests: `E'it\'s @result_1'`, escaped semicolons/comment markers,
+Unicode, dollar quotes, nested comments, multiple statements, Mongo template
+literals/`//` comments, and malformed input.
+
+#### P1.2 Make snapshot eligibility semantic and explicitly fall back before execution
+
+Relevant paths: `pg_snapshot.rs::snapshot_source`,
+`app.rs::execute_notebook_cell_with_snapshot`.
+
+Current eligibility checks tree validity and the first keyword. It admits
+`SELECT ... INTO` and data-changing CTEs, which prepare successfully but fail
+when nested in CTAS. It also routes pseudo-type/unbound-parameter queries into
+snapshot errors instead of executing them normally once. Conversely, the
+bundled grammar rejects standalone `VALUES` and `TABLE`, so two documented
+forms can never produce snapshots. Roles without TEMP privilege and hot
+standbys similarly fail valid SELECTs.
+
+Implementation:
+
+- Add a typed preflight result such as `Eligible`, `Ineligible(reason)`, and
+  `Invalid(error)`. Walk the semantic tree and reject data-changing CTEs,
+  `SELECT INTO`, locking/transaction/write statements, and unknown shapes.
+- Explicitly support or conservatively normalize `VALUES` and `TABLE` if they
+  remain part of the public contract.
+- Before materialization, check TEMP privilege/recovery state, output columns,
+  unbound parameters, and all PostgreSQL pseudo-types (including arrays such as
+  `record[]` and types such as `cstring`).
+- Route known-ineligible-but-valid queries to normal execution exactly once and
+  publish a precise unavailable reason. Never retry after materialization may
+  have executed user SQL.
+- Place a newline around interpolated source SQL in CTAS so a valid trailing
+  `-- comment` cannot comment out the wrapper suffix.
+
+Required tests: ordinary SELECT/read-only CTE/VALUES/TABLE; data-changing CTE,
+`SELECT INTO`, locking clauses, `record`, `record[]`, `cstring`, `$1`, TEMP
+denied, recovery/read-only, and trailing line comment.
+
+#### P1.3 Fix logical-result aliases, pinned identity, and dependency editing
+
+Relevant paths: `refinement.rs::compile_logical_reference`,
+`app.rs::resolve_notebook_result_dependency`, dependency rendering/actions.
+
+Problems:
+
+- Compilation always appends a generated alias. Natural SQL such as
+  `FROM @result_1 AS r` becomes two aliases and fails at `AS`.
+- When a live numbered dependency is evicted, resolution falls back to the
+  latest source result and silently rebases it. This violates immutable
+  lineage. Restored/unbound references and runtime-pinned-but-evicted
+  references need distinct states.
+- Removing the logical reference from a dependent cell leaves its dependency
+  pinned. The cell can never run independent SQL; clear/rebind/rebase do not
+  detach it.
+
+Implementation:
+
+- Preserve caller aliases or compile logical relations into collision-safe
+  generated CTEs; support explicit/shorthand aliases and repeated self-use.
+- Track whether lineage is restored/unbound versus live-pinned. Only the former
+  may automatically bind a source's latest result. An evicted live binding must
+  report an actionable `:rebase`/rerun error.
+- Clear lineage when an edit removes its last logical reference, or add an
+  explicit `:detach` action with clear UI feedback.
+
+Required tests: aliased/shorthand/self-joined references, pinned v1 followed by
+source v2 and v1 eviction, restored rebind, reference removal/replacement, and cyclic or
+malformed dependencies.
+
+#### P1.4 Make generated identifiers collision-safe and byte-correct
+
+Relevant path: `pg_snapshot.rs::normalize_column_names` and CTAS construction.
+
+Output normalization truncates by characters, not PostgreSQL's 63-byte limit,
+then appends `_2`, `_3`, and so on. Three duplicate 62-byte UTF-8 aliases were
+reproduced failing with `column ... specified more than once`. A user alias
+matching `__tsql_row_ordinal_<execution>` also collides with the internal
+ordinal column.
+
+Implementation:
+
+- Reserve the internal ordinal name and all suffix bytes before truncating.
+  Truncate at a valid UTF-8 boundary, then deduplicate the final emitted
+  identifier, not the pre-truncation candidate.
+- Apply the same byte budget to all generated relation/alias names.
+
+Required tests: empty names, three or more duplicates, 63-byte ASCII and
+multibyte aliases, quoted names, large suffixes, and ordinal-name collisions.
+
+### P1 - lifecycle, availability, and bounded results
+
+#### P1.5 Centralize snapshot publication, invalidation, deletion, and eviction
+
+Relevant paths: the three snapshot registries in `app.rs`,
+`NotebookQueryFinished`, delete/clear/reconnect, and result summaries.
+
+Problems:
+
+- Deleting a rerun source drops only its current output handle. Older immutable
+  versions remain registered/server-resident, contradict the delete prompt, and
+  keep pinned dependents runnable.
+- Completion registers a new snapshot before checking destination existence or
+  revision. An edited/deleted in-flight cell can insert an unreachable snapshot,
+  evict a useful one, and render `SUCCEEDED` with no output.
+- Eviction/invalidation changes `refinement` but leaves `output.retained`; the
+  UI continues to say `SESSION SNAPSHOT · COMPLETE`, `:rebase` can claim
+  success with a dead handle, and a newly published snapshot can be evicted
+  before its output is marked available.
+- The advertised LRU is FIFO: access/refinement never refreshes recency.
+  Publication order for `@result` and access order for eviction are distinct.
+
+Implementation:
+
+- Move registry/lifetime operations into a small snapshot manager indexed by
+  handle, result version, and source cell. Return whether publication survived
+  budget enforcement and expose one authoritative availability state.
+- Validate destination/revision before publication; conditionally drop any
+  discarded result. On source deletion, remove every version for that source;
+  keep rendered downstream output but mark reruns unavailable.
+- Remove duplicated `retained`/availability and unused error state from
+  `NotebookOutput`, or enforce a single invariant. Make badges, Refine, and
+  `:rebase` consult live registry state.
+- Implement a true access-order LRU and maintain separate publication order for
+  `@result`. Honor explicit zero limits predictably.
+
+Required tests: source reruns/deletion, clear tree, edited/deleted in-flight at
+capacity, reconnect/eviction/new-snapshot-immediate-eviction, real LRU access,
+zero limits, and no orphan relations.
+
+#### P1.6 Separate retention, display, and memory budgets; bound every execution path
+
+Relevant paths: `pg_snapshot.rs::execute`, simple/Mongo execution and result
+handling in `app.rs`, notebook result/grid state.
+
+Problems:
+
+- CTAS stages only `snapshot_max_rows + 1`. If the retention cap is lower than
+  the display cap, users lose legitimate display rows.
+- If a snapshot is complete but larger than the initial display cap, its
+  retained rows are not pageable: Result focus, search, copy, and export see
+  only the in-memory prefix. Metadata also reports `at least N+1` instead of
+  using the exact retained row count.
+- Non-snapshot Notebook queries use `simple_query`, which buffers the complete
+  server result before applying `max_rows`; Notebook bypasses Classic paging.
+  Large results can exhaust memory, and the configured timeout is not applied
+  consistently outside snapshot execution.
+- Oversized snapshots are read into the UI before being rejected; accumulated
+  cell grids have no aggregate display-memory budget.
+- Complete zero-row snapshots lose their column headers because headers are
+  inferred only from the first returned row.
+
+Implementation:
+
+- Stage up to the independently required display/retention row boundary while
+  keeping explicit byte safeguards. Decide retention before reading an
+  oversized result back into the UI and fetch only a byte-bounded preview.
+- Reuse cursor/portal paging or stream with a hard row/byte cutoff for ordinary
+  notebook queries; enforce timeout/cancellation consistently.
+- Add lazy paging against a retained snapshot so focused grids/search/export can
+  intentionally access all retained rows without loading them all at once.
+- Track fetched, exact total, and visible counts separately; use retained row
+  count when known and seed headers from prepared output metadata for zero-row
+  results.
+- Add an aggregate display-memory policy (evict/spill/collapse old previews)
+  separate from backend snapshot retention.
+
+Required tests: unequal display/retention caps, `N-1/N/N+1`, byte-cap boundary,
+zero rows with columns, snapshots off/ineligible/active transaction with large
+results, timeout/cancel, retained paging/search/export, and multiple large
+cells.
+
+### P2 - user-facing correctness, accessibility, and discoverability
+
+#### P2.1 Fix focus, editor parity, and prompts
+
+Relevant paths: focus/sidebar/editor dispatch and rendering in `app.rs`,
+`notebook.rs`, `ui/help_popup.rs`, and `ui/theme.rs`.
+
+Implementation:
+
+- When a focused sidebar is hidden in Notebook mode, return focus to the
+  notebook (preserving Cell/Result intent), never to an invisible Classic
+  Query/Grid. Make mode commands repair inconsistent focus if encountered.
+- Replace the temporary `self.editor` swap with explicit editor-target
+  dispatch. Configured notebook-editor actions such as `execute_query`,
+  `focus_grid`, and `goto_results` must target the notebook cell/result, not
+  hidden Classic state.
+- Populate notebook editor/shared history so the advertised `Ctrl-p/n` works.
+- Restore persisted cell editors as saved and track source dirtiness separately
+  from execution state. A restored `NEEDS RUN` cell is not automatically an
+  unsaved edit and must not trigger a false quit/connection prompt.
+- Use stable `cell.id` in deletion confirmation and count both bound and
+  textual/unbound numbered dependents. Keep cancellation semantics explicit:
+  `Ctrl+C` cancels a notebook run; `Esc` changes focus and must not unexpectedly
+  cancel from Cell focus.
+- Add `:notebook`, `:mode`, `:rebase`, `:rebind`, `:detach`, and
+  `:run-without-snapshot` to in-app Commands help. Clearly identify a running
+  notebook cell when viewing Classic mode.
+
+Required tests: hide sidebar from each section/subfocus, configured editor
+actions, editor history, restored unchanged notebook, stable/out-of-order cell
+IDs and unbound dependents, mode switch while running, and keyboard-only flows.
+
+#### P2.2 Restore editor visuals, useful errors, and theme/terminal fallbacks
+
+Notebook composers currently render plain text rather than the shared
+highlighted editor. SQL/Mongo syntax, search matches, logical-reference tokens,
+and Vim Visual selections are invisible; Visual operations can therefore be
+destructive without any selection cue. Long sources and errors are silently
+clipped, and partial light/custom themes fall back to hard-coded dark notebook
+styles.
+
+Implementation:
+
+- Reuse `HighlightedTextArea`/the shared highlighter for the visible composer
+  window, including cursor, Visual selection, search state, syntax scopes, and
+  a distinct logical-reference token. Avoid highlighting off-screen source.
+- Show explicit lines-above/lines-below or `+N lines` source indicators and a
+  clear horizontal-clipping cue. Keep state/source completeness visible at
+  60x20.
+- Replace flattened failure strings with a structured, inspectable/copyable
+  error view containing message, SQLSTATE, position, detail, and hint; wrap
+  inline errors and offer a detail action for long diagnostics.
+- Derive missing notebook theme scopes from the already-resolved background,
+  elevated background, text, muted, accent, warning, and grid styles. Add
+  light/partial-custom/monochrome and ASCII-safe disclosure/rail fallbacks.
+
+Required tests: Visual selection/search visibility, logical token styling,
+multiline/horizontal clipping, long errors at 60 columns, built-in dark/light,
+legacy partial custom theme, and no-Unicode/monochrome terminal behavior.
+
+### P2 - rendering and execution performance
+
+#### P2.3 Stop rendering hidden work and remove whole-document hot-path scans
+
+Relevant paths: the main render loop, notebook renderer, editor-key dispatch,
+snapshot classifier, and `tui-syntax` highlighter.
+
+Problems:
+
+- Every Notebook frame highlights/renders the hidden Classic editor/grid and
+  then clears it before rendering Notebook. Long Classic SQL remains expensive
+  at idle and running frame rates.
+- Each notebook-editor key clones and compares the complete SQL twice, even for
+  cursor motion.
+- Renderer availability construction repeatedly scans snapshot order and all
+  cells for every cell, producing approximately `O(retained * cells^2)` work per
+  frame. Unsaved-state checks and reference parsing repeatedly allocate/scan
+  full sources.
+- Composer rendering reserves capacity using the full line count despite
+  displaying only a small window, and compact summaries join the entire source.
+- Snapshot eligibility reparses SQL several times and comment masking uses
+  repeated `replace_range`, which is quadratic for many comments.
+
+Implementation:
+
+- Branch on workspace before Classic highlight/layout/render. Render only the
+  active workspace and only visible notebook cells/source windows.
+- Have editor actions report whether they mutated text; update revision/dirty
+  state without serializing the full buffer on navigation keys.
+- Maintain `latest_by_cell`, availability, dirty counts, and parsed logical
+  references by revision. Build per-frame lookup state once in `O(retained +
+  cells)` and bound summaries by visible width.
+- Classify once per execution, pass the validated source/preflight result
+  through completion, and build a comment-masked parser buffer in one pass.
+- Maintain aggregate retained-byte totals and batch validated cleanup where
+  possible. Add debug-only phase timings for classify, lock wait, materialize,
+  inspect, display, and cleanup.
+
+Required benchmarks: 100 clean cells, 100 long-source cells, a very long
+multiline composer, repeated cursor movement, focused-result navigation, and
+snapshot-off large-result execution. Record frame/input latency and peak memory.
+
+## Recommended next features
+
+These should follow the correctness/bounds work; each can ship independently.
+
+- **F1 - page retained results.** Make a complete snapshot genuinely
+  inspectable beyond the initial prefix without loading it all into memory.
+  Fetch a focused grid page from the retained TEMP relation, show exact
+  total/range, and preserve cursor/search/export semantics.
+- **F1 - Run All / run dependents.** Turn a notebook into a repeatable workflow
+  and remove manual rerun ordering. Build a dependency graph, run topologically
+  with one active execution, show progress/cancel, stop on error, and clear
+  stale downstream results.
+- **F2 - named and multiple result sources.** Make joins/comparisons readable
+  and remove the current one-source limitation. Add stable names and a parsed
+  set of references, validate each source/version, and support joins and
+  explicit aliases.
+- **F2 - notebook files: save/load/export/share.** Allow multiple reusable
+  investigations instead of one global session snapshot. Define a versioned
+  source/lineage-only file format, open/save/save-as, dirty indicator, and safe
+  migration.
+- **F2 - cell operations/outline.** Improve larger-document navigation and
+  composition with duplicate, move/reorder, insert above/below, collapse
+  source, outline/jump, and dependency-aware delete confirmation.
+- **F3 - rich error/result tools.** Improve diagnosis and sharing with error
+  detail/copy, explain action, export selected/full retained rows, and per-cell
+  execution history.
+- **F3 - Mongo refinement provider.** Extend the model without pretending SQL
+  semantics apply. Add typed bounded BSON snapshots, capability/version gating,
+  and explicit Mongo-specific reference compilation.
+
+`@result` should continue to mean latest *published* result. Accessing an older
+snapshot for LRU purposes must not change that meaning. Multiple-source and
+Run All work should use explicit result versions so a notebook remains
+reproducible.
+
+## Suggested implementation slices
+
+Keep the follow-up reviewable by landing these in order:
+
+1. **Merge current master and protect Classic regressions.** Resolve conflicts,
+   restore CI, and establish the combined baseline.
+2. **Execution coordinator/transaction safety.** Scope all events/cancellation,
+   fix transaction inference, and add concurrency/reconnect/savepoint tests.
+3. **Snapshot identity and lifecycle manager.** Conditional drops, simple-path
+   validation, publication/invalidation invariants, all-version deletion, and
+   real LRU.
+4. **Shared SQL lexer and semantic eligibility.** Escape strings/comments,
+   supported/rejected shapes, pseudo-types/parameters, privileges/recovery, and
+   safe pre-execution fallback.
+5. **Reference ergonomics and generated names.** Aliases, detach/edit behavior,
+   immutable eviction semantics, and UTF-8/ordinal collision safety.
+6. **Bounded results and retained paging.** Independent limits, streaming/simple
+   fallback, timeout, zero-row metadata, exact counts, and F1 paging.
+7. **Notebook UX/accessibility.** Focus/editor parity, prompts/history/help,
+   highlighting/selection, source/error cues, and theme/terminal fallbacks.
+8. **Performance pass.** Remove hidden rendering/whole-document work, cache
+   derived state, add benchmarks/phase timings, and set latency/memory budgets.
+9. **Workflow features.** Run All/dependents, named/multiple sources, notebook
+   files, and larger-document operations.
+
+## Validation matrix for the follow-up
+
+Use the existing targeted notebook/unit suite plus PostgreSQL integration and
+live tmux checks. At minimum, the completed follow-up should demonstrate:
+
+- Classic paging, query execution, schema actions, `Alt+M`, completion, history,
+  grid editing, reconnect, and cancellation still work.
+- Notebook source/refinement/latest-reference flows work with normal, aliased,
+  restored, evicted, edited, cleared, deleted, and reordered cells.
+- PostgreSQL tests cover read-only candidates, valid non-materializable SQL,
+  write-producing CTE/INTO exclusion, pseudo-types/parameters, trailing
+  comments/escape strings, zero rows, duplicate UTF-8 names, privilege/recovery,
+  exact row/byte boundaries, immutable versions, replaced relations, and
+  transaction/cancellation races.
+- Large results remain bounded with snapshots both on and off; focused retained
+  results can reach all retained rows without loading them all at once.
+- Keyboard-only, mouse, tmux, narrow 60x20, dark/light/partial custom theme,
+  and monochrome/ASCII terminal flows remain legible and usable.
+- A 100-cell notebook and long SQL composer meet explicit frame/input-latency
+  and memory targets without rendering hidden Classic content.
+
+No snapshot path may execute a user statement twice, silently redirect an
+immutable dependency, commit an unknown user transaction, read/drop an
+untracked relation, or buffer an unbounded server result in the TUI process.

--- a/docs/NOTEBOOK_MODE_PLAN.md
+++ b/docs/NOTEBOOK_MODE_PLAN.md
@@ -1,7 +1,7 @@
 # Notebook Mode Implementation Plan
 
-Status: proposed  
-Worktree: `/Users/fcoury/code/tsql.feat-notebook-mode`  
+Status: implemented (MVP)
+Worktree: `/Users/felipe.coury/code/tsql.ui-improvements`
 Branch: `feat/notebook-mode`  
 Base: `ui-improvements` at `d54379c`  
 Date: 2026-07-10
@@ -131,7 +131,7 @@ Visual rules:
 - Cell metadata is compact and secondary metadata disappears first at narrow
   widths.
 - Composer language is explicit: `SQL` for PostgreSQL and `MONGOSH` for Mongo.
-- Logical `@result_N` references render as a distinct lineage token even if the
+- Logical `@result` and `@result_N` references render as distinct lineage tokens even if the
   underlying SQL grammar marks `@` as nonstandard; completion can offer only
   result versions retained by the current notebook.
 - Output begins under the composer with the same indentation as OpenCode
@@ -195,7 +195,10 @@ never the only binding, because legacy terminals often cannot distinguish it.
 | Cell | execute and advance | `E`; modified Enter may be an alias |
 | Cell | select/create unrelated trailing draft | `n` |
 | Cell | refine selected result | `r` |
-| Cell | collapse/expand output | `z` |
+| Cell | collapse selected output | `h` |
+| Cell | expand selected output | `l` |
+| Cell | toggle output | `z` |
+| Cell | clear execution and dependent executions | `x`, confirm and preserve SQL/lineage |
 | Cell | delete cell | `dd`, confirm non-empty/executed cells |
 | Cell | page document | PageUp / PageDown, `Ctrl+U` / `Ctrl+D` |
 | Cell | return to trailing draft | `G` when draft is last |
@@ -320,8 +323,9 @@ The UI must distinguish:
   show `TXN`, snapshot refinement remains disabled, and the status tells the
   user to switch to Classic for COMMIT/ROLLBACK in the MVP.
 - On restart, restored cells contain source and lineage only. They render
-  `NEEDS RUN`; dependencies render `SOURCE UNAVAILABLE · run/rebase cell N`
-  because no output or PostgreSQL backend snapshot is persisted.
+  `NEEDS RUN`; dependencies render `SOURCE UNAVAILABLE · run cell N first`
+  because no output or PostgreSQL backend snapshot is persisted. Once the source
+  is rerun, a restored `@result_N` can bind its latest available snapshot.
 
 Deletion policy is locked: `dd` opens `ConfirmContext::DeleteNotebookCell` for
 any non-empty, executed, or dependency-bearing cell. The empty tail composer is
@@ -362,7 +366,7 @@ identity, and unfetched rows. It is therefore explicitly rejected for the MVP.
 
 ### 6.1 Database-neutral contract
 
-Notebook cells and logical `@result_N` references are database-neutral. The
+Notebook cells and logical `@result`/`@result_N` references are database-neutral. The
 active adapter supplies the retention and compilation behavior:
 
 ```rust
@@ -522,10 +526,12 @@ Before executing a snapshot candidate:
 
 1. Require PostgreSQL, a connected direct/session-affine client, safe
    transaction state, and snapshot feature enabled.
-2. Resolve structured `@result_<cell>` tokens outside literals/comments to
-   their immutable, safely quoted physical snapshot identifiers. A reference
-   without matching dependency metadata is an error, not free-form text
-   substitution.
+2. Resolve structured `@result`/`@result_<cell>` tokens outside literals/comments
+   to immutable, safely quoted physical snapshot identifiers. Bare `@result`
+   selects the latest completed refinable result for each execution. An unbound
+   or restored `@result_<cell>` selects the latest available snapshot from that
+   stable cell identity; a live numbered dependency remains pinned. Missing
+   sources fail before PostgreSQL with an actionable run-source message.
 3. Use the existing `tree-sitter-sequel` grammar on the compiled SQL as a
    conservative semantic
    classifier for statement shape, transaction control, data-changing CTEs,
@@ -608,8 +614,9 @@ zero), and call transaction commit or rollback. The SQL above illustrates the
 server sequence.
 
 Every successful backing table is immutable and revision-specific. The source
-cell exposes only a logical `@result_3` reference; dependency metadata binds it
-to cell 3/run 2 and compilation substitutes the collision-safe physical table.
+cell exposes a logical `@result_3` reference (or the latest-result alias
+`@result`); dependency metadata binds the chosen version to cell 3/run 2 and
+compilation substitutes the collision-safe physical table.
 No stable per-cell temp view is replaced, so a failed rerun cannot silently
 redirect an older dependency. Physical names stay out of normal UI, source
 history, and exported SQL unless a diagnostic view is requested.
@@ -1236,7 +1243,8 @@ Exit: acceptance criteria below pass and Classic regressions remain green.
 - snapshot eviction and disabled-reason transitions;
 - v1-to-v2 session migration and corrupt/future schema behavior;
 - restored source cells become `NEEDS RUN`; restored dependents become
-  `SOURCE UNAVAILABLE` until their exact source result is rerun/rebased;
+  `SOURCE UNAVAILABLE` until their source is rerun, then numbered references
+  bind its latest retained result;
 - capability dispatch selects only the active backend's provider and preserves
   its semantic label/dialect;
 - logical result references reject backend, connection-generation, and result-
@@ -1244,7 +1252,7 @@ Exit: acceptance criteria below pass and Classic regressions remain green.
 - native/client snapshot handle invalidation keeps display output while making
   dependent execution unavailable with a typed reason;
 - SQL-aware statement/semicolon classification;
-- `@result_N` rewriting ignores quoted identifiers, single/dollar-quoted
+- `@result`/`@result_N` rewriting ignores quoted identifiers, single/dollar-quoted
   strings, and line/block comments;
 - identifier quoting and duplicate/empty output-name normalization;
 - row/byte boundary decisions at `N-1`, `N`, and `N+1`.

--- a/docs/NOTEBOOK_MODE_PLAN.md
+++ b/docs/NOTEBOOK_MODE_PLAN.md
@@ -1,0 +1,1426 @@
+# Notebook Mode Implementation Plan
+
+Status: proposed  
+Worktree: `/Users/fcoury/code/tsql.feat-notebook-mode`  
+Branch: `feat/notebook-mode`  
+Base: `ui-improvements` at `d54379c`  
+Date: 2026-07-10
+
+## 1. Recommendation
+
+Add an opt-in `WorkspaceMode::Notebook` that replaces only the main
+query/results split. The existing connection/schema sidebar, overlays, and
+full-width status strip remain available.
+
+The notebook should combine two interaction models:
+
+- OpenCode's visual rhythm: elevated composer cards with a colored left rail,
+  sparse metadata, and responses rendered directly on a dark canvas.
+- Jupyter's document model: ordered cells, a selected-cell command state,
+  explicit editor and result focus, durable inline outputs, and top-to-bottom
+  navigation.
+
+For PostgreSQL refinement, the MVP should create a bounded, session-scoped
+temporary snapshot while the source cell is originally executed. A downstream
+cell then queries that snapshot with normal PostgreSQL SQL. This preserves
+PostgreSQL types, NULLs, custom types, and execute-once semantics.
+
+The notebook domain itself must not depend on PostgreSQL. It asks the active
+database adapter for one of four capabilities: native snapshot, bounded client
+snapshot, explicit live lineage, or unavailable. PostgreSQL is the first
+provider; SQLite can use connection-local TEMP tables when a SQLite driver is
+added; MongoDB can later use bounded retained BSON with `$documents`.
+
+Do **not** describe that implementation as an in-memory table. PostgreSQL temp
+tables are session-local but can use server storage. The UI should call it a
+`session snapshot` and show whether it is complete. Literal client-memory SQL
+would require a typed result layer plus a separate engine such as DataFusion or
+DuckDB; that is a later, explicitly labelled backend with different SQL
+semantics.
+
+## 2. Locked product decisions for the first release
+
+1. Classic mode remains the default and must remain behaviorally unchanged.
+2. `WorkspaceMode` is separate from the existing Vim `Mode` enum.
+3. The notebook owns one vertically scrolling document and at most one empty
+   trailing draft composer. Refine may insert a non-empty `NEEDS RUN` cell.
+4. Inputs look like OpenCode composers; outputs are unboxed on the canvas.
+5. Only one database execution runs at a time, but users may navigate and edit
+   other cells while it runs.
+6. Query errors are durable inline cell outputs, not global modal errors.
+7. Existing grid search/copy/export/detail behavior is reused for focused
+   notebook results. Result-row editing is deferred.
+8. Refinement is enabled only for a complete, retained result snapshot.
+9. A truncated/preview result is never silently exposed as a complete table.
+10. The MVP core ships a database-neutral refinement contract with PostgreSQL
+    as its first provider. Mongo cells may execute in notebook mode, but Refine
+    is initially disabled. SQLite refinement ships with SQLite driver support,
+    not as part of the PostgreSQL notebook milestone.
+11. Results and server snapshot handles are not persisted across app restarts.
+    Cell source, order, lineage, selection, and collapse state are persisted.
+12. Completing a query never steals focus or scroll position if the user has
+    navigated away.
+
+## 3. Goals and non-goals
+
+### Goals
+
+- Let users build an exploratory SQL narrative without replacing the current
+  database/session model.
+- Make `new query`, `edit and rerun`, and `refine this result` distinct actions.
+- Keep source, output, timing, completeness, and lineage visible together.
+- Preserve existing Vim editing, completion, history, AI assistance, schema
+  insertion, grid navigation, cancellation, and theming where applicable.
+- Remain usable at 60x20, responsive on wide terminals, keyboard-complete, and
+  understandable without color.
+- Provide exact, explicitly labelled snapshot semantics for every backend that
+  advertises a supported refinement provider.
+
+### Non-goals for the MVP
+
+- `.ipynb` compatibility or a general notebook file format.
+- Concurrent/background cell execution.
+- Automatic dependency-graph execution or reactive reruns.
+- Cell reordering, branching visualization, charts, or Markdown cells.
+- Editing database rows through a materialized notebook result.
+- Refining only the visible/truncated rows.
+- Silently rerunning an upstream query as a CTE.
+- Embedding DuckDB/DataFusion or emulating SQL filters in application code.
+- Adding SQLite or another database driver as part of the PostgreSQL notebook
+  milestone.
+- Supporting PostgreSQL transaction/statement poolers for snapshot refinement.
+
+## 4. UX specification
+
+### 4.1 Layout
+
+The main workspace becomes a borderless vertical document:
+
+```text
+ CONNECTIONS/SCHEMA     NOTEBOOK CANVAS
+ ──────────────────     ┃ CELL 1 · SQL · main/app · SUCCEEDED
+                        ┃ select customer_id, sum(total)
+                        ┃ from orders group by customer_id;
+                        ┃ Ctrl+E run · r refine · n new
+
+                          ✓ SELECT · 842 rows · 318ms
+                          SESSION SNAPSHOT · result 1.2 · COMPLETE
+                          customer_id │ sum
+                          ────────────┼────────
+                          1042        │ 918.20
+                          … 834 more · o inspect result
+
+                        ┃ CELL 2 · SQL · from cell 1/run 2 · NEEDS RUN
+                        ┃ select * from @result_1
+                        ┃ where sum > 500;
+                        ┃ Ctrl+E run · Esc cell mode
+
+                        ┃ DRAFT · SQL · main/app
+                        ┃
+                        ┃ Ctrl+E run · n new
+ ─────────────────────────────────────────────────────────────
+ NOTEBOOK · CELL · 2/3 · main/app · Ready
+```
+
+Visual rules:
+
+- The canvas uses `ui.notebook.canvas`, falling back to `ui.background`.
+- A composer uses an elevated surface, two columns of horizontal padding, one
+  top row of padding, and a left accent rail. Avoid a full box border.
+- The active cell has both an accent rail and a textual focus/state label.
+- Cell metadata is compact and secondary metadata disappears first at narrow
+  widths.
+- Composer language is explicit: `SQL` for PostgreSQL and `MONGOSH` for Mongo.
+- Logical `@result_N` references render as a distinct lineage token even if the
+  underlying SQL grammar marks `@` as nonstandard; completion can offer only
+  result versions retained by the current notebook.
+- Output begins under the composer with the same indentation as OpenCode
+  responses. It has no surrounding card or zone title.
+- Result tables retain header/separator styling but not the classic RESULTS
+  pane chrome.
+- A short document places the trailing draft near the bottom, like OpenCode's
+  composer. Once content exceeds the viewport, the draft is an ordinary final
+  document cell rather than a permanently fixed overlay.
+- Historical cells do not show a second blinking cursor while another cell is
+  being edited.
+
+### 4.2 One selected cell, three notebook focus states
+
+Notebook focus is an outer state; Vim mode remains an inner editor state:
+
+```rust
+enum NotebookFocus {
+    Cell,
+    Editor,
+    Result,
+}
+```
+
+The status strip must expose both layers:
+
+```text
+NOTEBOOK · CELL · 3/8
+NOTEBOOK · EDITOR · NORMAL · 3/8
+NOTEBOOK · EDITOR · INSERT · 3/8
+NOTEBOOK · RESULT · cell 3 · row 12/842 · col 4/19
+```
+
+Behavior:
+
+- `Cell`: keys operate on whole cells and move through the document.
+- `Editor`: the selected cell's `QueryEditor` receives existing Vim/editor
+  behavior.
+- `Result`: the selected cell's `GridState` receives existing grid behavior.
+- `Esc` from Result returns to Cell.
+- With Vim enabled, the first `Esc` in Insert returns to editor Normal; a
+  second `Esc` returns to Cell.
+- Async completion updates the target cell but does not change selection,
+  focus, or document scroll.
+- If another cell is already executing, Execute leaves the requested cell
+  unchanged and reports `cell N is running`; the MVP has no queue.
+
+### 4.3 Default notebook bindings
+
+All actions must be represented in `Action`, configurable through the keymap,
+and discoverable through help and `:` commands. Modified Enter may be an alias,
+never the only binding, because legacy terminals often cannot distinguish it.
+
+| Context | Action | Default |
+|---|---|---|
+| Cell | previous/next cell | `k` / `j`, Up / Down |
+| Cell | first/last cell | `gg` / `G`, Home / End |
+| Cell | enter editor | `Enter` or `e` |
+| Cell | inspect result | `o` |
+| Cell | execute in place | `Ctrl+E` |
+| Cell | execute and advance | `E`; modified Enter may be an alias |
+| Cell | select/create unrelated trailing draft | `n` |
+| Cell | refine selected result | `r` |
+| Cell | collapse/expand output | `z` |
+| Cell | delete cell | `dd`, confirm non-empty/executed cells |
+| Cell | page document | PageUp / PageDown, `Ctrl+U` / `Ctrl+D` |
+| Cell | return to trailing draft | `G` when draft is last |
+| Editor | execute in place | existing `Ctrl+E` |
+| Editor Normal | execute in place | existing `Enter` behavior |
+| Editor | leave editor | second `Esc` from editor Normal |
+| Result | leave result | `Esc` |
+| Any | cancel running query | existing `Ctrl+C`/cancel action |
+
+Footer hints show at most the two or three most relevant actions for the
+current focus. Never overload `Esc` as both leave-focus and cancel-query.
+
+### 4.4 New, rerun, and refine are separate
+
+**New query**
+
+- Selects the existing empty tail composer. If the tail contains source text,
+  preserve it as `NEEDS RUN` and append exactly one new empty tail composer.
+- Inherits live connection/database/transaction context only.
+- Has no dependency on an earlier result.
+- Shows `source: database`.
+
+**Edit and rerun**
+
+- Edits a historical cell in place.
+- The old output remains visible but is immediately labelled `STALE OUTPUT`.
+- Successful rerun replaces that cell's output and snapshot.
+- Failed/cancelled rerun does not present the old output as current.
+
+**Refine result**
+
+- Creates a cell immediately below the selected source cell.
+- Records a structural dependency on an immutable executed result version.
+- Prefills an immediately runnable PostgreSQL query:
+
+  ```sql
+  SELECT *
+  FROM @result_3
+  ```
+
+- Shows `from cell 3 · run 2 · PostgreSQL · session snapshot`.
+- If unavailable, `r` remains discoverable but reports a precise reason.
+- A source rerun never silently rebinds this dependency. Offer `rebase to cell
+  3 run 3` after a new source snapshot commits.
+
+### 4.5 Cell lifecycle and output contract
+
+Every rendered state/freshness badge uses text/symbols in addition to color:
+
+- `DRAFT`
+- `NEEDS RUN`
+- `DIRTY`
+- `RUNNING`
+- `SUCCEEDED`
+- `FAILED`
+- `CANCELLED`
+- `STALE OUTPUT`
+- `STALE DEPENDENCY`
+- `SOURCE UNAVAILABLE`
+- `SNAPSHOT EVICTED`
+
+Output completeness is independent of run status:
+
+```rust
+struct ResultExtent {
+    fetched_rows: usize,
+    total_rows: TotalRows,
+    retained_rows: Option<usize>,
+}
+
+enum TotalRows { Exact(usize), AtLeast(usize), Unknown }
+```
+
+The UI must distinguish:
+
+- `SESSION SNAPSHOT · COMPLETE · 842 rows` — refinement enabled.
+- `12 visible · 2,000 fetched · at least 2,001 total · no snapshot` —
+  refinement disabled. Visible rows, fetched rows, total extent, and retained
+  snapshot size are never conflated.
+- `LIVE QUERY` — a future explicit fallback that reruns upstream SQL.
+- `LOCAL MEMORY · DataFusion/DuckDB` — a possible future backend whose engine
+  and dialect must be named.
+
+### 4.6 Scrolling and result inspection
+
+- In Cell focus the document owns vertical wheel/page scrolling. In Editor
+  focus a composer capped by `composer_max_rows` and available viewport space
+  owns cursor-driven internal editor scrolling; page commands may still move
+  the document when explicitly invoked.
+- Selection is stable by `CellId`, never by screen row.
+- Use cell-aligned outer scrolling for the MVP. Composer/output caps guarantee
+  the selected cell fits; render only complete cells that fit rather than
+  restarting `HighlightedTextArea` or `DataGrid` inside a clipped rectangle.
+- Treat the short-document spacer that bottom-aligns the tail composer as
+  visual layout only, never as logical scroll height.
+- Cache measured heights to avoid jumps as off-screen cells update.
+- Auto-scroll only enough to reveal the selected composer or focused result.
+- A result preview is bounded to roughly 40% of the viewport, with a frozen
+  header and a visible range/footer.
+- Result focus activates its internal vertical/horizontal grid scrolling.
+- `Esc` returns scroll ownership to the document.
+- If a running off-screen cell updates, show a `↓ cell N updated` affordance;
+  do not jump to it.
+- Support independent collapse of source and output in the domain model, even
+  if source collapse ships after output collapse.
+
+### 4.7 Switching between Classic and Notebook
+
+- Keep independent Classic and Notebook workspace state; switching modes never
+  destroys the other workspace.
+- On the first switch to Notebook, copy a non-empty Classic editor buffer into
+  the initial notebook draft. Do not import the Classic grid as a refinable
+  result because no snapshot relation exists; show `run to create snapshot`.
+- Later switches restore the last selected cell, document scroll, and focus.
+- Switching while a cell runs is allowed after target-aware events land. The
+  status strip shows `notebook cell N running`; Classic execution remains
+  disabled until the single active execution finishes or is cancelled.
+- Leaving Notebook does not drop its retained snapshots. Disconnect/reconnect,
+  eviction, deletion, or backend-session close on app exit owns that lifecycle.
+- If Notebook is entered while Classic has an Active/Failed transaction,
+  ordinary cells may execute against that current transaction, but composers
+  show `TXN`, snapshot refinement remains disabled, and the status tells the
+  user to switch to Classic for COMMIT/ROLLBACK in the MVP.
+- On restart, restored cells contain source and lineage only. They render
+  `NEEDS RUN`; dependencies render `SOURCE UNAVAILABLE · run/rebase cell N`
+  because no output or PostgreSQL backend snapshot is persisted.
+
+Deletion policy is locked: `dd` opens `ConfirmContext::DeleteNotebookCell` for
+any non-empty, executed, or dependency-bearing cell. The empty tail composer is
+protected; deleting it clears its contents and leaves one empty tail. Deleting
+a source reports the dependent count, drops its tracked snapshots, preserves
+already-rendered downstream output, and marks dependent reruns
+`SOURCE UNAVAILABLE`.
+
+## 5. Why the current grid cannot become a safe relation
+
+The current execution path is globally single-target:
+
+```text
+QueryEditor
+  -> App::execute_query_text
+  -> async PostgreSQL/Mongo task
+  -> unaddressed DbEvent
+  -> App::apply_db_event
+  -> one global GridModel/GridState
+```
+
+The displayed result is insufficient for exact reconstruction:
+
+- `QueryResult` and `GridModel` store `Vec<Vec<String>>`.
+- `simple_query` returns text values.
+- SQL NULL is converted to the string `"NULL"`, making it indistinguishable
+  from an actual text value containing those four characters.
+- Arbitrary expression/CTE types are generally blank; metadata lookup only
+  works for simple extracted source tables.
+- Results beyond `effective_max_rows` are not held by the app.
+- BSON is also flattened into display strings.
+
+Rebuilding a relation with `VALUES`, JSON, or application filters would lose
+types, precision, arrays, custom/domain/composite values, binary data, NULL
+identity, and unfetched rows. It is therefore explicitly rejected for the MVP.
+
+## 6. Refinement backend architecture
+
+### 6.1 Database-neutral contract
+
+Notebook cells and logical `@result_N` references are database-neutral. The
+active adapter supplies the retention and compilation behavior:
+
+```rust
+enum RefinementCapability {
+    NativeSnapshot(RefinementProviderId),
+    ClientSnapshot(RefinementProviderId),
+    LiveLineage(RefinementProviderId),
+    Unavailable(RefinementUnavailableReason),
+}
+
+enum RefinementProviderId {
+    PostgresTemp,
+    SqliteTemp,
+    MongoDocuments,
+    LocalArrow,
+}
+
+struct RetainedResult {
+    provider: RefinementProviderId,
+    handle: RetainedResultHandle,
+    version: ResultVersion,
+    rows: usize,
+    retained_bytes: usize,
+    connection_generation: u64,
+}
+
+struct RetainedResultHandle(u64);
+
+struct CellOutput {
+    display: GridModel,
+    retained: Option<RetainedResult>,
+    // extent, execution metadata, provenance, and grid state omitted here
+}
+```
+
+`RetainedResultHandle` is opaque outside the provider registry and is never
+persisted. Provider managers map it to `PgTempSnapshot`,
+`SqliteTempSnapshot`, retained Mongo BSON, or a future Arrow object. Adding an
+adapter therefore extends provider dispatch without putting backend resource
+types in `NotebookCell`.
+
+The provider contract owns:
+
+- capability/preflight and a typed unavailable reason;
+- executing a source exactly once while retaining a complete result when
+  supported;
+- compiling a structural ResultVersion into an engine-specific source;
+- validating lifetime/connection provenance before use;
+- cancellation and cleanup;
+- row/byte retention accounting;
+- the user-visible semantic label and dialect.
+
+Provider selection follows this order:
+
+1. native connection/session snapshot in the source database dialect;
+2. bounded client snapshot re-submitted through a native typed mechanism;
+3. explicit live lineage that reruns upstream SQL/pipeline;
+4. unavailable with a precise reason.
+
+Never silently move a cell between these semantics. The composer/output badge
+must identify `SESSION SNAPSHOT`, `CONNECTION SNAPSHOT`, `CLIENT BSON SNAPSHOT`,
+`LIVE QUERY`, or `LOCAL MEMORY`, plus the active dialect.
+
+| Backend | First safe refinement provider | Initial status |
+|---|---|---|
+| PostgreSQL | session-local TEMP CTAS | Notebook MVP |
+| SQLite | connection-local TEMP CTAS | ships with future SQLite driver |
+| MongoDB 6.0+ | bounded retained BSON via `$documents` | follow-up; disabled in MVP |
+| Other SQL engines | adapter-proven native temp relation | per-driver |
+| Stateless/unsupported engines | explicit live lineage or none | disabled by default |
+
+#### SQLite provider (with SQLite driver support)
+
+SQLite should implement `NativeSnapshot`; it does not need PostgreSQL,
+DataFusion, or DuckDB for refinement. Keep one dedicated SQLite connection
+alive and execute database work on a dedicated blocking worker. Opening a new
+connection per cell would lose the `temp` schema and would create an unrelated
+database for `:memory:` connections.
+
+For an eligible query:
+
+```sql
+CREATE TEMP TABLE "__tsql_nb_<nonce>_3_2" AS
+SELECT *
+FROM (<validated SQLite SELECT>)
+LIMIT <snapshot_max_rows + 1>;
+```
+
+- retain native SQLite values (`NULL`, integer, real, text, blob), never
+  reconstruct from display strings;
+- bind `@result_3` to an immutable revision-specific table in `temp`;
+- use the same N+1 completeness rule and row/total retention budgets;
+- use CTAS-assigned ascending `rowid` for source delivery order in display,
+  while still requiring `ORDER BY` for relational guarantees;
+- snapshot only from proven autocommit state in the first version;
+- cancel with the SQLite interrupt handle/progress mechanism;
+- invalidate all handles when the dedicated connection closes or is replaced.
+
+Call this a `CONNECTION SNAPSHOT` by default. SQLite temporary tables may be
+memory-backed or file-backed according to its build and `PRAGMA temp_store`.
+Only label `LOCAL MEMORY` when the adapter can prove the effective
+`temp_store=MEMORY`; a `:memory:` main database alone does not prove where the
+separate temp database is stored. Set any desired temp-store policy at
+connection initialization; changing it after snapshots exist deletes temp
+objects.
+
+SQLite is not currently a TSQL backend. Its delivery therefore also requires a
+new DbKind/connection adapter, schema introspection, typed row decoding,
+dedicated-worker execution, and interrupt-driven cancellation. The notebook
+refinement contract should already accommodate it, but those driver concerns
+remain a separate feature track.
+
+#### MongoDB provider follow-up
+
+Do not use `$out` or `$merge` automatically: they write ordinary visible
+collections, require write permissions, and are not session-local snapshots.
+
+For MongoDB 6.0+, retain the original `Vec<Document>` before flattening it for
+GridModel. If the result is complete and below a conservative BSON byte cap, a
+refinement can compile to a database-level aggregation whose first stage is:
+
+```javascript
+{ $documents: <retained BSON documents> }
+```
+
+Subsequent stages use native MongoDB aggregation semantics. Label this
+`CLIENT BSON SNAPSHOT · MONGODB`; it is transferred back to the server for each
+refinement. MongoDB versions without `$documents`, oversized/incomplete
+results, and non-document outputs keep Refine disabled. A future live-pipeline
+fallback may rerun the upstream operation only through an explicit `LIVE`
+action.
+
+#### Future adapters and local engines
+
+An SQL adapter may use a native snapshot only if it proves relation lifetime,
+connection affinity, type fidelity, bounded retention, cancellation, and
+cleanup. A common local DataFusion/DuckDB fallback comes only after a typed
+CellValue/Arrow result layer exists. It must display the local engine/dialect
+and cannot silently reinterpret source-database SQL.
+
+### 6.2 PostgreSQL semantics
+
+An eligible cell is materialized **during its original execution**, not when a
+later Refine action is pressed. This guarantees that refinement observes the
+same snapshot shown to the user and does not rerun volatile SQL.
+
+PostgreSQL `CREATE TEMP TABLE AS` evaluates the query once and retains native
+types. Temporary tables survive commits with `ON COMMIT PRESERVE ROWS` and are
+dropped when the database session ends.
+
+### 6.3 PostgreSQL eligibility/preflight
+
+Add `SnapshotEligibility`; do not reuse the current first-token
+`is_row_returning_query` helper.
+
+Before executing a snapshot candidate:
+
+1. Require PostgreSQL, a connected direct/session-affine client, safe
+   transaction state, and snapshot feature enabled.
+2. Resolve structured `@result_<cell>` tokens outside literals/comments to
+   their immutable, safely quoted physical snapshot identifiers. A reference
+   without matching dependency metadata is an error, not free-form text
+   substitution.
+3. Use the existing `tree-sitter-sequel` grammar on the compiled SQL as a
+   conservative semantic
+   classifier for statement shape, transaction control, data-changing CTEs,
+   `SELECT ... INTO`, and SQL-aware source/reference ranges. Unknown or
+   error-containing trees are non-materializable. `Client::prepare` and CTAS
+   remain the PostgreSQL authorities.
+4. Call `Client::prepare` on the compiled SQL. Extended protocol rejects
+   multiple statements and exposes output columns and PostgreSQL `Type`
+   metadata without executing the query.
+5. Require no unbound parameters and at least one output column.
+6. Initially accept one `SELECT`, read-only `WITH ... SELECT`, `VALUES`, or
+   `TABLE` statement.
+7. Reject `SELECT ... INTO`, locking clauses (`FOR UPDATE/SHARE`), `SHOW`,
+   `EXPLAIN`, `COPY`, transaction control, DML/DDL, data-changing CTEs, and
+   `INSERT/UPDATE/DELETE/MERGE ... RETURNING` in the first release.
+8. Reject pseudo output types such as anonymous `record` or `void` from
+   snapshotting. Because prepare discovers these before execution, run the
+   source normally once and mark it non-refinable.
+9. Normalize empty/duplicate output names through an explicit CTAS column list
+   (`id`, `id_2`, `column_3`) and show those names in the output.
+10. Enforce PostgreSQL's 63-byte identifier limit on generated table/column
+    names. Reserve suffix space before UTF-8-safe truncation so normalized
+    duplicates remain unique.
+11. Use a SQL-aware trailing-semicolon scanner. Do not use
+   `trim_end_matches(';')` or reject semicolons inside strings/comments.
+12. Check known capabilities with
+   `has_database_privilege(current_database(), 'TEMP')` and
+   `pg_is_in_recovery()`. The actual CTAS remains authoritative.
+
+If eligibility is known to be unavailable before execution, run normally and
+return a non-refinable result. If an attempted snapshot fails unexpectedly, do
+not automatically rerun the source normally: volatile/nontransactional effects
+such as sequence advancement might happen twice. Offer an explicit `Run without
+snapshot` action.
+
+### 6.4 PostgreSQL bounded transactional flow
+
+Configuration defaults:
+
+```toml
+[notebook]
+snapshot_mode = "auto" # auto | off
+snapshot_max_rows = 2000
+snapshot_max_bytes = 67108864
+snapshot_total_bytes = 134217728
+max_retained_snapshots = 8
+composer_max_rows = 10
+output_preview_rows = 12
+live_refinement_fallback = false
+```
+
+For cell 3, run 2:
+
+```sql
+-- transaction started by tokio_postgres::Client::transaction()
+SET LOCAL statement_timeout = <configured milliseconds>;
+
+CREATE TEMP TABLE "__tsql_nb_<nonce>_3_2" (
+    "__tsql_row_ordinal_<nonce>", "id", "name", "total"
+) ON COMMIT PRESERVE ROWS AS
+SELECT row_number() OVER (), "__tsql_source".*
+FROM (
+    <validated source SQL>
+) AS "__tsql_source"
+LIMIT <snapshot_max_rows + 1>;
+
+-- Inspect row count and pg_total_relation_size(...).
+-- Fetch rows for display in stable ordinal order:
+SELECT "id", "name", "total"
+FROM pg_temp."__tsql_nb_<nonce>_3_2"
+ORDER BY "__tsql_row_ordinal_<nonce>";
+
+-- transaction committed through the Rust transaction handle
+```
+
+Use exactly one transaction mechanism: acquire the mutable SharedClient guard,
+create `tokio_postgres::Transaction`, issue `SET LOCAL statement_timeout` from
+`connection.query_timeout_secs` when nonzero (skip the statement when it is
+zero), and call transaction commit or rollback. The SQL above illustrates the
+server sequence.
+
+Every successful backing table is immutable and revision-specific. The source
+cell exposes only a logical `@result_3` reference; dependency metadata binds it
+to cell 3/run 2 and compilation substitutes the collision-safe physical table.
+No stable per-cell temp view is replaced, so a failed rerun cannot silently
+redirect an older dependency. Physical names stay out of normal UI, source
+history, and exported SQL unless a diagnostic view is requested.
+
+The worker holds the existing SharedClient mutex, publishes only after the
+transaction has finished, and explicitly rolls back every materialization
+error/cancellation path before releasing the guard. Generated wrapper errors
+retain an internal/source classification, and PostgreSQL source positions are
+remapped through a source map covering both wrapper offsets and expanded
+`@result_N` tokens back into cell coordinates.
+
+Limit behavior:
+
+- `rows <= snapshot_max_rows` and bytes within budget: complete snapshot;
+  commit relation and enable Refine.
+- `rows == snapshot_max_rows + 1`: fetch up to the GridModel/connection row
+  limit, drop staging inside the transaction, commit, label Preview, and
+  disable Refine.
+- byte limit exceeded: fetch the bounded display result, drop staging, commit,
+  and disable Refine.
+- later, an explicit `Refine first N preview rows` may be added, but it must not
+  be called a complete snapshot.
+
+Do not roll back an otherwise successful source solely because it exceeded a
+retention limit: SELECT can call state-changing functions, so commit versus
+rollback must not depend on result size. Rollback is reserved for execution,
+materialization, cancellation, or cleanup errors.
+
+`output_preview_rows` is only the on-screen result viewport height.
+`connection.max_rows` bounds rows fetched into GridModel/search/export/detail.
+`snapshot_max_rows + 1` decides whether a complete snapshot may be retained.
+They are independent and all four quantities (visible, fetched, total,
+retained) are shown accurately.
+
+The hidden ordinal preserves source delivery order for display and is omitted
+from the public view. Tables remain logically unordered: a refinement whose
+result order matters must still include its own `ORDER BY`.
+
+### 6.5 PostgreSQL transaction safety prerequisite
+
+`DbSession::in_transaction` is currently unreliable: `CommandComplete` is
+converted to `"N rows"`, then later code looks for tags beginning with `BEGIN`,
+`COMMIT`, or `ROLLBACK`.
+
+Before snapshot execution:
+
+- introduce `TransactionState::{Idle, Active, Failed, Unknown}`;
+- initialize Idle only on a fresh connection;
+- use the conservative SQL classifier on every submitted statement, including
+  `COMMIT/ROLLBACK ... AND CHAIN`;
+- move unclassified multi-statements, `CALL`, and ambiguous control flow to
+  Unknown;
+- mark errors inside an active transaction as Failed;
+- reset on connection generation changes;
+- prohibit snapshot execution unless state is Idle;
+- prohibit manual transaction-control cells in Notebook MVP, while Classic
+  retains existing commands;
+- never let an internal snapshot `COMMIT` commit a user transaction.
+
+Recover Failed/Unknown only through a successfully classified ROLLBACK or a new
+connection. `tokio-postgres` does not expose the wire protocol's ReadyForQuery
+transaction byte through this path, so optimistic inference is not acceptable.
+The conservative reducer is: BEGIN/START -> Active; successful plain
+COMMIT/ROLLBACK -> Idle; `AND CHAIN` -> Active; any database error while Active
+-> Failed; ambiguous/multi-statement/CALL -> Unknown.
+
+The app-owned snapshot transaction is safe only after this prerequisite. A
+later design may support snapshots created inside user transactions with
+explicit rollback invalidation.
+
+### 6.6 PostgreSQL connection affinity and validation
+
+Each retained snapshot records:
+
+```rust
+struct PgTempSnapshot {
+    result_version: ResultVersion,
+    logical_reference: String,
+    physical_name: String,
+    relation_oid: u32,
+    connection_generation: u64,
+    backend_pid: i32,
+    row_count: usize,
+    byte_size: u64,
+}
+```
+
+Before running a refinement, validate the same backend and relation:
+
+```sql
+SELECT pg_backend_pid(),
+       to_regclass('pg_temp.__tsql_nb_<nonce>_3_2');
+```
+
+Perform validation and the downstream materialization inside the same database
+transaction so no validation/use race exists. Compare the resolved relation
+OID as well as backend PID/generation; never drop an untracked object and never
+use `CASCADE` during cleanup.
+
+Invalidate refinement handles on disconnect, reconnect, connection loss,
+backend PID change, notebook clear, cell deletion, eviction, or missing
+relation. Keep the old display snapshot visible with `SNAPSHOT EVICTED`.
+
+PgBouncer transaction and statement pooling are incompatible with cross-cell
+temp state. Exact refinement requires a direct PostgreSQL connection or
+PgBouncer session pooling. `SHOW pool_mode` is generally limited to PgBouncer's
+admin console, so detection is best-effort and cannot prove future affinity.
+Add a saved-connection capability `temp_relations = auto | session | disabled`:
+`session` is an explicit user assertion, `disabled` covers transaction/statement
+poolers, and `auto` performs probes plus use-time validation while labelling the
+capability best-effort. Surface a precise reason when affinity is lost.
+
+### 6.7 PostgreSQL cancellation and cleanup
+
+- Give every run an `ExecutionId`; cancellation and completion are matched by
+  execution, cell, revision, and connection generation.
+- A cancel request is best-effort. Do not emit final `Cancelled` immediately;
+  wait for the query future/server response.
+- Roll back the staging transaction on cancel/error.
+- Keep prior immutable result versions only while retention permits; a failed
+  rerun never redirects dependents away from their recorded version.
+- On cell deletion/eviction, best-effort drop tracked backing tables.
+- PostgreSQL backend-session teardown is the final cleanup guarantee. A
+  frontend disconnect through a proxy does not necessarily terminate/reset the
+  backend, which is another reason pooled temp relations require explicit care.
+- Keep total retained snapshots within a configurable LRU budget. Never evict a
+  currently running source; mark dependents stale when a required source is
+  evicted.
+
+PostgreSQL's `temp_file_limit` does not cover explicit temp tables. The row cap,
+post-creation `pg_total_relation_size` check, LRU budget, statement timeout, and
+server-side permissions are the practical safeguards. The byte check limits
+retained size, not peak staging allocation.
+
+### 6.8 PostgreSQL refinement fallback matrix
+
+| Situation | Execute cell | Refine |
+|---|---:|---:|
+| Complete eligible PostgreSQL result | yes | session snapshot |
+| Result exceeds row/byte cap | preview | disabled with limit reason |
+| PostgreSQL lacks TEMP privilege | normal execution | disabled |
+| Hot standby/read-only server rejects temp DDL | normal execution | disabled |
+| Active/failed/unknown user transaction | normal execution | disabled |
+| Multi-statement or non-materializable output | normal execution | disabled |
+| Pseudo output type known from prepare | one normal execution | disabled |
+| Unexpected CTAS failure after attempt | no automatic rerun | explicit retry without snapshot |
+| Connection changed/backend missing | keep display | stale/disabled |
+| PgBouncer transaction/statement pooling | normal execution | disabled |
+| MongoDB | normal notebook execution | disabled |
+
+Disabled reasons are typed domain values, not ad hoc status strings.
+
+## 7. Application architecture
+
+### 7.1 Domain model
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct CellId(u64);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct ExecutionId(u64);
+
+enum WorkspaceMode {
+    Classic,
+    Notebook,
+}
+
+struct NotebookState {
+    cells: Vec<NotebookCell>,
+    selected: CellId,
+    focus: NotebookFocus,
+    scroll: NotebookScroll,
+    next_cell_id: u64,
+    tail_follow: bool,
+}
+
+struct NotebookCell {
+    id: CellId,
+    revision: u64,
+    language: CellLanguage,
+    editor: QueryEditor,
+    editor_scroll: (u16, u16),
+    execution: CellExecutionState,
+    freshness: SourceFreshness,
+    output: Option<CellOutput>,
+    dependency: DependencyState,
+    collapse: CellCollapse,
+}
+
+struct ResultVersion {
+    source_cell: CellId,
+    source_execution: ExecutionId,
+    source_revision: u64,
+}
+
+enum CellLanguage { PostgresSql, SqliteSql, MongoShell }
+enum CellExecutionState {
+    NeverRun,
+    Running(ActiveCellRun),
+    Succeeded(CompletedCellRun),
+    Failed(CompletedCellRun, QueryFailure),
+    Cancelled(CompletedCellRun),
+}
+enum SourceFreshness { Clean, Dirty }
+enum DependencyState {
+    None,
+    Available(ResultVersion),
+    SourceDirtyButVersionRetained(ResultVersion),
+    Unavailable(ResultVersion, RefinementUnavailableReason),
+}
+
+struct CellOutput {
+    grid: GridModel,
+    grid_state: GridState,
+    extent: ResultExtent,
+    retained: Option<RetainedResult>,
+    refinement: RefinementAvailability,
+    command_tag: Option<String>,
+    elapsed: Duration,
+    executed_sql: String,
+    executed_revision: u64,
+    provenance: ExecutionProvenance,
+}
+
+struct ActiveCellRun {
+    context: ExecutionContext,
+    execution_count: u64,
+    started_at: Instant,
+    provenance: ExecutionProvenance,
+}
+
+struct CompletedCellRun {
+    context: ExecutionContext,
+    execution_count: u64,
+    started_at: SystemTime,
+    elapsed: Duration,
+    provenance: ExecutionProvenance,
+}
+
+struct ExecutionProvenance {
+    backend: DbKind,
+    saved_connection: Option<String>,
+    connection_generation: u64,
+    backend_pid: Option<i32>,
+    database: String,
+    schema: Option<String>,
+    transaction_state: TransactionState,
+}
+```
+
+`QueryEditor` currently owns its own history cursor. Extract reusable editor
+buffer state from history navigation so every cell does not duplicate history.
+Persistent `History` remains app-level and history selection targets the active
+cell.
+
+These dimensions are intentionally orthogonal: a cell can be Running while an
+older output is stale, or have a valid already-produced output while its source
+snapshot has been evicted. Render label priority is `RUNNING`, `FAILED`,
+`CANCELLED`, `DIRTY`, `STALE DEPENDENCY`, `NEEDS RUN`, then `SUCCEEDED`; output
+and snapshot badges remain visible as secondary state.
+
+Every editor mutation must go through a revision-aware cell API. Direct
+textarea input, completion, AI acceptance, history loading, schema insertion,
+external-editor return, and query replacement all increment revision and
+recompute output/dependency freshness consistently.
+
+A historical cell is bound to its recorded connection provenance. If the live
+connection/database differs, Execute prompts for an explicit rebind (or asks
+the user to reconnect); it never silently runs the cell against a different
+database. A dependent may continue using its immutable prior ResultVersion
+while that snapshot is retained, even if the source cell is now dirty or a
+rerun failed. A newly committed source result is adopted only through explicit
+rebase. Eviction disables future dependent reruns but does not invalidate an
+already-produced downstream output.
+
+### 7.2 Target every asynchronous operation
+
+The current `DbEvent` variants have no request/cell identity. Introduce:
+
+```rust
+enum ExecutionTarget {
+    Classic,
+    Notebook(CellId),
+}
+
+struct ExecutionContext {
+    id: ExecutionId,
+    target: ExecutionTarget,
+    source_revision: u64,
+    connection_generation: u64,
+}
+```
+
+Carry `ExecutionContext` on QueryFinished, QueryError, QueryCancelled,
+RowsAppended, and MetadataLoaded. Ignore any event whose execution, revision,
+cell, or connection generation is no longer current.
+
+Replace `DbSession::running: bool` and `active_query_kind` with one
+`Option<ActiveExecution>`. Keep one active query globally for the MVP. Allocate
+ExecutionId and display execution counts in the app/execution coordinator, not
+inside NotebookState, so Classic and Notebook share one identity namespace.
+
+Notebook MVP does not retain a server-side pager per historical cell. It
+fetches at most the configured GridModel row limit, closes/drains any cursor,
+and publishes a bounded durable result. Classic keeps its existing pager.
+Classic `RowsAppended` events validate against the execution ID stored with the
+target pager even after foreground ActiveExecution has cleared.
+
+Move command tag, elapsed time, executed SQL, provenance, and completeness into
+the target CellOutput/CompletedCellRun. During migration, global
+`DbSession.last_command_tag`, `last_elapsed`, `last_executed_query`, and
+`paged_query` remain Classic-only presentation state.
+
+Completion, history, AI acceptance, schema template insertion, external editor,
+search, confirm prompts, JSON/row detail, and future cell edits also need an
+explicit target captured when the action opens:
+
+```rust
+enum EditorTarget { Classic, Notebook(CellId) }
+enum ResultTarget { Classic, Notebook(CellId) }
+```
+
+This prevents a modal or async response from mutating whichever cell happens to
+be selected later.
+
+Integrate global focus as `Focus::Notebook` plus `NotebookState.focus`; update
+`focus_navigation_action`, `set_focus`, pane cycling, sidebar directional
+navigation, Focus::label, and terminal cursor-style selection. In Notebook,
+route Esc through NotebookFocus before the current global Escape handler:
+Insert -> Normal -> Cell and Result -> Cell never cancel a query. Ctrl+C remains
+the explicit notebook cancellation path.
+
+Add central `workspace_has_unsaved_changes()` and target-aware
+`query_editor_has_content()` helpers before replacing direct Classic checks in
+quit and connection-switch confirmation paths.
+
+Command semantics in Notebook:
+
+- `:refresh` reruns the selected executed cell in place;
+- global UI/connection commands remain global and do not create output cells;
+- schema templates, history selection, and AI proposals populate the selected
+  editor target without executing;
+- Mongo helper/query commands execute into the selected MongoShell cell;
+- export/generate/detail commands read the selected ResultTarget;
+- only user-authored source enters History, never generated CTAS, validation,
+  snapshot cleanup, or display-select SQL.
+
+On explicit disconnect, advance/invalidate connection generation, close pager
+channels, resolve the active execution safely, and invalidate all snapshot
+handles so late events cannot apply.
+
+### 7.3 Rendering decomposition
+
+`app.rs` is already the main integration risk. Extract before adding notebook
+branches:
+
+```text
+App::run
+  render_app
+    render_sidebar
+    render_classic_workspace
+    render_notebook_workspace
+    render_status
+    render_overlays
+```
+
+Add `ui/notebook.rs` with:
+
+- pure cell measurement;
+- logical-to-screen viewport translation;
+- composer rendering;
+- inline output/error/status rendering;
+- cell-aligned visible-range rendering (move to slice-aware/offscreen-buffer
+  virtualization only if smooth row scrolling is added later);
+- focus/cursor placement;
+- mouse hit testing through `NotebookLayoutSnapshot`.
+
+Refactor `DataGrid` into reusable chrome and body layers:
+
+- `DataGrid` keeps the classic zone wrapper;
+- `GridViewport` renders header/body/scrollbar without a zone;
+- both consume the same `GridModel`, `GridState`, and `UiTheme`.
+
+Replace global `render_query_area`/`render_grid_area` assumptions in notebook
+mode with per-cell rectangles keyed by CellId and region.
+
+### 7.4 Theme additions
+
+Add component-merged scopes with fallbacks to the existing tonal theme:
+
+- `ui.notebook.canvas`
+- `ui.notebook.composer`
+- `ui.notebook.composer.focused`
+- `ui.notebook.rail`
+- `ui.notebook.output`
+- `ui.notebook.output.header`
+- `ui.notebook.meta`
+- `ui.notebook.stale`
+
+Every built-in theme gets coherent values. When a custom theme omits these
+scopes, UiTheme resolution explicitly uses the corresponding existing
+`ui.background`, `ui.background.elevated`, `ui.text`, `ui.text.muted`,
+`ui.accent`, `ui.warning`, and `ui.grid.header` values; unrelated theme scopes
+do not inherit automatically.
+
+### 7.5 Structured errors
+
+The current pipeline flattens PostgreSQL errors into a string. Add a structured
+`QueryFailure` carrying severity, SQLSTATE, message, position, detail, and hint
+where available. Classic mode may continue showing its modal; Notebook renders
+the same diagnostic inline and durably.
+
+## 8. File-by-file implementation map
+
+Current load-bearing hotspots (line numbers are from `d54379c`):
+
+- `app.rs:728-790`: `QueryResult` and `PagedQueryState`;
+- `app.rs:2110`: targetless `DbEvent`;
+- `app.rs:2205`: `DbSession`;
+- `app.rs:2431`: global `App` editor/grid state;
+- `app.rs:2970`: main render/event loop;
+- `app.rs:3751`: key routing and modal precedence;
+- `app.rs:4555-4840`: global query/grid mouse rectangles;
+- `app.rs:9449-10330`: PostgreSQL/Mongo execution;
+- `app.rs:10389`: global event application;
+- `app.rs:10774`: status-line composition;
+- `ui/editor.rs:83`: `QueryEditor`;
+- `ui/grid.rs:193`: `GridState`, with `GridModel`/`DataGrid` later in the file;
+- `app/state.rs:1`: focus and mode definitions;
+- `config/keymap.rs:11`: action/keymap definitions;
+- `session.rs:18`: versioned session persistence.
+
+### Existing files
+
+- `crates/tsql/Cargo.toml`
+  - add direct `tree-sitter`/`tree-sitter-sequel` dependencies for conservative
+    statement classification and logical-reference rewriting.
+- `crates/tsql/src/app/state.rs`
+  - add `WorkspaceMode`, notebook focus integration, transaction state, and
+    target identifiers/re-exports.
+- `crates/tsql/src/app/app.rs`
+  - shrink rendering/execution blocks; route workspace, targets, commands,
+    events, connection invalidation, and status.
+- `crates/tsql/src/ui/editor.rs`
+  - separate per-buffer editing from global history navigation.
+- `crates/tsql/src/ui/grid.rs`
+  - derive/move reusable result model state and extract borderless grid body.
+- `crates/tsql/src/ui/theme.rs`
+  - resolve notebook styles and helpers with explicit fallbacks from existing
+    UiTheme fields; unrelated theme scopes do not inherit automatically.
+- `crates/tsql/src/ui/mod.rs`
+  - register notebook widgets and result body.
+- `crates/tsql/src/config/keymap.rs`
+  - add notebook cell actions, `KeymapConfig.notebook`, a Notebook Cell-focus
+    keymap, and `App::build_notebook_keymap`; Editor/Result reuse existing maps.
+- `crates/tsql/src/config/schema.rs`
+  - add startup workspace and `[notebook]` retention/render settings.
+- `crates/tsql/src/session.rs`
+  - bump schema version; persist notebook source/order/lineage/collapse only.
+- `crates/tsql/src/main.rs`
+  - restore workspace and optionally accept `--notebook` after the mode is
+    stable.
+- `crates/tsql/src/ui/help_popup.rs`
+  - context-sensitive Cell/Editor/Result help.
+- `crates/tsql/src/ui/confirm_prompt.rs`
+  - add target-stable notebook deletion/rebind confirmations.
+- `crates/tsql/src/config/connections.rs`
+  - store optional temp-relation/session-affinity capability for saved
+    connections.
+- `README.md` and `config.example.toml`
+  - document mode, semantics, limits, pool compatibility, and bindings.
+
+### New files/modules
+
+- `crates/tsql/src/app/notebook.rs`
+  - notebook reducer/state transitions, dirty/stale propagation, cell actions,
+    persistence conversion.
+- `crates/tsql/src/app/refinement.rs`
+  - database-neutral capability, opaque `RetainedResultHandle` registry,
+    structural logical references, provider dispatch, validation/cleanup
+    contract, and shared unavailable reasons.
+- `crates/tsql/src/ui/notebook.rs`
+  - measurement, viewport, composer/canvas/output rendering, hit map.
+- `crates/tsql/src/app/execution.rs`
+  - target-aware query request/event orchestration shared by Classic/Notebook.
+- `crates/tsql/src/app/pg_snapshot.rs`
+  - PostgreSQL implementation of the refinement contract: capability probe,
+    prepare/eligibility, logical-result compilation, CTAS transaction,
+    validation, cleanup, and typed unavailable reasons.
+
+Future driver tracks add `sqlite_snapshot.rs` and `mongo_snapshot.rs` only when
+their database adapters land. Provider-specific snapshot resource types remain
+inside their managers and never enter `NotebookCell`.
+
+Register both through `app/mod.rs`; do not introduce an otherwise-empty `db`
+module in this feature. Put PostgreSQL DbError extraction/position remapping
+with the execution layer and reuse it from the existing `format_pg_error` path.
+
+Do not put the entire notebook renderer or snapshot manager back into
+`app.rs`.
+
+## 9. Phased delivery plan
+
+Each phase should be a reviewable conventional commit, preserve Classic mode,
+run formatting/clippy/unit tests, and avoid committing `.aidocs`.
+
+### Phase 0 — Spikes and characterization
+
+- Add characterization tests around classic execution, paging, cancellation,
+  transaction commands, focus, and session restore.
+- Prove `Client::prepare` metadata for SELECT/WITH/VALUES/TABLE and rejection of
+  multiple statements/pseudo types.
+- Prove bounded CTAS, duplicate-column normalization, immutable result-version
+  binding, cancellation rollback, volatile execute-once behavior, and type
+  fidelity on supported PostgreSQL versions.
+- Confirm PgBouncer behavior or add a reproducible compatibility fixture.
+- Lock `tree-sitter-sequel` classification, `@result_N` compilation, physical
+  identifier length/escaping, and error-position remapping rules.
+
+Exit: no user-visible changes; hard constraints are captured in tests.
+
+### Phase 1 — Target-aware execution seam
+
+- Add `ExecutionId`, `ExecutionTarget`, `ExecutionContext`, and
+  `ActiveExecution`.
+- Tag every query/paging/metadata/cancel event.
+- Ignore stale run/connection events.
+- Fix cancellation finalization and transaction-state tracking.
+- Extract execution orchestration from `app.rs` while keeping Classic behavior.
+- Make paged cursor names execution-specific for Classic, or explicitly retain
+  one pager with assertions.
+
+Exit: full existing test suite passes; Classic UI is unchanged.
+
+### Phase 2 — Notebook domain and persistence
+
+- Add `WorkspaceMode`, `NotebookState`, `NotebookCell`, lifecycle reducer, and
+  at-most-one empty trailing draft invariant.
+- Add the database-neutral `RefinementCapability`, `RetainedResult`, logical
+  `ResultVersion`, and typed unavailable-reason contract. No provider is
+  enabled in this phase.
+- Add `EditorTarget`/`ResultTarget` and active-target accessors.
+- Add notebook actions/keymap internally, but do not expose a startup/switching
+  path until a minimally usable renderer exists.
+- Bump session schema and migrate v1 safely.
+- Persist sources/order/selection/lineage/collapse, not outputs.
+
+Exit: domain transitions and persistence round-trip in tests; Classic remains
+the only publicly selectable workspace.
+
+### Phase 3 — Composer canvas and navigation
+
+- Extract `render_classic_workspace` and overlays.
+- Implement notebook measurement/virtualization and OpenCode-style composers.
+- Implement the empty state, bottom-aligned visual spacer, and trailing
+  composer as part of the base canvas rather than later polish.
+- Add Cell/Editor/Result focus and status-line labels.
+- Extract borderless `GridViewport` and show bounded output previews.
+- Add inline running, command, failure, cancellation, dirty, and stale states.
+- Route keyboard, cursor, completion, search, history, external editor, AI, and
+  schema insertion to the selected cell.
+- Add layout hit maps and mouse behavior after keyboard behavior is stable.
+- Expose `:mode notebook`, `:mode classic`, `:notebook`, startup config, and
+  tested Classic/Notebook transition semantics.
+
+Exit: ordinary Postgres/Mongo queries run in ordered cells, with no refinement.
+
+### Phase 4 — PostgreSQL session snapshots
+
+- Implement the first refinement provider: capability/preflight and
+  `PgSnapshotManager` behind the neutral contract.
+- Gate on reliable idle transaction state and session affinity.
+- Materialize eligible source cells with row+1 and byte budgets.
+- Publish immutable result versions only for complete results.
+- Add Refine action, structural `@result_N` compilation, explicit dependency
+  rebase, validation, cleanup, and LRU eviction.
+- Surface typed unavailable reasons and explicit run-without-snapshot retry.
+
+Exit: a supported complete result can be refined without rerunning upstream;
+unsupported cases are explicit.
+
+### Phase 5 — Parity, polish, and rollout
+
+- Re-enable safe result search/copy/export/detail in notebook output focus.
+- Add contextual help, README/config docs, narrow layout, light theme, no-color
+  cues, and ASCII-safe fallbacks.
+- Add `--notebook` only after config/session switching is stable.
+- Profile 100 cells and large previews; remove avoidable full-document work.
+- Add screenshots/GIFs and a manual terminal compatibility matrix.
+- Keep feature opt-in for at least one release before considering Notebook as a
+  default.
+
+Exit: acceptance criteria below pass and Classic regressions remain green.
+
+### Later phases
+
+- Named/renamable logical results and richer dependency references.
+- Explicit live PostgreSQL CTE fallback, labelled as rerunning upstream.
+- SQLite adapter milestone: add `DbKind::Sqlite`, connection/schema support,
+  typed row decoding, a pinned blocking worker, interrupt cancellation, and
+  `SqliteSnapshotManager` using connection-local TEMP CTAS.
+- Mongo refinement milestone: retain bounded typed BSON and compile dependent
+  aggregations through MongoDB 6.0+ `$documents`; keep older versions,
+  incomplete results, and oversized payloads disabled.
+- Per-driver native providers for other databases only after their relation
+  lifetime, type fidelity, connection affinity, limits, cancellation, and
+  cleanup are characterized.
+- Run above/below/all, duplicate/reorder, outline, export, and notebook files.
+- Typed `CellValue`/Arrow ingestion followed by an optional DataFusion or
+  DuckDB local-memory engine with its dialect always visible.
+
+## 10. Test strategy
+
+### Unit/domain tests
+
+- at most one empty trailing draft plus non-empty `NEEDS RUN` cells;
+- insertion/deletion and selected-cell invariants;
+- execute during another active run leaves the requested cell unchanged;
+- source edits increment revision and mark output/dependents stale;
+- dependencies remain bound to immutable ResultVersion until explicit rebase;
+- connection-provenance mismatch requires explicit cell rebind;
+- connection generation invalidates snapshots without deleting display output;
+- snapshot eviction and disabled-reason transitions;
+- v1-to-v2 session migration and corrupt/future schema behavior;
+- restored source cells become `NEEDS RUN`; restored dependents become
+  `SOURCE UNAVAILABLE` until their exact source result is rerun/rebased;
+- capability dispatch selects only the active backend's provider and preserves
+  its semantic label/dialect;
+- logical result references reject backend, connection-generation, and result-
+  version mismatches before execution;
+- native/client snapshot handle invalidation keeps display output while making
+  dependent execution unavailable with a typed reason;
+- SQL-aware statement/semicolon classification;
+- `@result_N` rewriting ignores quoted identifiers, single/dollar-quoted
+  strings, and line/block comments;
+- identifier quoting and duplicate/empty output-name normalization;
+- row/byte boundary decisions at `N-1`, `N`, and `N+1`.
+
+### Renderer/buffer tests
+
+- One Dark and GitHub Light cells have explicit legible foreground/background;
+- Cell/Editor/Result focus is visible by text/symbol as well as color;
+- 60x20 clips secondary metadata but retains state and source completeness;
+- composer cursor/selection and syntax highlighting use the active theme;
+- output is unboxed and aligned with the response gutter;
+- selected-cell auto-scroll reveals without recentering;
+- off-screen completion does not move viewport/focus;
+- cached cell heights remain stable across off-screen updates;
+- result focus owns nested scrolling and Esc returns document ownership;
+- mouse hit tests map to the correct CellId and region.
+
+### PostgreSQL integration tests
+
+- ordinary SELECT, CTE, VALUES, TABLE, zero-row result;
+- NULL versus text `"NULL"`;
+- numeric precision, timestamptz, UUID, JSONB, bytea, arrays;
+- enum, domain, composite/custom types where CTAS supports them;
+- pseudo-type snapshot rejection with one normal execution;
+- duplicate/empty column names are normalized predictably;
+- volatile source executes once;
+- base-table changes after execution do not alter the retained snapshot;
+- chained refine preserves PostgreSQL types;
+- source over row/byte cap becomes Preview and cannot refine;
+- snapshot `SET LOCAL statement_timeout` honors `query_timeout_secs`;
+- failed/cancelled rerun leaves prior committed snapshot intact but stale;
+- logical references bind to the exact immutable result version;
+- wrapped-query database error positions map back to cell source positions;
+- deletion/eviction cleanup;
+- reconnect/backend PID change invalidates relation;
+- revoked TEMP privilege and hot-standby behavior;
+- active/failed transaction gating;
+- PgBouncer transaction mode is rejected or fails with the documented reason.
+
+### Future SQLite provider integration tests
+
+These gate the separate SQLite-driver milestone, not the first Notebook
+release:
+
+- file-backed and `:memory:` databases retain TEMP snapshots only while the
+  pinned connection remains alive;
+- TEMP CTAS captures zero rows and the `N-1`, `N`, and `N+1` boundaries;
+- NULL, integer, real, text, and blob values retain native SQLite identity;
+- immutable logical versions resolve to distinct temp tables and cleanup does
+  not redirect dependents;
+- CTAS `rowid` preserves source delivery order for display, while refinement
+  makes no ordering promise without `ORDER BY`;
+- connection replacement and `PRAGMA temp_store` changes invalidate handles;
+- the badge says `CONNECTION SNAPSHOT`, and says `LOCAL MEMORY` only when the
+  adapter has proved that storage mode;
+- interrupt cancellation leaves no published partial snapshot.
+
+### Mongo tests
+
+- cells execute and render normally;
+- in the Notebook MVP, Refine is visible but disabled with a Mongo-specific
+  provider/version reason;
+- switching between Mongo/Postgres invalidates old snapshot capabilities.
+
+The later Mongo provider additionally tests typed BSON retention,
+`$documents` pipeline compilation, immutable versions, row/byte/BSON limits,
+MongoDB version gating, and cancellation. It must never issue `$out` or
+`$merge` implicitly.
+
+### Regression/performance/manual tests
+
+- all existing Classic tests remain unchanged and pass;
+- classic paging, refresh, grid edit, AI, history, completion, cancellation, and
+  session restore remain functional;
+- 100-cell notebook navigation does not flicker or rerender all cell content;
+- large results remain bounded in UI and snapshot retention;
+- keyboard-only operation with mouse capture disabled;
+- legacy terminal, kitty keyboard protocol terminal, tmux, and SSH;
+- dark/light/custom theme and monochrome/readability audit.
+
+## 11. Acceptance criteria
+
+The first Notebook release enables PostgreSQL refinement only. SQLite and
+MongoDB provider criteria gate their separate adapter milestones. The first
+release is complete when:
+
+1. `:mode notebook` replaces query/results with one scrollable top-to-bottom
+   canvas while sidebar/status remain functional.
+2. Users can create, edit, execute, rerun, delete, navigate, collapse, cancel,
+   and inspect cells without a mouse.
+3. Executing two cells in sequence produces stable ordered output and async
+   completion never steals focus.
+4. Editing executed SQL immediately labels its old output stale.
+5. Complete PostgreSQL results expose a stable session snapshot and Refine runs
+   against it without rerunning the upstream query.
+6. Preview/truncated results cannot be mistaken for complete snapshots and do
+   not enable Refine.
+7. The notebook domain and logical-reference model do not assume PostgreSQL;
+   an unsupported provider remains safely unavailable without UI special
+   cases.
+8. Every unavailable refinement shows an actionable, backend-specific reason.
+9. A dependent remains bound to an explicit source result version until the
+   user rebases it; source reruns never redirect it silently.
+10. Rerunning a historical cell on a different connection/database requires an
+   explicit rebind.
+11. PostgreSQL versus future/local dialect and snapshot versus live semantics
+   are always visible.
+12. Connection changes and snapshot eviction retain display output but disable
+   invalid refinement safely.
+13. A 60x20 terminal and a 100-cell document remain usable.
+14. Both built-in themes and partial custom themes remain legible.
+15. Classic mode's existing behavior and test suite remain green.
+
+## 12. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `app.rs` has hundreds of direct global editor/grid references | Land target accessors and rendering/execution extraction before notebook behavior |
+| Async result lands in wrong cell | Execution/cell/revision/connection IDs on every event |
+| Old output appears current after edit | Separate source revision from executed revision and render `STALE OUTPUT` |
+| Truncated rows are refined silently | `ResultExtent` separates total/fetched/retained counts; Refine requires a published retained handle |
+| CTAS failure causes a double execution | Never auto-fallback after an attempted materialization |
+| User transaction is committed accidentally | Reliable transaction state; snapshot only from Idle; notebook transaction control initially prohibited |
+| Pooler loses temp relation | Declared connection capability plus best-effort backend/OID validation |
+| Temp tables consume server disk | row+1 cap, byte check, LRU, timeout, cleanup, opt-in feature |
+| Backend adapters imply different snapshot semantics | One capability contract plus mandatory provider, storage, dialect, and live/snapshot labels |
+| SQLite connection is reopened and loses TEMP snapshots | Pin one worker-owned connection and invalidate every handle on replacement or close |
+| SQLite TEMP storage is assumed to be RAM | Default to `CONNECTION SNAPSHOT`; claim `LOCAL MEMORY` only after checking effective `temp_store` |
+| Mongo refinement exceeds BSON limits or creates server objects | Conservative retained-byte/document caps, `$documents` version gating, and no implicit `$out`/`$merge` |
+| Modified Enter is unavailable | ordinary configurable keys are primary; modified Enter aliases only |
+| Nested scrolling is confusing | focus text identifies document, editor, or result as the active scroll owner |
+| Embedded engine creates dialect surprise | defer and label engine/dialect if later introduced |
+
+## 13. Research basis
+
+### UX and notebook model
+
+- [JupyterLab notebooks: command and edit mode](https://jupyterlab.readthedocs.io/en/stable/user/notebook.html)
+- [Jupyter nbformat cell/output model](https://nbformat.readthedocs.io/en/latest/format_description.html)
+- [JupyterLab commands](https://jupyterlab.readthedocs.io/en/stable/user/commands.html)
+- [VS Code Jupyter notebook interaction](https://code.visualstudio.com/docs/datascience/jupyter-notebooks)
+- [OpenCode TUI](https://dev.opencode.ai/docs/tui/)
+- [OpenCode keybindings](https://dev.opencode.ai/docs/keybinds)
+- [OpenCode prompt source](https://github.com/anomalyco/opencode/blob/dev/packages/tui/src/component/prompt/index.tsx)
+- [OpenCode session canvas source](https://github.com/anomalyco/opencode/blob/dev/packages/tui/src/routes/session/index.tsx)
+- [Hex SQL cell references](https://learn.hex.tech/docs/explore-data/cells/sql-cells/sql-cells-introduction)
+- [Databricks notebook outputs](https://docs.databricks.com/aws/notebooks/notebook-outputs)
+- [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/)
+- [Jupyter accessibility](https://jupyterlab.readthedocs.io/en/stable/getting_started/accessibility.html)
+
+### Database and engine behavior
+
+- [PostgreSQL `CREATE TABLE AS`](https://www.postgresql.org/docs/current/sql-createtableas.html)
+- [PostgreSQL temporary tables](https://www.postgresql.org/docs/current/sql-createtable.html)
+- [PostgreSQL privileges](https://www.postgresql.org/docs/current/ddl-priv.html)
+- [PostgreSQL protocol flow](https://www.postgresql.org/docs/current/protocol-flow.html)
+- [PostgreSQL resource limits](https://www.postgresql.org/docs/current/runtime-config-resource.html)
+- [PostgreSQL CTE behavior](https://www.postgresql.org/docs/current/queries-with.html)
+- [PgBouncer feature compatibility](https://www.pgbouncer.org/features.html)
+- [`tokio-postgres::Client`](https://docs.rs/tokio-postgres/latest/tokio_postgres/struct.Client.html)
+- [`postgres_types::Kind`](https://docs.rs/postgres-types/latest/postgres_types/enum.Kind.html)
+- [SQLite `CREATE TABLE AS` and TEMP tables](https://www.sqlite.org/lang_createtable.html)
+- [SQLite in-memory databases and connection lifetime](https://www.sqlite.org/inmemorydb.html)
+- [SQLite `PRAGMA temp_store`](https://www.sqlite.org/pragma.html#pragma_temp_store)
+- [SQLite operation interruption](https://www.sqlite.org/c3ref/interrupt.html)
+- [MongoDB `$documents` aggregation stage](https://www.mongodb.com/docs/manual/reference/operator/aggregation/documents/)
+- [MongoDB BSON/document limits](https://www.mongodb.com/docs/manual/reference/limits/)
+- [MongoDB `$out`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/)
+- [MongoDB `$merge`](https://www.mongodb.com/docs/v8.2/reference/operator/aggregation/merge/)
+- [DataFusion in-memory engine](https://datafusion.apache.org/user-guide/introduction.html)
+- [DuckDB Rust client](https://duckdb.org/docs/stable/clients/rust.html)
+
+## 14. First implementation step
+
+Start with Phase 0 and Phase 1 only. Do not begin the composer renderer until
+target-aware execution, cancellation finalization, and transaction-state tests
+are in place. Those seams determine whether notebook output and snapshot
+lineage can be correct; the visual layer can then be built without embedding a
+second execution architecture in `app.rs`.

--- a/docs/UI_REDESIGN_PLAN.md
+++ b/docs/UI_REDESIGN_PLAN.md
@@ -1,0 +1,151 @@
+# Tonal Zones UI Redesign — Implementation Plan
+
+## Context
+
+The current TUI wraps all four panes (connections, schema, query, results) in `Block::default().borders(Borders::ALL)` with focus shown by a border-color change — visually noisy, space-wasting, and a weak focus signal. Following the case study, the maintainer chose **Direction A (tonal zones)**, opencode-style: background tones per pane, uppercase section labels instead of border titles, a left accent edge on the focused pane, and a status strip with a solid vim-mode pill.
+
+**Maintainer decisions (locked):**
+- **Full replacement** — the bordered UI is deleted; no legacy path, no `show_borders` flag (field removed), no truecolor fallback/detection. `Color::Rgb` is emitted unconditionally (matches existing stance: syntax highlighting and `grid.rs:1746` already do).
+- **Custom theme files in scope** — `display.theme` resolves built-ins first, then `~/.tsql/themes/<name>.toml` (honoring `TSQL_CONFIG_DIR`), falling back to `one_dark` with a nonfatal startup warning.
+- One Helix-style TOML drives both syntax and UI chrome via new `ui.*` keys; modals/popups keep their current bordered look (only must-not-regress).
+
+**Verified load-bearing facts:**
+- ratatui 0.29 `Block::inner()` reserves the top row when a top title exists even without `Borders::TOP` (`block.rs:644`), and `Block::render` paints `self.style` over the whole area — so `zone_block` needs no manual label rendering. Use `title_top(Line)` (the `Title` struct is deprecated; repo pushes with `-D warnings`).
+- `symbols::border::Set` fields are `&'static str` — a custom set with `vertical_left: "▍"` is const-legal.
+- `HighlightedTextArea` already has `.cursor_style()` / `.selection_style()` setters (`highlighted_editor.rs:66-74`) and derives cursor position from `block.inner()`.
+- Syntax themes set **fg only** (no bg anywhere in one_dark/github_light) — pane tones show through tokens.
+- The grid renders manually via `buf.set_string` with `Style::default()` (bg None) for all non-highlight cells — a block-level bg composes cleanly.
+- `Config`/`DisplayConfig` use `#[serde(default)]`, no `deny_unknown_fields` — removing `show_borders` keeps old configs parseable (pin with a test).
+- `tui-syntax` `Theme` parser accepts arbitrary keys via `#[serde(flatten)]`, supports fg/bg/modifiers, and `style_for()` has hierarchical dotted-scope fallback.
+- `main.rs:367-369` overwrites `app.last_status` with startup warnings — the theme warning must be merged into `startup_warnings`, not just set in `with_config`.
+
+## Core new module: `crates/tsql/src/ui/theme.rs`
+
+### `UiTheme` — pre-resolved chrome styles, built once in `App::with_config`
+
+```rust
+pub struct UiTheme {
+    // tones
+    pub bg_base: Color,      // ui.background           — results grid
+    pub bg_panel: Color,     // ui.background.panel     — sidebar
+    pub bg_elevated: Color,  // ui.background.elevated  — query editor
+    pub bg_status: Color,    // ui.statusline bg
+    // text
+    pub text: Color, pub text_muted: Color,
+    // labels
+    pub label: Style, pub label_focused: Style,
+    // focus accents (vim-mode)
+    pub accent: Color, pub accent_insert: Color, pub accent_visual: Color,
+    // selection & cursors (explicit fg+bg, never REVERSED)
+    pub selection: Style, pub cursor_cell: Style,
+    pub editor_cursor: Style, pub editor_selection: Style,
+    // search
+    pub search_match: Style, pub search_match_current: Style,
+    // semantic
+    pub success: Color, pub warning: Color, pub error: Color,
+    // misc
+    pub pill_fg: Color, pub scrollbar: Style, pub grid_header: Style,
+}
+```
+
+- `UiTheme::from_theme(&tui_syntax::Theme)` — `style_for("ui.*")` lookups; every field has a hardcoded One Dark constant as final fallback (any theme, even empty, yields a coherent UI). `UiTheme::fallback()` for tests/Default.
+- `mode_accent(mode) -> Color`: Normal→accent, Insert→accent_insert, Visual→accent_visual.
+
+### Zone helpers (geometry single source of truth)
+
+```rust
+pub const ZONE_EDGE_SET: border::Set = border::Set { vertical_left: "▍", ..border::PLAIN };
+
+pub fn zone_block(label: Line, tone: Color, focused: bool, accent: Color) -> Block {
+    let edge = if focused { Style::default().fg(accent).bg(tone) }
+               else { Style::default().fg(tone).bg(tone) };  // invisible, column still reserved
+    Block::default().style(Style::default().bg(tone))
+        .borders(Borders::LEFT).border_set(ZONE_EDGE_SET).border_style(edge)
+        .title_top(label).padding(Padding::new(1, 1, 0, 0))
+}
+pub fn zone_inner(area: Rect) -> Rect      // (x+2, y+1, w-3, h-1) — mirror of zone_block().inner()
+pub fn zone_scrollbar_area(area: Rect) -> Rect  // right padding column below label row
+pub fn zone_label(name, detail_spans, focused, accent, theme) -> Line<'static>  // " QUERY" style
+```
+
+**Inner geometry** (vs. old `Borders::ALL` inset of +1,+1,−2,−2): `x+2, y+1, width−3, height−1`. Identical focused/unfocused — no layout shift on focus change, by construction. Unit test pins `zone_block(...).inner(area) == zone_inner(area)` incl. degenerate rects.
+
+### Theme loading
+
+```rust
+pub fn load_theme_from(name: &str, themes_dir: Option<&Path>) -> (Theme, Option<String>)
+// "" | "default" | "one_dark" → built-in one_dark; "github_light" → built-in;
+// else themes_dir/<name>.toml; missing/parse-error → one_dark + warning message
+pub fn load_theme(name: &str) -> (Theme, Option<String>)  // dir = config_dir().join("themes")
+```
+
+Warning surfaces via `startup_warnings` in `main.rs` (merge `app.last_status.take()` before the join at `main.rs:367-369`).
+
+### `ui.*` keys appended to `ONE_DARK_TOML` (`crates/tui-syntax/src/themes/mod.rs`)
+
+Scopes: `ui.background` (#282C34) / `.panel` (#21252B) / `.elevated` (#2C313A); `ui.text` / `.muted`; `ui.label` / `.focused` (cyan bold); `ui.accent` (cyan) / `.insert` (green) / `.visual` (yellow); `ui.selection` (#3E4451 bg) / `.editor`; `ui.cursor` (explicit fg/bg) / `.cell`; `ui.search.match` / `.current`; `ui.statusline` (bg #1D2025) / `.mode` (pill ink); `ui.success/warning/error`; `ui.scrollbar`; `ui.grid.header`. Syntax scopes stay fg-only.
+
+## Phases
+
+Each phase: compiles, `cargo fmt --all`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test --all` pass; app renders coherently (transitional mixed look between phases is acceptable).
+
+### Phase 1 — Theme foundation, no visual change (M)
+- `crates/tui-syntax/src/themes/mod.rs`: append `ui.*` block to `ONE_DARK_TOML`.
+- `crates/tui-syntax/src/theme.rs`: tests only (`ui.*` parses with bg; hierarchical fallback panel→background).
+- **New** `crates/tsql/src/ui/theme.rs`: `UiTheme`, `from_theme`, `fallback`, `mode_accent`, `load_theme(_from)`, zone helpers; `#[cfg(test)]` `luminance`/`contrast_ratio` helpers.
+- `crates/tsql/src/ui/mod.rs`: register module.
+- `crates/tsql/src/ui/highlighted_editor.rs:429`: `create_sql_highlighter(theme: Theme)` (was zero-arg hardcoded one_dark).
+- `crates/tsql/src/app/app.rs`: `pub ui_theme: UiTheme` field (~:2434); build in `with_config` (:2654) from `config.display.theme`; pass syntax theme to highlighter (:2697).
+- `crates/tsql/src/main.rs:367-369`: merge `last_status` into `startup_warnings`.
+- `crates/tsql/src/config/schema.rs`: **delete** `show_borders` (:47, :62); reword `theme` doc (:48). Update `config.example.toml` (:27-31).
+- Tests: tone resolution from one_dark; `from_theme(empty) == fallback()`; contrast ratios ≥ 4.5 for text-on-tone pairs across all built-ins + fallback, tones mutually distinguishable; `load_theme_from` tempdir matrix (valid/malformed/missing/built-in); old config with `show_borders = true` still parses.
+
+### Phase 2 — Zone helpers live: query pane + geometry plumbing (L)
+All in `app.rs` draw closure (:2995-3280) unless noted:
+- :3071-3100 — replace border/title with `zone_block(zone_label("QUERY", …), ui_theme.bg_elevated, focused, ui_theme.mode_accent(mode))`; label detail: `[INSERT]` (focused, accent) + modified `[+]`.
+- :3109-3114 — add `.cursor_style(ui_theme.editor_cursor)` + `.selection_style(ui_theme.editor_selection)` (kills REVERSED-on-tint and hardcoded Blue).
+- :3128-3139 — **load-bearing**: replace `query_area.height/width.saturating_sub(2)` with `query_block.inner(query_area)` dims for `calculate_editor_scroll`.
+- :3141-3170 — scrollbar → `zone_scrollbar_area(query_area)` + `ui_theme.scrollbar`.
+- :3345-3348 — completion popup anchor derives from `zone_inner(query_area)`.
+- :801 — `QUERY_BORDER_ROWS = 2` → `QUERY_CHROME_ROWS = 1`; usage :872; update `compute_query_panel_height` tests (:11693-11726).
+- Tests (TestBackend/Buffer): label on row 0; `▍` accent column when focused; **focused-vs-unfocused buffer symbols identical** (geometry-stability regression test); all cell bg == tone; cursor position (x+2, y+1) for cursor (0,0).
+
+### Phase 3 — Results grid zone (L)
+- `grid.rs` `DataGrid` (:1391): add `label: Line<'a>`, `theme: &'a UiTheme` fields; render (:1400-1432) uses `zone_block(label, theme.bg_base, focused, theme.accent)`. Style swaps: header (:1503) → `theme.grid_header`; cursor row (:1529) → `theme.selection`; search/cursor-cell (:1744-1748) → theme; gutter DarkGray/Gray (:1607-1654) → `theme.text_muted/text`; empty-state messages → `theme.text_muted`; scrollbar (:1572-1592) → `zone_scrollbar_area` (content regains its last column).
+- `app.rs`: build grid label in draw closure (`RESULTS · {n} rows · {ms}ms` + search match info — data lives on App); viewport math (:3172-3191) via `zone_inner(grid_area)` (preserve existing marker_w parity quirk — do not fix in this pass); `grid_mouse_target` (:11040-11096) hardcoded inset → `zone_inner`, update its tests (~:12322).
+- `style.rs`: add `#[cfg(test)] assert_bg_cells_have_visible_fg(buf, bg)` (generalizes :46-64; keep old helper for modals).
+- Tests: update grid render tests (:2046-2066, :2145-2175) for new offsets (data starts x=5); label row content; cell bg ∈ allowed set; contrast assertion on selection; focus-toggle symbol equality; mouse mapping.
+
+### Phase 4 — Sidebar zones (M)
+- `sidebar.rs` render (:64-100): add `theme: &UiTheme` param; split `[Percentage(30), Length(1), Min(0)]` with the 1-row spacer painted `bg_panel`; areas = chunks[0]/chunks[2].
+- `render_connections` (:102-191) / `render_schema` (:193-270): `zone_block(…, bg_panel, focused, theme.accent)` each (accent edge only on the focused sub-section); selection highlight → `theme.selection` (focused) / `fg(theme.accent)` (unfocused, replaces Yellow); current-conn marker → `theme.success`; loading/error/empty → `theme.warning/error/text_muted`.
+- Click math unchanged (label row occupies the old border row — `sidebar.rs:441-468`); schema tree uses stored absolute coords (:477-482).
+- `app.rs:3031-3041`: pass `&self.ui_theme`.
+- Tests: labels render; spacer bg; `▍` on focused section only; focus-toggle symbol equality; selection contrast.
+
+### Phase 5 — Status strip + pill, light theme, docs (S/M)
+- `status_line.rs`: add `separator_style()` to builder (separator hardcodes DarkGray at :270).
+- `app.rs status_line()` (:10726-10881): mode segment = pill (`" {mode} "` with `bg(mode_accent) fg(pill_fg) BOLD`); segment styles → theme semantic colors; return `Paragraph::new(line).style(bg(bg_status).fg(text))` (paints full strip).
+- `themes/mod.rs`: matching `ui.*` block for `GITHUB_LIGHT_TOML` (base #ffffff, panel #f6f8fa, elevated #eaeef2…) — Phase 1 contrast tests cover it automatically.
+- Docs: `config.example.toml`, README note on custom themes dir.
+- Noted follow-up (out of scope): `json_editor.rs:108` / `row_detail.rs:89` hardcode one_dark for modal syntax; ~170 modal `Color::` literals stay.
+
+## Risks & mitigations
+1. **Geometry regressions** (cursor drift, scroll jumps, mouse mis-hits) → single geometry source (`zone_block`/`zone_inner` + equality test); editor scroll uses the same `block.inner()` as the widget; per-pane focus-toggle symbol-equality tests.
+2. **REVERSED cursor on tinted bg** → explicit `ui.cursor` style from Phase 2; fallback constants guarantee it's always set.
+3. **Contrast on tones** → all highlight styles carry explicit fg+bg; contrast-ratio unit tests over every built-in + fallback; buffer assertions in render tests.
+4. **Config back-compat** → `show_borders` removal safe (`#[serde(default)]`, no deny_unknown_fields; pinned by test); `theme = "default"` → one_dark; Config never written back to disk (verified).
+5. **Sparse custom themes** → hierarchical `style_for` fallback + hardcoded final fallbacks; test with a minimal TOML.
+6. **Clippy -D warnings vs deprecated `Title`** → use `title_top(Line)` exclusively.
+7. **Insert-mode auto-height** grows one row (chrome 2→1) — intended; tests updated in Phase 2.
+
+## Critical files
+- `crates/tsql/src/app/app.rs` (draw closure :2995-3280, scroll math :3128, viewport :3172, `grid_mouse_target` :11040, `status_line()` :10726, `with_config` :2654)
+- `crates/tsql/src/ui/theme.rs` (new)
+- `crates/tsql/src/ui/grid.rs` (:1391-1593, :1744-1748)
+- `crates/tsql/src/ui/sidebar.rs` (:64-270, :441-468)
+- `crates/tui-syntax/src/themes/mod.rs`, `crates/tsql/src/config/schema.rs`, `crates/tsql/src/ui/status_line.rs`, `crates/tsql/src/main.rs`
+
+## Verification
+- Per phase: `cargo fmt --all` && `cargo clippy --all --all-targets -- -D warnings` && `cargo test --all`.
+- End-to-end after Phases 2-5: run the app against a live connection (`cargo run`), and verify visually: no borders anywhere; tones distinct (sidebar/query/results/status); focus cycling (Tab / Ctrl-hjkl) moves the `▍` edge with **zero content shift**; vim mode flips edge+pill colors (i / v / Esc); scroll long query + grid with scrollbars in the gutter; mouse clicks on tree items and grid cells hit the right rows; search highlights legible; `display.theme = "github_light"` renders the light variant; a custom `~/.tsql/themes/test.toml` loads (and a bogus name shows the startup warning in the status strip).

--- a/docs/UI_REDESIGN_PLAN.md
+++ b/docs/UI_REDESIGN_PLAN.md
@@ -1,151 +1,396 @@
-# Tonal Zones UI Redesign — Implementation Plan
+# Tonal Zones UI Redesign — Implementation Plan (Revision 2)
 
 ## Context
 
-The current TUI wraps all four panes (connections, schema, query, results) in `Block::default().borders(Borders::ALL)` with focus shown by a border-color change — visually noisy, space-wasting, and a weak focus signal. Following the case study, the maintainer chose **Direction A (tonal zones)**, opencode-style: background tones per pane, uppercase section labels instead of border titles, a left accent edge on the focused pane, and a status strip with a solid vim-mode pill.
+The current TUI wraps the four primary panes (connections, schema, query, and results) in `Block::default().borders(Borders::ALL)`. Focus is indicated only by changing the border color. This is visually noisy, consumes space, and provides a weak focus signal.
+
+The replacement follows **Direction A (tonal zones)**: each primary pane has a background tone, uppercase section labels replace border titles, the focused pane has a left accent edge, and the status strip has a solid vim-mode pill.
 
 **Maintainer decisions (locked):**
-- **Full replacement** — the bordered UI is deleted; no legacy path, no `show_borders` flag (field removed), no truecolor fallback/detection. `Color::Rgb` is emitted unconditionally (matches existing stance: syntax highlighting and `grid.rs:1746` already do).
-- **Custom theme files in scope** — `display.theme` resolves built-ins first, then `~/.tsql/themes/<name>.toml` (honoring `TSQL_CONFIG_DIR`), falling back to `one_dark` with a nonfatal startup warning.
-- One Helix-style TOML drives both syntax and UI chrome via new `ui.*` keys; modals/popups keep their current bordered look (only must-not-regress).
 
-**Verified load-bearing facts:**
-- ratatui 0.29 `Block::inner()` reserves the top row when a top title exists even without `Borders::TOP` (`block.rs:644`), and `Block::render` paints `self.style` over the whole area — so `zone_block` needs no manual label rendering. Use `title_top(Line)` (the `Title` struct is deprecated; repo pushes with `-D warnings`).
-- `symbols::border::Set` fields are `&'static str` — a custom set with `vertical_left: "▍"` is const-legal.
-- `HighlightedTextArea` already has `.cursor_style()` / `.selection_style()` setters (`highlighted_editor.rs:66-74`) and derives cursor position from `block.inner()`.
-- Syntax themes set **fg only** (no bg anywhere in one_dark/github_light) — pane tones show through tokens.
-- The grid renders manually via `buf.set_string` with `Style::default()` (bg None) for all non-highlight cells — a block-level bg composes cleanly.
-- `Config`/`DisplayConfig` use `#[serde(default)]`, no `deny_unknown_fields` — removing `show_borders` keeps old configs parseable (pin with a test).
-- `tui-syntax` `Theme` parser accepts arbitrary keys via `#[serde(flatten)]`, supports fg/bg/modifiers, and `style_for()` has hierarchical dotted-scope fallback.
-- `main.rs:367-369` overwrites `app.last_status` with startup warnings — the theme warning must be merged into `startup_warnings`, not just set in `with_config`.
+- **Full replacement:** remove the bordered primary-pane UI. Do not retain a legacy rendering path or `show_borders` flag.
+- **Truecolor:** emit `Color::Rgb` unconditionally. This matches existing syntax highlighting and grid search styling.
+- **Custom themes:** resolve `display.theme` against built-ins first, then `<config_dir>/themes/<name>.toml`, where `config_dir()` honors `TSQL_CONFIG_DIR`. Missing or invalid themes fall back to `one_dark` and produce a nonfatal startup warning.
+- **One theme source:** Helix-style TOML drives both syntax highlighting and UI chrome through `ui.*` scopes.
+- **Modals and popups:** retain their current bordered appearance. They are regression-tested but are not redesigned in this change.
 
-## Core new module: `crates/tsql/src/ui/theme.rs`
+## Verified load-bearing facts
 
-### `UiTheme` — pre-resolved chrome styles, built once in `App::with_config`
+- In ratatui 0.29, `Block::inner()` reserves the top row for a top title even without `Borders::TOP`, and `Block::render` applies the block style over its complete area. Zone labels therefore do not require separate rendering.
+- Use `title_top(Line)` rather than the deprecated `Title` type because the repository runs clippy with `-D warnings`.
+- `symbols::border::Set` fields are `&'static str`, so a const set with `vertical_left: "▍"` is valid.
+- `HighlightedTextArea` exposes `.cursor_style()` and `.selection_style()`, and both rendering and native-cursor positioning derive their viewport from `block.inner()`.
+- `HighlightedTextArea` replaces the syntax style on selected and block-cursor characters rather than patching it. Editor selection and cursor styles must therefore resolve to explicit foreground and background colors.
+- The grid writes cells using styles whose unset fields inherit the buffer's existing style. A zone-level foreground and background provides a reliable base style for ordinary grid cells.
+- `Config` and `DisplayConfig` use `#[serde(default)]` without `deny_unknown_fields`; removing `show_borders` keeps old configuration files parseable.
+- The `tui-syntax` parser accepts arbitrary capture keys and supports foreground, background, and modifiers. Its current hierarchical fallback selects the nearest complete ancestor style; it does not merge missing fields from parent and child styles.
+- `main.rs` currently writes joined startup warnings into `app.last_status`. Theme-loading diagnostics must join that warning collection without using `last_status` as temporary transport.
+
+## Theme architecture
+
+### `UiTheme`
+
+Add `crates/tsql/src/ui/theme.rs` with a pre-resolved theme built once during `App::with_config`:
 
 ```rust
+#[derive(Clone, Debug, PartialEq)]
 pub struct UiTheme {
-    // tones
-    pub bg_base: Color,      // ui.background           — results grid
-    pub bg_panel: Color,     // ui.background.panel     — sidebar
-    pub bg_elevated: Color,  // ui.background.elevated  — query editor
-    pub bg_status: Color,    // ui.statusline bg
-    // text
-    pub text: Color, pub text_muted: Color,
-    // labels
-    pub label: Style, pub label_focused: Style,
-    // focus accents (vim-mode)
-    pub accent: Color, pub accent_insert: Color, pub accent_visual: Color,
-    // selection & cursors (explicit fg+bg, never REVERSED)
-    pub selection: Style, pub cursor_cell: Style,
-    pub editor_cursor: Style, pub editor_selection: Style,
-    // search
-    pub search_match: Style, pub search_match_current: Style,
-    // semantic
-    pub success: Color, pub warning: Color, pub error: Color,
-    // misc
-    pub pill_fg: Color, pub scrollbar: Style, pub grid_header: Style,
+    // Pane tones and base text
+    pub bg_base: Color,
+    pub bg_panel: Color,
+    pub bg_elevated: Color,
+    pub bg_status: Color,
+    pub text: Color,
+    pub text_muted: Color,
+
+    // Labels and focus
+    pub label: Style,
+    pub label_focused: Style,
+    pub accent: Color,
+    pub accent_insert: Color,
+    pub accent_visual: Color,
+
+    // Explicit foreground + background styles
+    pub selection: Style,
+    pub cursor_cell: Style,
+    pub editor_cursor: Style,
+    pub editor_selection: Style,
+    pub search_match: Style,
+    pub search_match_current: Style,
+
+    // Semantic and miscellaneous styles
+    pub success: Color,
+    pub warning: Color,
+    pub error: Color,
+    pub pill_fg: Color,
+    pub scrollbar: Style,
+    pub grid_header: Style,
 }
 ```
 
-- `UiTheme::from_theme(&tui_syntax::Theme)` — `style_for("ui.*")` lookups; every field has a hardcoded One Dark constant as final fallback (any theme, even empty, yields a coherent UI). `UiTheme::fallback()` for tests/Default.
-- `mode_accent(mode) -> Color`: Normal→accent, Insert→accent_insert, Visual→accent_visual.
+`UiTheme::fallback()` is the canonical hardcoded One Dark UI theme. `UiTheme::from_theme(&Theme)` starts from that fallback and applies theme values component by component.
 
-### Zone helpers (geometry single source of truth)
+### Component-wise style resolution
+
+Do not use `Theme::style_for()` alone to resolve UI styles. An exact child style containing only `bg` must still inherit its parent's `fg`, and both must retain hardcoded defaults for any remaining fields.
+
+Add an exact lookup API to `tui-syntax`:
 
 ```rust
-pub const ZONE_EDGE_SET: border::Set = border::Set { vertical_left: "▍", ..border::PLAIN };
+pub fn style_for_exact(&self, capture: &str) -> Option<RatatuiStyle>
+```
 
-pub fn zone_block(label: Line, tone: Color, focused: bool, accent: Color) -> Block {
-    let edge = if focused { Style::default().fg(accent).bg(tone) }
-               else { Style::default().fg(tone).bg(tone) };  // invisible, column still reserved
-    Block::default().style(Style::default().bg(tone))
-        .borders(Borders::LEFT).border_set(ZONE_EDGE_SET).border_style(edge)
-        .title_top(label).padding(Padding::new(1, 1, 0, 0))
+Resolve a UI style in this order:
+
+1. Start with the complete hardcoded fallback style.
+2. Patch each defined ancestor from least to most specific, for example `ui`, `ui.selection`, then `ui.selection.editor`.
+3. Preserve fallback fields when a theme style omits them.
+4. Remove `REVERSED` from normalized selection and cursor styles; these styles use explicit colors.
+
+For example, a custom theme with only:
+
+```toml
+["ui.selection.editor"]
+bg = "#44475a"
+```
+
+retains the fallback editor-selection foreground while replacing its background.
+
+Tests must cover exact lookup, parent/child component merging, modifier merging, and a child that supplies only a background.
+
+### Theme scopes
+
+Add matching `ui.*` scopes to both built-in themes during Phase 1:
+
+- `ui.background`, `ui.background.panel`, `ui.background.elevated`
+- `ui.text`, `ui.text.muted`
+- `ui.label`, `ui.label.focused`
+- `ui.accent`, `ui.accent.insert`, `ui.accent.visual`
+- `ui.selection`, `ui.selection.editor`
+- `ui.cursor`, `ui.cursor.cell`
+- `ui.search.match`, `ui.search.match.current`
+- `ui.statusline`, `ui.statusline.mode`
+- `ui.success`, `ui.warning`, `ui.error`
+- `ui.scrollbar`, `ui.grid.header`
+
+One Dark tones:
+
+- base `#282C34`
+- panel `#21252B`
+- elevated `#2C313A`
+- status `#1D2025`
+
+GitHub Light tones:
+
+- base `#FFFFFF`
+- panel `#F6F8FA`
+- elevated `#EAEEF2`
+- status `#D8DEE4`
+
+Selection, cursor, and search scopes in both built-ins must specify explicit foreground and background colors. Syntax scopes remain foreground-only so the zone base style shows through.
+
+### Theme loading and diagnostics
+
+```rust
+pub fn load_theme_from(
+    name: &str,
+    themes_dir: Option<&Path>,
+) -> (Theme, Option<String>);
+
+pub fn load_theme(name: &str) -> (Theme, Option<String>);
+```
+
+Resolution order:
+
+1. `""`, `"default"`, or `"one_dark"` → built-in One Dark.
+2. `"github_light"` → built-in GitHub Light.
+3. A valid custom name → `<themes_dir>/<name>.toml`.
+4. Missing, unreadable, or invalid TOML → One Dark plus a warning containing the requested name and failure reason.
+
+Custom names must be a single file stem: reject absolute paths, path separators, `.` and `..`. This keeps theme resolution inside the themes directory.
+
+Add a private `startup_warnings: Vec<String>` field to `App` and a `take_startup_warnings()` method. `App::with_config` pushes only theme-loading diagnostics into that collection. In `main.rs`, extend the existing local `startup_warnings` with `app.take_startup_warnings()` before joining them into `last_status`. Do not read or clear `last_status` during this merge.
+
+## Zone geometry
+
+```rust
+pub const ZONE_EDGE_SET: border::Set = border::Set {
+    vertical_left: "▍",
+    ..border::PLAIN
+};
+
+pub fn zone_block(
+    label: Line,
+    tone: Color,
+    text: Color,
+    focused: bool,
+    accent: Color,
+) -> Block {
+    let edge = if focused {
+        Style::default().fg(accent).bg(tone)
+    } else {
+        Style::default().fg(tone).bg(tone)
+    };
+
+    Block::default()
+        .style(Style::default().fg(text).bg(tone))
+        .borders(Borders::LEFT)
+        .border_set(ZONE_EDGE_SET)
+        .border_style(edge)
+        .title_top(label)
+        .padding(Padding::new(1, 1, 0, 0))
 }
-pub fn zone_inner(area: Rect) -> Rect      // (x+2, y+1, w-3, h-1) — mirror of zone_block().inner()
-pub fn zone_scrollbar_area(area: Rect) -> Rect  // right padding column below label row
-pub fn zone_label(name, detail_spans, focused, accent, theme) -> Line<'static>  // " QUERY" style
+
+pub fn zone_inner(area: Rect) -> Rect;
+pub fn zone_scrollbar_area(area: Rect) -> Rect;
+pub fn zone_label(
+    name: &str,
+    detail_spans: Vec<Span<'static>>,
+    focused: bool,
+    accent: Color,
+    theme: &UiTheme,
+) -> Line<'static>;
 ```
 
-**Inner geometry** (vs. old `Borders::ALL` inset of +1,+1,−2,−2): `x+2, y+1, width−3, height−1`. Identical focused/unfocused — no layout shift on focus change, by construction. Unit test pins `zone_block(...).inner(area) == zone_inner(area)` incl. degenerate rects.
+For normal-sized rectangles, `zone_block(...).inner(area)` is `(x + 2, y + 1, width - 3, height - 1)`:
 
-### Theme loading
+- one column for the left edge
+- one column for left padding
+- one column for right padding and the scrollbar gutter
+- one row for the label
 
-```rust
-pub fn load_theme_from(name: &str, themes_dir: Option<&Path>) -> (Theme, Option<String>)
-// "" | "default" | "one_dark" → built-in one_dark; "github_light" → built-in;
-// else themes_dir/<name>.toml; missing/parse-error → one_dark + warning message
-pub fn load_theme(name: &str) -> (Theme, Option<String>)  // dir = config_dir().join("themes")
-```
+`zone_inner` must mirror ratatui's saturating behavior exactly for degenerate rectangles. A unit test pins `zone_block(...).inner(area) == zone_inner(area)` over normal and degenerate sizes.
 
-Warning surfaces via `startup_warnings` in `main.rs` (merge `app.last_status.take()` before the join at `main.rs:367-369`).
+The focused and unfocused forms always reserve the same geometry. Only styles change.
 
-### `ui.*` keys appended to `ONE_DARK_TOML` (`crates/tui-syntax/src/themes/mod.rs`)
+## Implementation phases
 
-Scopes: `ui.background` (#282C34) / `.panel` (#21252B) / `.elevated` (#2C313A); `ui.text` / `.muted`; `ui.label` / `.focused` (cyan bold); `ui.accent` (cyan) / `.insert` (green) / `.visual` (yellow); `ui.selection` (#3E4451 bg) / `.editor`; `ui.cursor` (explicit fg/bg) / `.cell`; `ui.search.match` / `.current`; `ui.statusline` (bg #1D2025) / `.mode` (pill ink); `ui.success/warning/error`; `ui.scrollbar`; `ui.grid.header`. Syntax scopes stay fg-only.
+Each phase must compile, pass formatting and linting, pass tests, and leave every enabled built-in theme coherent. Transitional mixtures of bordered and zone panes are acceptable, but foreground/background combinations must remain legible.
 
-## Phases
+### Phase 1 — Theme foundation and loading (M)
 
-Each phase: compiles, `cargo fmt --all`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test --all` pass; app renders coherently (transitional mixed look between phases is acceptable).
+- Add all `ui.*` scopes to both `ONE_DARK_TOML` and `GITHUB_LIGHT_TOML`.
+- Add `Theme::style_for_exact()` and tests in `crates/tui-syntax/src/theme.rs`.
+- Add `crates/tsql/src/ui/theme.rs` with:
+  - `UiTheme`
+  - component-wise style resolution
+  - `fallback()`
+  - `mode_accent(mode)`
+  - `load_theme()` and `load_theme_from()`
+  - zone geometry helpers
+  - test-only luminance and contrast helpers
+- Register and re-export the required theme types/helpers from `crates/tsql/src/ui/mod.rs`.
+- Remove `DisplayConfig::show_borders` and its default; update `config.example.toml`.
+- Reword the `display.theme` configuration documentation.
 
-### Phase 1 — Theme foundation, no visual change (M)
-- `crates/tui-syntax/src/themes/mod.rs`: append `ui.*` block to `ONE_DARK_TOML`.
-- `crates/tui-syntax/src/theme.rs`: tests only (`ui.*` parses with bg; hierarchical fallback panel→background).
-- **New** `crates/tsql/src/ui/theme.rs`: `UiTheme`, `from_theme`, `fallback`, `mode_accent`, `load_theme(_from)`, zone helpers; `#[cfg(test)]` `luminance`/`contrast_ratio` helpers.
-- `crates/tsql/src/ui/mod.rs`: register module.
-- `crates/tsql/src/ui/highlighted_editor.rs:429`: `create_sql_highlighter(theme: Theme)` (was zero-arg hardcoded one_dark).
-- `crates/tsql/src/app/app.rs`: `pub ui_theme: UiTheme` field (~:2434); build in `with_config` (:2654) from `config.display.theme`; pass syntax theme to highlighter (:2697).
-- `crates/tsql/src/main.rs:367-369`: merge `last_status` into `startup_warnings`.
-- `crates/tsql/src/config/schema.rs`: **delete** `show_borders` (:47, :62); reword `theme` doc (:48). Update `config.example.toml` (:27-31).
-- Tests: tone resolution from one_dark; `from_theme(empty) == fallback()`; contrast ratios ≥ 4.5 for text-on-tone pairs across all built-ins + fallback, tones mutually distinguishable; `load_theme_from` tempdir matrix (valid/malformed/missing/built-in); old config with `show_borders = true` still parses.
+Do not connect the new loader to `App` yet. Phase 1 is intentionally a no-visual-change foundation: the configured syntax and UI themes become active together in Phase 2, when the query pane has an explicit base foreground and background.
 
-### Phase 2 — Zone helpers live: query pane + geometry plumbing (L)
-All in `app.rs` draw closure (:2995-3280) unless noted:
-- :3071-3100 — replace border/title with `zone_block(zone_label("QUERY", …), ui_theme.bg_elevated, focused, ui_theme.mode_accent(mode))`; label detail: `[INSERT]` (focused, accent) + modified `[+]`.
-- :3109-3114 — add `.cursor_style(ui_theme.editor_cursor)` + `.selection_style(ui_theme.editor_selection)` (kills REVERSED-on-tint and hardcoded Blue).
-- :3128-3139 — **load-bearing**: replace `query_area.height/width.saturating_sub(2)` with `query_block.inner(query_area)` dims for `calculate_editor_scroll`.
-- :3141-3170 — scrollbar → `zone_scrollbar_area(query_area)` + `ui_theme.scrollbar`.
-- :3345-3348 — completion popup anchor derives from `zone_inner(query_area)`.
-- :801 — `QUERY_BORDER_ROWS = 2` → `QUERY_CHROME_ROWS = 1`; usage :872; update `compute_query_panel_height` tests (:11693-11726).
-- Tests (TestBackend/Buffer): label on row 0; `▍` accent column when focused; **focused-vs-unfocused buffer symbols identical** (geometry-stability regression test); all cell bg == tone; cursor position (x+2, y+1) for cursor (0,0).
+Tests:
+
+- both built-ins parse all required `ui.*` scopes
+- `UiTheme::from_theme(empty) == UiTheme::fallback()`
+- partial child styles inherit parent and fallback components
+- base text meets a 4.5:1 contrast ratio against each pane tone for both built-ins
+- every explicit selection, cursor, and search foreground/background pair meets its documented contrast threshold
+- the three pane tones are distinct
+- valid, malformed, missing, and built-in theme loading
+- custom theme names cannot escape the themes directory
+- an old config containing `show_borders = true` still parses
+
+### Phase 2 — Query zone and syntax-theme activation (L)
+
+Application integration:
+
+- Add `ui_theme` and structured `startup_warnings` fields to `App`.
+- In `App::with_config`, load the configured theme once, build `UiTheme`, and pass that same loaded theme into the SQL highlighter.
+- In `main.rs`, merge `app.take_startup_warnings()` into the existing startup-warning vector without reading or clearing `last_status`.
+
+In the main draw closure:
+
+- Replace the query border/title with `zone_block` using `bg_elevated`, `text`, and `mode_accent(mode)`.
+- Build a `QUERY` label with focused mode detail and a modified `[+]` indicator.
+- Change `create_sql_highlighter` to accept the loaded `Theme`. This activates the configured syntax and UI themes atomically now that the editor has an explicit matching base foreground/background.
+- Apply `ui_theme.editor_cursor` and `ui_theme.editor_selection` to `HighlightedTextArea`.
+- Derive editor scroll dimensions from `query_block.inner(query_area)` rather than subtracting hardcoded border widths.
+- Render the scrollbar in `zone_scrollbar_area(query_area)` using `ui_theme.scrollbar`.
+- Derive the completion-popup origin from `zone_inner(query_area)`.
+- Rename `QUERY_BORDER_ROWS` to `QUERY_CHROME_ROWS` and change it from 2 to 1. Update query-height tests.
+
+Tests:
+
+- label appears on row 0
+- focused edge uses `▍` and the current mode accent
+- focused and unfocused buffers have identical symbols and geometry but different edge styles
+- ordinary editor cells inherit `theme.text` and `bg_elevated`
+- selection and cursor cells use their explicit allowed foreground/background pairs
+- native cursor position for editor coordinate `(0, 0)` is `(inner.x, inner.y)`
+- One Dark and GitHub Light query renders contain no reset foreground on nonblank content cells
+- a bad theme and an unrelated `last_status`/`last_error` remain separate
+
+Do not assert that every cell has the pane background: cursor and selection cells intentionally use different backgrounds.
 
 ### Phase 3 — Results grid zone (L)
-- `grid.rs` `DataGrid` (:1391): add `label: Line<'a>`, `theme: &'a UiTheme` fields; render (:1400-1432) uses `zone_block(label, theme.bg_base, focused, theme.accent)`. Style swaps: header (:1503) → `theme.grid_header`; cursor row (:1529) → `theme.selection`; search/cursor-cell (:1744-1748) → theme; gutter DarkGray/Gray (:1607-1654) → `theme.text_muted/text`; empty-state messages → `theme.text_muted`; scrollbar (:1572-1592) → `zone_scrollbar_area` (content regains its last column).
-- `app.rs`: build grid label in draw closure (`RESULTS · {n} rows · {ms}ms` + search match info — data lives on App); viewport math (:3172-3191) via `zone_inner(grid_area)` (preserve existing marker_w parity quirk — do not fix in this pass); `grid_mouse_target` (:11040-11096) hardcoded inset → `zone_inner`, update its tests (~:12322).
-- `style.rs`: add `#[cfg(test)] assert_bg_cells_have_visible_fg(buf, bg)` (generalizes :46-64; keep old helper for modals).
-- Tests: update grid render tests (:2046-2066, :2145-2175) for new offsets (data starts x=5); label row content; cell bg ∈ allowed set; contrast assertion on selection; focus-toggle symbol equality; mouse mapping.
+
+In `grid.rs`:
+
+- Add `label: Line<'a>` and `theme: &'a UiTheme` to `DataGrid`.
+- Render with `zone_block(label, bg_base, text, focused, accent)`.
+- Replace hardcoded styles with:
+  - `grid_header`
+  - `selection`
+  - `cursor_cell`
+  - `search_match`
+  - `search_match_current`
+  - `text` and `text_muted`
+- Preserve the zone base foreground for ordinary body cells.
+- Move the vertical scrollbar into `zone_scrollbar_area(area)` so it no longer overwrites the content column.
+
+In `app.rs`:
+
+- Build `RESULTS · {n} rows · {ms}ms`, with search match detail when active.
+- Derive viewport dimensions from `zone_inner(grid_area)`.
+- Preserve the existing marker-width parity behavior; changing it is outside this redesign.
+- Change `grid_mouse_target` to use `zone_inner(grid_area)` and update its tests.
+
+In `style.rs`, add a test helper that validates cells against an explicit set of allowed foreground/background pairs. Keep the existing modal selection helper.
+
+Tests:
+
+- label content and offsets
+- ordinary data cells use `text` on `bg_base`
+- selection, search, and cursor cells use allowed explicit pairs
+- no nonblank grid cell has a reset foreground under either built-in theme
+- focus changes styles without changing symbols or geometry
+- scrollbar occupies only the right gutter
+- mouse mapping matches rendered rows and columns
 
 ### Phase 4 — Sidebar zones (M)
-- `sidebar.rs` render (:64-100): add `theme: &UiTheme` param; split `[Percentage(30), Length(1), Min(0)]` with the 1-row spacer painted `bg_panel`; areas = chunks[0]/chunks[2].
-- `render_connections` (:102-191) / `render_schema` (:193-270): `zone_block(…, bg_panel, focused, theme.accent)` each (accent edge only on the focused sub-section); selection highlight → `theme.selection` (focused) / `fg(theme.accent)` (unfocused, replaces Yellow); current-conn marker → `theme.success`; loading/error/empty → `theme.warning/error/text_muted`.
-- Click math unchanged (label row occupies the old border row — `sidebar.rs:441-468`); schema tree uses stored absolute coords (:477-482).
-- `app.rs:3031-3041`: pass `&self.ui_theme`.
-- Tests: labels render; spacer bg; `▍` on focused section only; focus-toggle symbol equality; selection contrast.
 
-### Phase 5 — Status strip + pill, light theme, docs (S/M)
-- `status_line.rs`: add `separator_style()` to builder (separator hardcodes DarkGray at :270).
-- `app.rs status_line()` (:10726-10881): mode segment = pill (`" {mode} "` with `bg(mode_accent) fg(pill_fg) BOLD`); segment styles → theme semantic colors; return `Paragraph::new(line).style(bg(bg_status).fg(text))` (paints full strip).
-- `themes/mod.rs`: matching `ui.*` block for `GITHUB_LIGHT_TOML` (base #ffffff, panel #f6f8fa, elevated #eaeef2…) — Phase 1 contrast tests cover it automatically.
-- Docs: `config.example.toml`, README note on custom themes dir.
-- Noted follow-up (out of scope): `json_editor.rs:108` / `row_detail.rs:89` hardcode one_dark for modal syntax; ~170 modal `Color::` literals stay.
+- Change the sidebar split to `[Percentage(30), Length(1), Min(0)]`.
+- Paint the spacer row with `bg_panel` and `text`.
+- Render connections and schema with `zone_block(..., bg_panel, text, ...)`.
+- Show the accent edge only on the focused sidebar subsection.
+- Replace selection, current-connection, loading, error, empty-state, and muted styles with `UiTheme` values.
+- Ensure non-current connection and ordinary schema text inherit `text` on `bg_panel`.
+- Pass `&self.ui_theme` from `app.rs`.
 
-## Risks & mitigations
-1. **Geometry regressions** (cursor drift, scroll jumps, mouse mis-hits) → single geometry source (`zone_block`/`zone_inner` + equality test); editor scroll uses the same `block.inner()` as the widget; per-pane focus-toggle symbol-equality tests.
-2. **REVERSED cursor on tinted bg** → explicit `ui.cursor` style from Phase 2; fallback constants guarantee it's always set.
-3. **Contrast on tones** → all highlight styles carry explicit fg+bg; contrast-ratio unit tests over every built-in + fallback; buffer assertions in render tests.
-4. **Config back-compat** → `show_borders` removal safe (`#[serde(default)]`, no deny_unknown_fields; pinned by test); `theme = "default"` → one_dark; Config never written back to disk (verified).
-5. **Sparse custom themes** → hierarchical `style_for` fallback + hardcoded final fallbacks; test with a minimal TOML.
-6. **Clippy -D warnings vs deprecated `Title`** → use `title_top(Line)` exclusively.
-7. **Insert-mode auto-height** grows one row (chrome 2→1) — intended; tests updated in Phase 2.
+Connection click-row math remains unchanged because the label occupies the former top-border row. Schema-tree clicks continue to use the absolute coordinates recorded by the tree widget. The spacer is outside both stored hit-test areas.
+
+Tests:
+
+- both labels render
+- spacer has the panel base style
+- only the focused subsection has a visible `▍`
+- focus changes styles without changing symbols or geometry
+- ordinary and selected text have explicit visible foregrounds
+- clicks on labels, rows, blank content, and the spacer produce the expected result
+
+### Phase 5 — Status strip and documentation (S/M)
+
+- Add `separator_style()` to `StatusLineBuilder`.
+- Render the mode segment as `" {mode} "` with `bg(mode_accent)`, `fg(pill_fg)`, and `BOLD`.
+- Replace status segment colors with theme semantic colors.
+- Return `Paragraph::new(line).style(Style::default().bg(bg_status).fg(text))` so padding and unstyled spans inherit the status base style.
+- Add a status-line render test for narrow and wide widths under both built-ins.
+- Document the custom theme directory, supported `ui.*` keys, exact quoted TOML syntax, fallback behavior, and a minimal example in the README.
+- Update `config.example.toml` with `one_dark`, `github_light`, and custom-name examples.
+
+Out of scope:
+
+- `json_editor.rs` and `row_detail.rs` continue using One Dark syntax highlighting.
+- Existing modal and popup color literals remain unchanged.
+- Modal and popup borders remain visible.
+
+## Risks and mitigations
+
+1. **Reset foreground on painted backgrounds** — every zone applies both `text` and its tone as the base style; render tests reject reset foregrounds on nonblank content.
+2. **Partial custom styles lose required fields** — UI styles merge fallback, parent, and exact child components before use.
+3. **Geometry regressions** — `zone_block`, `zone_inner`, and `zone_scrollbar_area` are the shared geometry source; editor scroll, cursor placement, viewport sizing, and mouse hit-testing use those helpers.
+4. **Cursor or selection disappears on tinted backgrounds** — normalized cursor, selection, and search styles always have explicit foreground and background colors and never rely on `REVERSED`.
+5. **Built-in light/dark mismatch** — both built-ins receive complete UI palettes before the configured syntax theme is activated.
+6. **Theme warnings overwrite runtime status** — theme diagnostics use a dedicated startup-warning collection and never use `last_status` as transport.
+7. **Config compatibility** — unknown `show_borders` remains accepted, `theme = "default"` maps to One Dark, and configuration is not written back automatically.
+8. **Theme path escape** — custom theme names are validated as a single file stem before joining them to the theme directory.
+9. **Custom theme contrast** — hardcoded UI fallbacks keep omitted chrome scopes usable; custom syntax colors remain the theme author's responsibility and are documented as such.
+10. **Deprecated ratatui APIs** — zone helpers use `title_top(Line)` exclusively.
+11. **Insert-mode height change** — reducing query chrome from two rows to one intentionally adds one visible editor row; query-height tests pin the behavior.
 
 ## Critical files
-- `crates/tsql/src/app/app.rs` (draw closure :2995-3280, scroll math :3128, viewport :3172, `grid_mouse_target` :11040, `status_line()` :10726, `with_config` :2654)
+
+- `crates/tsql/src/app/app.rs`
+- `crates/tsql/src/main.rs`
 - `crates/tsql/src/ui/theme.rs` (new)
-- `crates/tsql/src/ui/grid.rs` (:1391-1593, :1744-1748)
-- `crates/tsql/src/ui/sidebar.rs` (:64-270, :441-468)
-- `crates/tui-syntax/src/themes/mod.rs`, `crates/tsql/src/config/schema.rs`, `crates/tsql/src/ui/status_line.rs`, `crates/tsql/src/main.rs`
+- `crates/tsql/src/ui/highlighted_editor.rs`
+- `crates/tsql/src/ui/grid.rs`
+- `crates/tsql/src/ui/sidebar.rs`
+- `crates/tsql/src/ui/status_line.rs`
+- `crates/tsql/src/ui/style.rs`
+- `crates/tsql/src/config/schema.rs`
+- `crates/tui-syntax/src/theme.rs`
+- `crates/tui-syntax/src/themes/mod.rs`
+- `config.example.toml`
+- `README.md`
 
 ## Verification
-- Per phase: `cargo fmt --all` && `cargo clippy --all --all-targets -- -D warnings` && `cargo test --all`.
-- End-to-end after Phases 2-5: run the app against a live connection (`cargo run`), and verify visually: no borders anywhere; tones distinct (sidebar/query/results/status); focus cycling (Tab / Ctrl-hjkl) moves the `▍` edge with **zero content shift**; vim mode flips edge+pill colors (i / v / Esc); scroll long query + grid with scrollbars in the gutter; mouse clicks on tree items and grid cells hit the right rows; search highlights legible; `display.theme = "github_light"` renders the light variant; a custom `~/.tsql/themes/test.toml` loads (and a bogus name shows the startup warning in the status strip).
+
+Per phase:
+
+```sh
+cargo fmt --all
+cargo clippy --all --all-targets -- -D warnings
+cargo test --all
+```
+
+After Phases 2–5, run the app against a live connection and verify:
+
+- primary panes have no surrounding borders; modal and popup borders remain
+- sidebar, query, results, and status tones are distinct
+- ordinary text is legible in One Dark and GitHub Light regardless of the terminal's default foreground
+- Tab, Shift-Tab, and Ctrl/Alt-hjkl move the `▍` edge without shifting content
+- `i`, `v`, and Esc update the query edge and status pill colors
+- long query and grid content scroll without the scrollbar overwriting content
+- sidebar and grid mouse clicks target the rendered row and column
+- selection, search, cursor, muted, error, and loading text remain legible
+- `display.theme = "github_light"` renders a complete light UI
+- a valid custom theme loads from `<config_dir>/themes`
+- an invalid or missing theme falls back to One Dark and appears in the startup-warning status without replacing unrelated application errors


### PR DESCRIPTION
## Why

Exploring a database often takes several dependent queries, but a single-query workspace makes intermediate steps and results easy to lose. This adds a first-class notebook workspace for repeatable investigations and makes both notebook and Classic results substantially easier to navigate and refine without manually rewriting SQL.

## What changed

- Add an opt-in notebook workspace with modal cell editing, keyboard/mouse targeting, expandable results, execution state, lineage, activity/error navigation, cell history, portable save/open, snippets, and dependency-aware run commands while keeping Classic mode available through `:mode classic`.
- Add bounded PostgreSQL result snapshots and safe lifecycle cleanup. Cells can reference the latest result with `@result`, a specific result with `@result_N`, or a stable named result; restored references rebind after their source is rerun, live bindings remain immutable, and clearing a cell also clears transitive dependents without deleting their SQL.
- Reuse the navigable results grid across Classic and Notebook, including focus, search, selection/copy, column navigation, row detail, scrolling, retained-result paging, compact neighboring cells, precise mouse targeting, and right-edge disclosure controls.
- Add contextual Actions (`Ctrl+Shift+P`, `Cmd+K`, or `:actions`) and reusable server-backed Classic/PostgreSQL result transformations: primary/secondary sorting, value and NULL-aware filters, custom comparisons/text filters, column selection/reordering, group/count, clear/reset, and generated-SQL copy/open. Transformations apply to the full source query rather than only the loaded page and preserve duplicate headers, actual NULL identity, paging, timeout, and transaction/editing safety.
- Add full-result notebook export (CSV/JSON/TSV/SQL), completion for live result references, improved diagnostics/error-position mapping, ASCII-safe rendering, documentation, focused regression coverage, and the follow-up implementation plan.

## How to Test

1. Start against a local PostgreSQL database in notebook mode:

   ```sh
   cargo run -p tsql -- --safe-mode --notebook postgresql://localhost/<database>
   ```

2. Press `Enter`, then `i`, enter the query below, and press `Ctrl-e`. Confirm the cell succeeds, shows a complete session snapshot, and displays an expanded result with the right-edge chevron.

   ```sql
   SELECT n, n * 10 AS amount, CASE WHEN n = 3 THEN NULL ELSE 'group_' || (n % 3) END AS label
   FROM generate_series(1, 1205) AS t(n);
   ```

3. Return to Cell focus with `Esc`, create a dependent cell with `r` or `n`, and run the query below. Confirm the expected rows and lineage appear. Repeat with `@result` and, optionally, name the source with `:name sample` and reference `@result_sample`.

   ```sql
   SELECT n, amount, label FROM @result_1 WHERE n > 1200;
   ```

4. In Cell focus, use `h`/`l` or click the chevron to collapse/expand a result. Press `o` to focus it and verify grid movement, search, row selection/copy, row detail, mouse targeting, and paging to the final row with `G`. Select the source, press `x`, cancel once, then confirm clearing: source/dependent results disappear, SQL remains, and rerunning the source lets the dependent rebind successfully.

5. Run `:mode classic`, execute the source query again, and focus a result cell. Open `:actions`; apply a descending sort, add a secondary sort, filter/exclude a value, filter NULL/non-NULL, choose/reorder columns, and group/count a column. Confirm the result header describes the applied transformation and paging operates on the transformed full result. Useful command equivalents include:

   ```text
   :sort desc
   :filter #1 > 1000
   :filter label null
   :columns
   :group-count
   :clear-filters
   :clear-sort
   :reset-result
   :result-sql open
   ```

6. Check focused regressions: an actual SQL NULL must not be treated like the literal text `NULL`; a filter with quotes/`%`/`_` must match literally for `contains`; a zero-row result must retain its real headers and still expose applicable Actions; multi-statement or locking/DML sources and active transactions must not offer unsafe transformations; a failed filter must leave the previously displayed result and applied-state summary intact.

Targeted automated checks run locally:

- `TERM=xterm-256color TEST_DATABASE_URL=postgresql://127.0.0.1/sqatch cargo test --locked --offline --quiet --lib --bins` — 826 library tests passed (3 pre-existing keychain tests ignored), plus 22 binary and 14 syntax tests.
- `TERM=xterm-256color TEST_DATABASE_URL=postgresql://127.0.0.1/sqatch cargo test --locked --offline --quiet -p tsql --test integration_tests` — 8 PostgreSQL integration tests passed.
- `TERM=xterm-256color TEST_DATABASE_URL=postgresql://127.0.0.1/sqatch cargo test --locked --offline --quiet -p tsql --test startup_nonblocking` — 2 startup tests passed.

The Classic transformations and notebook flows were also exercised end to end against PostgreSQL in tmux, including 1,205-row paging, NULL vs literal-`NULL`, escaped text filters, grouping, projection/reordering, zero-row actions, invalid typed filters, transaction gating, and mode switching.
