### PR TITLE
chore: prepare 0.7.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,11 @@ jobs:
       - name: Wait for crates.io index
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json, sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"] == "tui-syntax"))')
-          for _ in {1..20}; do
+          for attempt in {1..60}; do
             if cargo search tui-syntax --limit 1 | grep -q "tui-syntax = \"$VERSION\""; then
               exit 0
             fi
+            echo "Waiting for tui-syntax $VERSION to reach the crates.io index ($attempt/60)"
             sleep 15
           done
           echo "tui-syntax $VERSION did not appear in the crates.io index in time" >&2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3589,7 +3589,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsql"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "tui-syntax"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 exclude = ["vendor/tui-confirm-dialog"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/fcoury/tsql"

--- a/crates/tsql/Cargo.toml
+++ b/crates/tsql/Cargo.toml
@@ -68,7 +68,7 @@ tempfile.workspace = true
 uuid.workspace = true
 
 # Internal crate
-tui-syntax = { path = "../tui-syntax", version = "0.6.0" }
+tui-syntax = { path = "../tui-syntax", version = "0.7.0" }
 tree-sitter.workspace = true
 tree-sitter-sequel.workspace = true
 


### PR DESCRIPTION
## Summary

- bump the workspace, `tsql`, and `tui-syntax` release versions to 0.7.0
- update tsql's published `tui-syntax` dependency requirement
- extend crates.io index propagation polling from 5 to 15 minutes and log progress, preventing the timeout that interrupted the 0.6.0 publish workflow

## Verification

- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all --all-targets -- -D warnings`
- `cargo test --locked --lib --bins`
- `TERM=xterm-256color TEST_DATABASE_URL=postgres://fcoury@localhost/postgres cargo test --locked -p tsql --test integration_tests`
- `TERM=xterm-256color cargo test --locked -p tsql --test startup_nonblocking`

The `v0.7.0` tag will be created only after this release-preparation change is merged and `master` CI passes.
